### PR TITLE
clarify networking docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,6 +35,7 @@ extensions = [
     'sphinx.ext.pngmath',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
+    'sphinx.ext.autosectionlabel'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/getting_started/quickstart.rst
+++ b/docs/source/getting_started/quickstart.rst
@@ -48,3 +48,8 @@ to connect to must be your own IP address.
 
     mavproxy.py --master=192.168.1.1:14550
 
+
+.. note::
+
+   MavProxy can output a mavlink stream to remote network addresses using
+   UDP Broadcast. See :ref:`--out` for details.


### PR DESCRIPTION
Per #329, reading the docs front-to-back after a long lay-off, I found it confusing that I couldn't connect to remote network addresses. This was clarified a few screens of reading later, but I would like to propose this admonition to prevent future readers suffering the same confusion.

Also note, adding in the sphinx.ext.autosectionlable raised a few new build warnings (same section headings used in multiple parts of the document). I think those are legitimate warnings, so I don't think the fact it's now raising them is an issue.
