### PR TITLE
options: Allow multiple --cmd arguments to be specified as arguments

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -1005,7 +1005,7 @@ if __name__ == '__main__':
     parser.add_option("--speech", dest="speech", help="use text to speach",
                       action='store_true', default=False)
     parser.add_option("--aircraft", dest="aircraft", help="aircraft name", default=None)
-    parser.add_option("--cmd", dest="cmd", help="initial commands", default=None)
+    parser.add_option("--cmd", dest="cmd", help="initial commands", default=None, action='append')
     parser.add_option("--console", action='store_true', help="use GUI console")
     parser.add_option("--map", action='store_true', help="load map module")
     parser.add_option(
@@ -1149,9 +1149,10 @@ Auto-detected serial ports are:
             process_stdin('module load %s' % mod)
 
     if opts.cmd is not None:
-        cmds = opts.cmd.split(';')
-        for c in cmds:
-            process_stdin(c)
+        for cstr in opts.cmd:
+            cmds = cstr.split(';')
+            for c in cmds:
+                process_stdin(c)
 
     # run main loop as a thread
     mpstate.status.thread = threading.Thread(target=main_loop)


### PR DESCRIPTION
Hi @Tridge,

Although the existing code properly splits cmds based on a ; separator
I've had a couple DroneAPI users get bitten when they tried to specify
multiple --cmd args (which would be natural to try).  Mavproxy was
implicitly ignoring all but the the last --cmd.
