### PR TITLE
speech: Allow female speech synthesis. (espeak only)

### DIFF
--- a/MAVProxy/modules/mavproxy_speech.py
+++ b/MAVProxy/modules/mavproxy_speech.py
@@ -13,6 +13,10 @@ class SpeechModule(mp_module.MPModule):
             self.settings.set('speech', 1)
         except AttributeError:
             self.settings.append(('speech', int, 1))
+        try:
+            self.settings.set('speechfemale', 0)
+        except AttributeError:
+            self.settings.append(('speechfemale', int, 0))                
         self.kill_speech_dispatcher()
         for backend in [self.say_speechd, self.say_espeak, self.say_speech]:
             try:
@@ -64,6 +68,10 @@ class SpeechModule(mp_module.MPModule):
     def say_espeak(self, text, priority='important'):
         '''speak some text using espeak'''
         from espeak import espeak
+        if self.settings.get('speechfemale') == 1:
+            espeak.set_voice('female2')
+        else:
+            espeak.set_voice('male3')
         espeak.synth(text)
 
     def say_speech(self, text, priority='important'):


### PR DESCRIPTION
When switching back to the male voice at runtime, I couldn't figure out how to get exactly the same voice as the default voice that runs when set_voice() is never called.  I ended up choosing 'male3' which is slightly deeper and (I think) crisper and easier to understand than the default male -- of course that's only a personal opinion.

If I specify an empty string to the set_voice() method I can get the default voice back, but then it garbles words.
