### PR TITLE
console: Show percentage of packets received.

### DIFF
--- a/MAVProxy/modules/mavproxy_console.py
+++ b/MAVProxy/modules/mavproxy_console.py
@@ -236,7 +236,11 @@ class ConsoleModule(mp_module.MPModule):
                     linkline += "down"
                     fg = 'red'
                 else:
-                    linkline += "OK (%u pkts, %.2fs delay, %u lost)" % (m.mav_count, linkdelay, m.mav_loss)
+                    packets_rcvd_percentage = 100
+                    if (m.mav_loss != 0): #avoid divide-by-zero
+                        packets_rcvd_percentage = (1.0 - (float(m.mav_loss) / float(m.mav_count))) * 100.0
+
+                    linkline += "OK (%u pkts, %.2fs delay, %u lost) %u%%" % (m.mav_count, linkdelay, m.mav_loss, packets_rcvd_percentage)
                     if linkdelay > 1:
                         fg = 'orange'
                     else:


### PR DESCRIPTION
Show percentage of packets received on the console next to other link stats.
