### PR TITLE
fix #257 - Get rid of cv2.cv in order to support OpenCV3

### DIFF
--- a/MAVProxy/modules/lib/mp_image.py
+++ b/MAVProxy/modules/lib/mp_image.py
@@ -18,8 +18,8 @@ from MAVProxy.modules.lib.mp_menu import *
 class MPImageData:
     '''image data to display'''
     def __init__(self, img):
-        self.width = img.width
-        self.height = img.height
+        self.width = img.shape[1]
+        self.height = img.shape[0]
         self.data = img.tostring()
 
 class MPImageTitle:

--- a/MAVProxy/modules/lib/mp_image.py
+++ b/MAVProxy/modules/lib/mp_image.py
@@ -7,11 +7,8 @@ June 2012
 
 import time
 from wx_loader import wx
-
-try:
-    import cv2.cv as cv
-except ImportError:
-    import cv
+import cv2
+import numpy as np
 
 from MAVProxy.modules.lib import mp_util
 from MAVProxy.modules.lib import mp_widgets
@@ -122,8 +119,7 @@ class MPImage():
         if not self.is_alive():
             return
         if bgr:
-            img = cv.CloneImage(img)
-            cv.CvtColor(img, img, cv.CV_BGR2RGB)
+            img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
         self.in_queue.put(MPImageData(img))
 
     def set_title(self, title):
@@ -523,7 +519,7 @@ if __name__ == "__main__":
                  can_drag = opts.drag,
                  can_zoom = opts.zoom,
                  auto_size = opts.autosize)
-    img = cv.LoadImage(args[0])
+    img = cv2.imread(args[0])
     im.set_image(img, bgr=True)
 
     while im.is_alive():

--- a/MAVProxy/modules/lib/mp_widgets.py
+++ b/MAVProxy/modules/lib/mp_widgets.py
@@ -7,6 +7,8 @@ June 2012
 '''
 
 from wx_loader import wx
+import cv2
+import numpy as np
 
 class ImagePanel(wx.Panel):
     '''a resizable panel containing an image'''
@@ -23,5 +25,5 @@ class ImagePanel(wx.Panel):
 
     def set_image(self, img):
         '''set the image to be displayed'''
-        self._bmp = wx.BitmapFromImage(img)
+        self._bmp = wx.BitmapFromBuffer(img.shape[1], img.shape[0], np.uint8(img)) # http://stackoverflow.com/a/16866833/2559632
         self.SetMinSize((self._bmp.GetWidth(), self._bmp.GetHeight()))

--- a/MAVProxy/modules/mavproxy_map/mp_slipmap.py
+++ b/MAVProxy/modules/mavproxy_map/mp_slipmap.py
@@ -10,11 +10,8 @@ import functools
 import math
 import os, sys
 import time
-
-try:
-    import cv2.cv as cv
-except ImportError:
-    import cv
+import cv2
+import numpy as np
 
 from MAVProxy.modules.mavproxy_map import mp_elevation
 from MAVProxy.modules.mavproxy_map import mp_tile
@@ -201,11 +198,11 @@ if __name__ == "__main__":
         sm.add_object(SlipGrid('grid', layer=3, linewidth=1, colour=(255,255,0)))
 
     if opts.thumbnail:
-        thumb = cv.LoadImage(opts.thumbnail)
+        thumb = cv2.imread(opts.thumbnail)
         sm.add_object(SlipThumbnail('thumb', (opts.lat,opts.lon), layer=1, img=thumb, border_width=2, border_colour=(255,0,0)))
 
     if opts.icon:
-        icon = cv.LoadImage(opts.icon)
+        icon = cv2.imread(opts.icon)
         sm.add_object(SlipIcon('icon', (opts.lat,opts.lon), icon, layer=3, rotation=90, follow=True))
         sm.set_position('icon', mp_util.gps_newpos(opts.lat,opts.lon, 180, 100), rotation=45)
         sm.add_object(SlipInfoImage('detail', icon))

--- a/MAVProxy/modules/mavproxy_map/mp_slipmap_ui.py
+++ b/MAVProxy/modules/mavproxy_map/mp_slipmap_ui.py
@@ -115,7 +115,7 @@ class MPSlipMapFrame(wx.Frame):
         state.panel.re_center(state.width/2, state.height/2, lat, lon)
 
     def add_object(self, obj):
-        '''add an object to a later'''
+        '''add an object to a layer'''
         state = self.state
         if not obj.layer in state.layers:
             # its a new layer

--- a/MAVProxy/modules/mavproxy_map/mp_slipmap_util.py
+++ b/MAVProxy/modules/mavproxy_map/mp_slipmap_util.py
@@ -277,10 +277,10 @@ class SlipThumbnail(SlipObject):
         (px,py) = pixmapper(self.latlon)
 
         # find top left
-        px -= thumb.width/2
-        py -= thumb.height/2
-        w = thumb.width
-        h = thumb.height
+        px -= thumb.shape[1]/2
+        py -= thumb.shape[0]/2
+        w = thumb.shape[1]
+        h = thumb.shape[0]
 
         (px, py, sx, sy, w, h) = self.clip(px, py, w, h, img)
 
@@ -367,8 +367,7 @@ class SlipIcon(SlipThumbnail):
 
         (px, py, sx, sy, w, h) = self.clip(px, py, w, h, img)
 
-        img_roi = img[py:py+h, px:px+w]
-        icon[sy:sy+h, sx:sx+w] = cv2.add(img_roi, img_roi)
+        img[py:py+h, px:px+w] += icon[sy:sy+h, sx:sx+w]
 
         # remember where we placed it for clicked()
         self.posx = px+w/2
@@ -434,8 +433,8 @@ class SlipInfoImage(SlipInformation):
     def __init__(self, key, img):
         SlipInformation.__init__(self, key)
         self.imgstr = img.tostring()
-        self.width = img.width
-        self.height = img.height
+        self.width = img.shape[1]
+        self.height = img.shape[0]
         self.imgpanel = None
 
     def img(self):

--- a/MAVProxy/modules/mavproxy_map/mp_slipmap_util.py
+++ b/MAVProxy/modules/mavproxy_map/mp_slipmap_util.py
@@ -367,7 +367,7 @@ class SlipIcon(SlipThumbnail):
 
         (px, py, sx, sy, w, h) = self.clip(px, py, w, h, img)
 
-        img[py:py+h, px:px+w] += icon[sy:sy+h, sx:sx+w]
+        img[py:py + h, px:px + w] = cv2.add(img[py:py+h, px:px+w], icon[sy:sy+h, sx:sx+w])
 
         # remember where we placed it for clicked()
         self.posx = px+w/2

--- a/MAVProxy/modules/mavproxy_map/mp_slipmap_util.py
+++ b/MAVProxy/modules/mavproxy_map/mp_slipmap_util.py
@@ -87,7 +87,7 @@ class SlipLabel(SlipObject):
 
     def draw_label(self, img, pixmapper):
         pix1 = pixmapper(self.point)
-        cv2.putText(img, self.label, pix1, cv2.FONT_HERSHEY_SCRIPT_SIMPLEX, 1.0, self.colour)
+        cv2.putText(img, self.label, pix1, cv2.FONT_HERSHEY_SIMPLEX, 1.0, self.colour)
 
     def draw(self, img, pixmapper, bounds):
         if self.hidden:

--- a/MAVProxy/tools/mavflightview.py
+++ b/MAVProxy/tools/mavflightview.py
@@ -11,10 +11,7 @@ from MAVProxy.modules.mavproxy_map import mp_slipmap, mp_tile
 from MAVProxy.modules.lib import mp_util
 import functools
 
-try:
-    import cv2.cv as cv
-except ImportError:
-    import cv
+import cv2
 
 def create_map(title):
     '''create map object'''
@@ -44,8 +41,8 @@ def create_imagefile(options, filename, latlon, ground_width, path_objs, mission
             m.draw(map_img, pixmapper, None)
     if fence_obj is not None:
         fence_obj.draw(map_img, pixmapper, None)
-    cv.CvtColor(map_img, map_img, cv.CV_BGR2RGB)
-    cv.SaveImage(filename, map_img)
+    map_img = cv2.cvtColor(map_img, cv2.COLOR_BGR2RGB)
+    cv2.imwrite(filename, map_img)
 
 colourmap = {
     'MANUAL'    : (255,   0,   0),


### PR DESCRIPTION
This fix exchanges (hopefully) all OpenCV1 image structures through numpy arrays, therefore all comparisons (equality etc.) had to be adapted;
Additionally, the signatures of many OpenCV functions have changed (and many copies were not necessary any more).

The following tests have been performed:
- change map provider
- zoom level
- brightness (note that increasing brightness might lead to overflow artefacts, was this always the case?)
- display/alter waypoints in a mission

Using `OpenCV 3`.

It would be great if somebody could look over these changes, as I'm not aware of the impact of this PR (e.g. maybe a module which makes use of map etc.) - thanks

Note that two of the changed files are part of `/modules/lib`, I've checked their usages and PyCharm couldn't find any other callers than map.
Furthermore, I made some indentation adaptations, as PyCharm (and Sublime) had problems with the mixed tabs/spaces.
