### PR TITLE
Battery current draw now visible on console.

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -41,6 +41,7 @@ class MPStatus(object):
         self.last_avionics_battery_announce = 0
         self.battery_level = -1
         self.voltage_level = -1
+        self.current_battery = -1
         self.avionics_battery_level = -1
         self.exit = False
         self.flightmode = 'MAV'

--- a/MAVProxy/modules/mavproxy_console.py
+++ b/MAVProxy/modules/mavproxy_console.py
@@ -130,6 +130,7 @@ class ConsoleModule(mp_module.MPModule):
         # main flight battery
         self.mpstate.status.battery_level = SYS_STATUS.battery_remaining
         self.mpstate.status.voltage_level = SYS_STATUS.voltage_battery
+        self.mpstate.status.current_battery = SYS_STATUS.current_battery
 
         # avionics battery
         if not 'AP_ADC' in self.mpstate.status.msgs:
@@ -154,7 +155,7 @@ class ConsoleModule(mp_module.MPModule):
         if batt_mon == 3:
             self.mpstate.console.set_status('Battery', 'Batt: %.2fV' % (float(self.mpstate.status.voltage_level) / 1000.0), row=1)
         elif batt_mon == 4:
-            self.mpstate.console.set_status('Battery', 'Batt: %u%%/%.2fV' % (self.mpstate.status.battery_level, (float(self.mpstate.status.voltage_level) / 1000.0)), row=1)
+            self.mpstate.console.set_status('Battery', 'Batt: %u%%/%.2fV %.1fA' % (self.mpstate.status.battery_level, (float(self.mpstate.status.voltage_level) / 1000.0), self.mpstate.status.current_battery / 100.0 ), row=1)
 
             rbattery_level = int((self.mpstate.status.battery_level+5)/10)*10
 


### PR DESCRIPTION
Current draw now visible on the console.

I had to move the battery console output out of mavproxy.py to the console and also update the console more often for current draw to be updated often enough to be useful.
