### PR TITLE
Force python2

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 '''
 mavproxy - a MAVLink proxy program
 


### PR DESCRIPTION
`/usr/bin/python` is just an alias these days to either `python2` or `python3` depending on the OS.  Certain OS's (Arch especially) have it aliased to `python3`, and so programs starting with `#!/usr/bin/python` will run with the wrong version.
