### PR TITLE
Make wxPython optional for basic mavproxy operations.

### DIFF
--- a/MAVProxy/modules/lib/mp_util.py
+++ b/MAVProxy/modules/lib/mp_util.py
@@ -5,6 +5,14 @@
 import math
 import os
 
+# Some platforms (CYGWIN and others) many not have this library
+has_wxpython = False
+try:
+    import wx
+    has_wxpython = True
+except ImportError, e:
+    pass
+
 radius_of_earth = 6378100.0 # in meters
 
 def gps_distance(lat1, lon1, lat2, lon2):

--- a/MAVProxy/modules/mavproxy_fence.py
+++ b/MAVProxy/modules/mavproxy_fence.py
@@ -5,7 +5,7 @@ import os, time, platform
 from pymavlink import mavwp, mavutil
 from MAVProxy.modules.lib import mp_util
 from MAVProxy.modules.lib import mp_module
-if "CYGWIN" not in platform.system():
+if mp_util.has_wxpython:
     from MAVProxy.modules.lib.mp_menu import *
 
 class FenceModule(mp_module.MPModule):
@@ -31,7 +31,7 @@ class FenceModule(mp_module.MPModule):
                 self.have_list = True
                 print("Loaded fence from %s" % fencetxt)
 
-        if "CYGWIN" not in platform.system():
+        if mp_util.has_wxpython:
             self.menu_added_console = False
             self.menu_added_map = False
             self.menu = MPMenuSubMenu('Fence',
@@ -49,10 +49,10 @@ class FenceModule(mp_module.MPModule):
 
     def idle_task(self):
         '''called on idle'''
-        if not self.menu_added_console and self.module('console') is not None:
+        if self.module('console') is not None and not self.menu_added_console:
             self.menu_added_console = True
             self.module('console').add_menu(self.menu)
-        if not self.menu_added_map and self.module('map') is not None:
+        if self.module('map') is not None and not self.menu_added_map:
             self.menu_added_map = True
             self.module('map').add_menu(self.menu)
 

--- a/MAVProxy/modules/mavproxy_rally.py
+++ b/MAVProxy/modules/mavproxy_rally.py
@@ -6,8 +6,9 @@ from pymavlink import mavwp
 from pymavlink import mavutil
 import time, os, platform
 from MAVProxy.modules.lib import mp_module
+from MAVProxy.modules.lib import mp_util
 
-if "CYGWIN" not in platform.system():
+if mp_util.has_wxpython:
     from MAVProxy.modules.lib.mp_menu import *
 
 class RallyModule(mp_module.MPModule):
@@ -22,7 +23,7 @@ class RallyModule(mp_module.MPModule):
         self.abort_previous_send_time = 0
         self.abort_ack_received = True
 
-        if "CYGWIN" not in platform.system():
+        if mp_util.has_wxpython:
             self.menu_added_console = False
             self.menu_added_map = False
             self.menu = MPMenuSubMenu('Rally',
@@ -43,10 +44,10 @@ class RallyModule(mp_module.MPModule):
 
     def idle_task(self):
         '''called on idle'''
-        if not self.menu_added_console and self.module('console') is not None:
+        if self.module('console') is not None and not self.menu_added_console:
             self.menu_added_console = True
             self.module('console').add_menu(self.menu)
-        if not self.menu_added_map and self.module('map') is not None:
+        if self.module('map') is not None and not self.menu_added_map:
             self.menu_added_map = True
             self.module('map').add_menu(self.menu)
 

--- a/MAVProxy/modules/mavproxy_wp.py
+++ b/MAVProxy/modules/mavproxy_wp.py
@@ -4,7 +4,8 @@
 import time, os, fnmatch, copy, platform
 from pymavlink import mavutil, mavwp
 from MAVProxy.modules.lib import mp_module
-if "CYGWIN" not in platform.system():
+from MAVProxy.modules.lib import mp_util
+if mp_util.has_wxpython:
     from MAVProxy.modules.lib.mp_menu import *
 
 class WPModule(mp_module.MPModule):
@@ -30,7 +31,7 @@ class WPModule(mp_module.MPModule):
                 self.wploader.load(waytxt)
                 print("Loaded waypoints from %s" % waytxt)
 
-        if "CYGWIN" not in platform.system():
+        if mp_util.has_wxpython:
             self.menu_added_console = False
             self.menu_added_map = False
             self.menu = MPMenuSubMenu('Mission',
@@ -109,10 +110,10 @@ class WPModule(mp_module.MPModule):
                 seq = self.wploader.count()
                 print("re-requesting WP %u" % seq)
                 self.master.waypoint_request_send(seq)
-        if not self.menu_added_console and self.module('console') is not None:
+        if self.module('console') is not None and not self.menu_added_console:
             self.menu_added_console = True
             self.module('console').add_menu(self.menu)
-        if not self.menu_added_map and self.module('map') is not None:
+        if self.module('map') is not None and not self.menu_added_map:
             self.menu_added_map = True
             self.module('map').add_menu(self.menu)
 


### PR DESCRIPTION
Hi Tridge,

I also needed to cope with non wxPython platforms and when I pulled from master to rebase before sending in a PR I noticed you recently fixed a similar problem.  This PR actually changes your approach of detecting non wxPython platforms from a "CYGWIN" check to a more cross platform check of 'can I import the wx package'.  My platform (which I'll describe more fully in skype ;-)) doesn't yet have enough goo so that wxpython will compile, but it _is_ linux.

---

A previous change was checking for "CYGWIN" in platform.system() which
is a fine fix but insufficient for my platform.  My platform is not cygwin
(it is a very stripped down linux) but still can't run wxPython.  So
as a cleaner way for checking for this problem I added has_wxpython to
mp_util.  This bool will be True on platforms where wxPython could be
found.

I also fixed an error in idle callbacks for these platforms:

Without this change on platforms without wxPython the following
failures would occur, because self.menu_added... would not be initialized
in the constructor.  My fix flips the order of comparisons so we
check for the console or map module _first_ and short-circuit out before
noticing that self.menu_added... is empty.

AttributeError: 'RallyModule' object has no attribute 'menu_added_console'
Traceback (most recent call last):
  File "/home/kevinh/development/drone/MAVProxy/MAVProxy/mavproxy.py", line 862, in periodic_tasks
    m.idle_task()
  File "/home/kevinh/development/drone/MAVProxy/MAVProxy/modules/mavproxy_fence.py", line 52, in idle_task
    if not self.menu_added_console and self.module('console') is not None:
AttributeError: 'FenceModule' object has no attribute 'menu_added_console'
Traceback (most recent call last):
  File "/home/kevinh/development/drone/MAVProxy/MAVProxy/mavproxy.py", line 862, in periodic_tasks
    m.idle_task()
  File "/home/kevinh/development/drone/MAVProxy/MAVProxy/modules/mavproxy_rally.py", line 47, in idle_task
    if not self.menu_added_console and self.module('console') is not None:
AttributeError: 'RallyModule' object has no attribute 'menu_added_console'
Traceback (most recent call last):
  File "/home/kevinh/development/drone/MAVProxy/MAVProxy/mavproxy.py", line 862, in periodic_tasks
    m.idle_task()
  File "/home/kevinh/development/drone/MAVProxy/MAVProxy/modules/mavproxy_fence.py", line 52, in idle_task
    if not self.menu_added_console and self.module('console') is not None:
AttributeError: 'FenceModule' object has no attribute 'menu_added_console'
