### PR TITLE
mavproxy: No (Y/N) prompt after typing exit.  Typing is enough.

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -417,9 +417,7 @@ def process_stdin(line):
             print("%-15s : %s" % (cmd, help))
         return
     if cmd == 'exit' and mpstate.settings.requireexit:
-        reply = raw_input("Are you sure you want to exit? (y/N)")
-        if reply.lower() == 'y':
-            mpstate.status.exit = True
+        mpstate.status.exit = True
         return
 
     if not cmd in command_map:


### PR DESCRIPTION
No need to require a prompt when typing "exit."  Typing out exit is sufficient confirmation.
