### PR TITLE
mavproxy_rc: rc command gracefully handles invalid pwmvalues

### DIFF
--- a/MAVProxy/modules/mavproxy_rc.py
+++ b/MAVProxy/modules/mavproxy_rc.py
@@ -72,6 +72,8 @@ class RCModule(mp_module.MPModule):
             print("Usage: rc <channel|all> <pwmvalue>")
             return
         value = int(args[1])
+        if value > 65535 or value < -1:
+            raise ValueError("PWM value must be a positive integer between 0 and 65535")
         if value == -1:
             value = 65535
         if args[0] == 'all':


### PR DESCRIPTION
In mavproxy, entering an 'rc [chan] [pwmvalue]' command with a pwmvalue outside of -1 ... 65535 would result in mavproxy getting stuck outputting an infinite amount of error messages. My patch handles those values, throws an error if an invalid value is sent and ignores the command.
