### PR TITLE
Entire missions (and subsets of missions) can now be relocated via mouse drag.

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -184,6 +184,14 @@ class MPState(object):
         if name in self.public_modules:
             return self.public_modules[name]
         return None
+
+    def module_is_loaded(self, module_name):
+        '''Return True if module with module_name is loaded, False otherwise'''
+        for (m,pm) in self.modules:
+            if m.name == module_name:
+                return True
+                
+        return False
     
     def master(self):
         '''return the currently chosen mavlink master object'''


### PR DESCRIPTION
This PR allows entire missions to be moved about via the mouse.  Instructions:
1. Load mission.
2. Right click on map.
3. Use the new Mission > Drag menu item.
4. In the pop-up dialog, indicate start and end waypoint indices (works best with whole mission, but you can also move a piece of a mission).
5. Hold down middle mouse button to drag mission waypoints to new desired location.
6. Left click to complete operation and upload waypoints' new locations to aircraft.
