### PR TITLE
MAVProxy Horizon Indicator Pull Request

### DIFF
--- a/MAVProxy/modules/lib/wxhorizon.py
+++ b/MAVProxy/modules/lib/wxhorizon.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python
 
 """
-  MAVProxy message console, implemented in a child process
+  MAVProxy horizon indicator.
 """
 import multiprocessing
 import time
 
 class HorizonIndicator():
     '''
-    a message console for MAVProxy
+    A horizon indicator for MAVProxy.
     '''
     def __init__(self,title='MAVProxy: Horizon Indicator'):
         self.title  = title
@@ -34,7 +34,7 @@ class HorizonIndicator():
         app.MainLoop()
 
     def close(self):
-        '''close the console'''
+        '''Close the window.'''
         self.close_event.set()
         if self.is_alive():
             self.child.join(2)

--- a/MAVProxy/modules/lib/wxhorizon.py
+++ b/MAVProxy/modules/lib/wxhorizon.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+
+"""
+  MAVProxy message console, implemented in a child process
+"""
+import multiprocessing
+import time
+
+class HorizonIndicator():
+    '''
+    a message console for MAVProxy
+    '''
+    def __init__(self,title='MAVProxy: Horizon Indicator'):
+        self.title  = title
+        # Create Pipe to send attitude information from module to UI
+        self.child_pipe_recv,self.parent_pipe_send = multiprocessing.Pipe(duplex=False)
+        self.close_event = multiprocessing.Event()
+        self.close_event.clear()
+        self.child = multiprocessing.Process(target=self.child_task)
+        self.child.start()
+        self.child_pipe_recv.close()
+
+    def child_task(self):
+        '''child process - this holds all the GUI elements'''
+        self.parent_pipe_send.close()
+        
+        from wx_loader import wx
+        from wxhorizon_ui import HorizonFrame
+        # Create wx application
+        app = wx.App(False)
+        app.frame = HorizonFrame(state=self, title=self.title)
+        app.frame.SetDoubleBuffered(True)
+        app.frame.Show()
+        app.MainLoop()
+
+    def close(self):
+        '''close the console'''
+        self.close_event.set()
+        if self.is_alive():
+            self.child.join(2)
+
+    def is_alive(self):
+        '''check if child is still going'''
+        return self.child.is_alive()
+
+if __name__ == "__main__":
+    # test the console
+    multiprocessing.freeze_support()
+    horizon = HorizonIndicator()
+    while horizon.is_alive():
+        print 'test'
+        time.sleep(0.5)

--- a/MAVProxy/modules/lib/wxhorizon_ui.py
+++ b/MAVProxy/modules/lib/wxhorizon_ui.py
@@ -1,0 +1,108 @@
+import time
+from wxhorizon_util import Attitude
+from wx_loader import wx
+import math
+
+class HorizonFrame(wx.Frame):
+    """ The main frame of the horizon indicator."""
+
+    def __init__(self, state, title):
+        self.state = state
+        # Create Frame and Panel
+        wx.Frame.__init__(self, None, title=title, size=(400,400))
+        self.panel = wx.Panel(self)
+        state.frame = self
+
+        # Create vbox and panel
+        self.vbox = wx.BoxSizer(wx.VERTICAL)
+        self.panel.SetSizer(self.vbox)
+
+        # Create Event Timer
+        self.timer = wx.Timer(self)
+        self.Bind(wx.EVT_TIMER, self.on_timer, self.timer)
+        self.timer.Start(100)
+        self.Bind(wx.EVT_IDLE, self.on_idle)
+
+        # Test Button
+        self.btn = wx.Button(self.panel,-1,'Display Pitch')
+        self.vbox.Add(self.btn,0,wx.ALIGN_CENTER)
+        self.Bind(wx.EVT_BUTTON,self.OnButtonClicked)
+
+        # Initialise Attitude
+        self.pitch = 0  # Degrees
+        self.roll = 0   # Degrees
+        self.yaw = 0    # Degrees
+        
+        # History Values
+        self.oldRoll = 0 # Degrees
+        
+        # Attitude Text
+        self.pitchText = wx.StaticText(self.panel,pos=(0,340),label='Pitch: 0.0',style=wx.ALIGN_LEFT)
+        self.rollText = wx.StaticText(self.panel,pos=(0,360),label='Roll: 0.0',style=wx.ALIGN_LEFT)
+        self.yawText = wx.StaticText(self.panel,1,pos=(0,380),label='Yaw: 0.0',style=wx.ALIGN_LEFT)
+
+        # Add Roll Line
+        l = 200; # px
+        xc = 200
+        yc = 200
+        def on_paint(event):
+            # Create Drawing Canvasgit st
+            dc = wx.PaintDC(self.panel)
+            dc.Clear()
+            # Draw Roll Line
+            dc.SetPen(wx.Pen(wx.BLACK,4))
+            x1 = xc-((l/2.0)*math.cos(math.radians(self.roll)))
+            y1 = yc-((l/2.0)*math.sin(math.radians(self.roll)))
+            x2 = xc+((l/2.0)*math.cos(math.radians(self.roll)))
+            y2 = yc+((l/2.0)*math.sin(math.radians(self.roll)))
+            dc.DrawLine(x1,y1,x2,y2)
+            # Draw Roll Lag Arc
+            x1o = xc-((l/2.0)*math.cos(math.radians(self.oldRoll)))
+            y1o = yc-((l/2.0)*math.sin(math.radians(self.oldRoll)))
+            x2o = xc+((l/2.0)*math.cos(math.radians(self.oldRoll)))
+            y2o = yc+((l/2.0)*math.sin(math.radians(self.oldRoll)))
+            
+            dc.DrawLine(x1,y1,x2,y2)
+            #dc.DrawArc(x1,y1,x1o,y1o,xc,yc)
+            #dc.DrawArc(x2,y2,x2o,y2o,xc,yc)
+        
+        self.panel.Bind(wx.EVT_PAINT,on_paint)
+        
+        # Show Window
+        self.Show(True)
+        self.pending = []
+
+    def OnButtonClicked(self,e):
+        print 'Pitch: %f' % self.pitch
+
+        
+    def updateAttitudeText(self):
+        'Updates the displayed attitude Text'
+        self.pitchText.SetLabel('Pitch: %.2f' % self.pitch)
+        self.rollText.SetLabel('Roll: %.2f' % self.roll)
+        self.yawText.SetLabel('Yaw: %.2f' % self.yaw)
+
+    def on_idle(self, event):
+        time.sleep(0.05)
+ 
+    def on_timer(self, event):
+        state = self.state
+        if state.close_event.wait(0.001):
+            self.timer.Stop()
+            self.Destroy()
+            return
+        # Get attitude information
+        while state.child_pipe_recv.poll():
+            obj = state.child_pipe_recv.recv()
+            if isinstance(obj,Attitude):
+                self.oldRoll = self.roll
+                self.pitch = obj.pitch*180/math.pi
+                self.roll = obj.roll*180/math.pi
+                self.yaw = obj.yaw*180/math.pi
+                
+                # Update Displayed Text
+                self.updateAttitudeText()
+                
+   
+        self.Refresh()
+        self.Update()

--- a/MAVProxy/modules/lib/wxhorizon_ui.py
+++ b/MAVProxy/modules/lib/wxhorizon_ui.py
@@ -3,31 +3,30 @@ from wxhorizon_util import Attitude
 from wx_loader import wx
 import math
 
+import matplotlib
+matplotlib.use('wxAgg')
+from matplotlib.backends.backend_wxagg import FigureCanvasWxAgg as FigureCanvas
+from matplotlib.figure import Figure
+from matplotlib.pyplot import Polygon
+import matplotlib.patheffects as PathEffects
+from matplotlib import patches
+import matplotlib as mpl
+
 class HorizonFrame(wx.Frame):
     """ The main frame of the horizon indicator."""
 
     def __init__(self, state, title):
         self.state = state
-        # Create Frame and Panel
-        wx.Frame.__init__(self, None, title=title, size=(400,400))
-        self.panel = wx.Panel(self)
+        # Create Frame and Panel(s)
+        wx.Frame.__init__(self, None, title=title)
         state.frame = self
 
-        # Create vbox and panel
-        self.vbox = wx.BoxSizer(wx.VERTICAL)
-        self.panel.SetSizer(self.vbox)
+        # Initialisation
+        self.initData()
+        self.initUI()
 
-        # Create Event Timer
-        self.timer = wx.Timer(self)
-        self.Bind(wx.EVT_TIMER, self.on_timer, self.timer)
-        self.timer.Start(100)
-        self.Bind(wx.EVT_IDLE, self.on_idle)
 
-        # Test Button
-        self.btn = wx.Button(self.panel,-1,'Display Pitch')
-        self.vbox.Add(self.btn,0,wx.ALIGN_CENTER)
-        self.Bind(wx.EVT_BUTTON,self.OnButtonClicked)
-
+    def initData(self):
         # Initialise Attitude
         self.pitch = 0  # Degrees
         self.roll = 0   # Degrees
@@ -35,54 +34,186 @@ class HorizonFrame(wx.Frame):
         
         # History Values
         self.oldRoll = 0 # Degrees
-        
-        # Attitude Text
-        self.pitchText = wx.StaticText(self.panel,pos=(0,340),label='Pitch: 0.0',style=wx.ALIGN_LEFT)
-        self.rollText = wx.StaticText(self.panel,pos=(0,360),label='Roll: 0.0',style=wx.ALIGN_LEFT)
-        self.yawText = wx.StaticText(self.panel,1,pos=(0,380),label='Yaw: 0.0',style=wx.ALIGN_LEFT)
+    
 
-        # Add Roll Line
-        l = 200; # px
-        xc = 200
-        yc = 200
-        def on_paint(event):
-            # Create Drawing Canvasgit st
-            dc = wx.PaintDC(self.panel)
-            dc.Clear()
-            # Draw Roll Line
-            dc.SetPen(wx.Pen(wx.BLACK,4))
-            x1 = xc-((l/2.0)*math.cos(math.radians(self.roll)))
-            y1 = yc-((l/2.0)*math.sin(math.radians(self.roll)))
-            x2 = xc+((l/2.0)*math.cos(math.radians(self.roll)))
-            y2 = yc+((l/2.0)*math.sin(math.radians(self.roll)))
-            dc.DrawLine(x1,y1,x2,y2)
-            # Draw Roll Lag Arc
-            x1o = xc-((l/2.0)*math.cos(math.radians(self.oldRoll)))
-            y1o = yc-((l/2.0)*math.sin(math.radians(self.oldRoll)))
-            x2o = xc+((l/2.0)*math.cos(math.radians(self.oldRoll)))
-            y2o = yc+((l/2.0)*math.sin(math.radians(self.oldRoll)))
-            
-            dc.DrawLine(x1,y1,x2,y2)
-            #dc.DrawArc(x1,y1,x1o,y1o,xc,yc)
-            #dc.DrawArc(x2,y2,x2o,y2o,xc,yc)
+    def initUI(self):
+        # Create Event Timer and Bindings
+        self.timer = wx.Timer(self)
+        self.Bind(wx.EVT_TIMER, self.on_timer, self.timer)
+        self.timer.Start(100)
+        self.Bind(wx.EVT_IDLE, self.on_idle)
+        self.Bind(wx.EVT_CHAR_HOOK,self.on_KeyPress)
+
+        # Create Panel
+        self.panel = wx.Panel(self)
         
-        self.panel.Bind(wx.EVT_PAINT,on_paint)
+        # Create Matplotlib Panel
+        self.figure = Figure()
+        self.axes = self.figure.add_subplot(111)
+        self.canvas = FigureCanvas(self,-1,self.figure)
+        self.canvas.SetSize(wx.Size(300,300))
+        self.axes.axis('off')
+        self.figure.subplots_adjust(left=0,right=1,top=1,bottom=0)
+        self.sizer = wx.BoxSizer(wx.VERTICAL)
+        self.sizer.Add(self.canvas,1,wx.EXPAND,wx.ALL)
+        self.SetSizerAndFit(self.sizer)
+        self.Fit()
+
+        # Fix Axes - vertical is of length 2, horizontal keeps the same lengthscale
+        self.rescaleX()
         
-        # Show Window
+        # Sky Polygon
+        vertsTop = [[-1,0],[-1,1],[1,1],[1,0],[-1,0]]
+        self.topPolygon = Polygon(vertsTop,facecolor='cyan',edgecolor='none')
+        self.axes.add_patch(self.topPolygon)
+        # Ground Polygon
+        vertsBot = [[-1,0],[-1,-1],[1,-1],[1,0],[-1,0]]
+        self.botPolygon = Polygon(vertsBot,facecolor='brown',edgecolor='none')
+        self.axes.add_patch(self.botPolygon)
+        
+        # Markers
+        self.axes.plot([-1,-1,1,1],[-1,1,1,-1],'ro')
+        
+        # Center Pointer Marker
+        self.thick = 0.015
+        self.axes.add_patch(patches.Rectangle((-0.75,-self.thick),0.5,2.0*self.thick,facecolor='orange',zorder=3))
+        self.axes.add_patch(patches.Rectangle((0.25,-self.thick),0.5,2.0*self.thick,facecolor='orange',zorder=3))
+        self.axes.add_patch(patches.Circle((0,0),radius=self.thick,facecolor='orange',edgecolor='none',zorder=3))
+        
+        # Pitch Markers
+        self.dist10deg = 0.2 # Graph distance per 10 deg
+        self.createPitchmMarkers()
+        
+        # Add Roll, Pitch, Yaw Text
+        self.vertSize = 0.09
+        ypx = self.figure.get_size_inches()[1]*self.figure.dpi
+        self.fontSize = self.vertSize*(ypx/2.0)
+        leftPos = self.axes.get_xlim()[0]
+        self.rollText = self.axes.text(leftPos+(self.vertSize/10.0),-0.97+(2*self.vertSize)-(self.vertSize/10.0),'Roll:   %.2f' % self.roll,color='w',size=self.fontSize)
+        self.pitchText = self.axes.text(leftPos+(self.vertSize/10.0),-0.97+self.vertSize-(0.5*self.vertSize/10.0),'Pitch: %.2f' % self.pitch,color='w',size=self.fontSize)
+        self.yawText = self.axes.text(leftPos+(self.vertSize/10.0),-0.97,'Yaw:   %.2f' % self.yaw,color='w',size=self.fontSize)
+        self.rollText.set_path_effects([PathEffects.withStroke(linewidth=1,foreground='k')])
+        self.pitchText.set_path_effects([PathEffects.withStroke(linewidth=1,foreground='k')])
+        self.yawText.set_path_effects([PathEffects.withStroke(linewidth=1,foreground='k')])
+        
+        # Show Frame
         self.Show(True)
         self.pending = []
-
-    def OnButtonClicked(self,e):
-        print 'Pitch: %f' % self.pitch
-
+        
+    def calcPitchMarkerWidth(self,i):
+        '''Calculates the width of a pitch marker.'''
+        if (i % 3) == 0:
+            if i == 0:
+                width = 1.5
+            else:
+                width = 0.9
+        else:
+            width = 0.6
+            
+        return width
+        
+    def createPitchmMarkers(self):
+        '''Creates the rectangle patches for the pitch indicators.'''
+        self.pitchPatches = []
+        # Major Lines (multiple of 10 deg)
+        for i in [-9,-8,-7,-6,-5,-4,-3,-2,-1,0,1,2,3,4,5,6,7,8,9]:
+            width = self.calcPitchMarkerWidth(i)
+            currPatch = patches.Rectangle((-width/2.0,self.dist10deg*i-(self.thick/2.0)),width,self.thick,facecolor='w',edgecolor='none')
+            self.axes.add_patch(currPatch)
+            self.pitchPatches.append(currPatch)
+        # Add Label for +-30 deg
+        self.vertSize = 0.09
+        ypx = self.figure.get_size_inches()[1]*self.figure.dpi
+        self.fontSize = self.vertSize*(ypx/2.0)
+        self.pitchLabelsLeft = []
+        self.pitchLabelsRight = []
+        i=0
+        for j in [-90,-60,-30,30,60,90]:
+            self.pitchLabelsLeft.append(self.axes.text(-0.55,(j/10.0)*self.dist10deg,str(j),color='w',size=self.fontSize,horizontalalignment='center',verticalalignment='center'))
+            self.pitchLabelsLeft[i].set_path_effects([PathEffects.withStroke(linewidth=1,foreground='k')])
+            self.pitchLabelsRight.append(self.axes.text(0.55,(j/10.0)*self.dist10deg,str(j),color='w',size=self.fontSize,horizontalalignment='center',verticalalignment='center'))
+            self.pitchLabelsRight[i].set_path_effects([PathEffects.withStroke(linewidth=1,foreground='k')])
+            i += 1
+        
+    def adjustPitchmarkers(self):
+        '''Adjusts the location and orientation of pitch markers.'''
+        pitchdiff = self.dist10deg*(self.pitch/10.0)
+        rollRotate = mpl.transforms.Affine2D().rotate_deg_around(0.0,-pitchdiff,self.roll)+self.axes.transData
+        j=0
+        for i in [-9,-8,-7,-6,-5,-4,-3,-2,-1,0,1,2,3,4,5,6,7,8,9]:
+            width = self.calcPitchMarkerWidth(i)
+            self.pitchPatches[j].set_xy((-width/2.0,self.dist10deg*i-(self.thick/2.0)-pitchdiff))
+            self.pitchPatches[j].set_transform(rollRotate)
+            j+=1
+        # Adjust Text Size and rotation
+        i=0
+        for j in [-9,-6,-3,3,6,9]:
+                self.pitchLabelsLeft[i].set_y(j*self.dist10deg-pitchdiff)
+                self.pitchLabelsRight[i].set_y(j*self.dist10deg-pitchdiff)
+                self.pitchLabelsLeft[i].set_size(self.fontSize)
+                self.pitchLabelsRight[i].set_size(self.fontSize)
+                self.pitchLabelsLeft[i].set_rotation(self.roll)
+                self.pitchLabelsRight[i].set_rotation(self.roll)
+                self.pitchLabelsLeft[i].set_transform(rollRotate)
+                self.pitchLabelsRight[i].set_transform(rollRotate)
+                i += 1
+        
+    def rescaleX(self):
+        '''Rescales the horizontal axes to make the lengthscales equal.'''
+        self.ratio = self.figure.get_size_inches()[0]/float(self.figure.get_size_inches()[1])
+        self.axes.set_xlim(-self.ratio,self.ratio)
+        self.axes.set_ylim(-1,1)
+        
+    def calcHorizonPoints(self):
+        '''Updates the verticies of the patches for the ground and sky.'''
+        self.ratio = self.figure.get_size_inches()[0]/float(self.figure.get_size_inches()[1])
+        ydiff = math.tan(math.radians(-self.roll))*float(self.ratio)
+        pitchdiff = self.dist10deg*(self.pitch/10.0)
+        # Sky Polygon
+        vertsTop = [(-self.ratio,ydiff-pitchdiff),(-self.ratio,1),(self.ratio,1),(self.ratio,-ydiff-pitchdiff),(-self.ratio,ydiff-pitchdiff)]       
+        self.topPolygon.set_xy(vertsTop)
+        # Ground Polygon
+        vertsBot = [(-self.ratio,ydiff-pitchdiff),(-self.ratio,-1),(self.ratio,-1),(self.ratio,-ydiff-pitchdiff),(-self.ratio,ydiff-pitchdiff)]       
+        self.botPolygon.set_xy(vertsBot)       
         
     def updateAttitudeText(self):
         'Updates the displayed attitude Text'
-        self.pitchText.SetLabel('Pitch: %.2f' % self.pitch)
-        self.rollText.SetLabel('Roll: %.2f' % self.roll)
-        self.yawText.SetLabel('Yaw: %.2f' % self.yaw)
+        self.rollText.set_text('Roll:   %.2f' % self.roll)
+        self.pitchText.set_text('Pitch: %.2f' % self.pitch)
+        self.yawText.set_text('Yaw:   %.2f' % self.yaw)
+
+    def updateRPYLocations(self):
+        '''Update the locations of rol, pitch, yaw text.'''
+        leftPos = self.axes.get_xlim()[0]
+        # Locations
+        self.rollText.set_position((leftPos+(self.vertSize/10.0),-0.97+(2*self.vertSize)-(self.vertSize/10.0)))
+        self.pitchText.set_position((leftPos+(self.vertSize/10.0),-0.97+self.vertSize-(0.5*self.vertSize/10.0)))
+        self.yawText.set_position((leftPos+(self.vertSize/10.0),-0.97))
+        # Font Size
+        ypx = self.figure.get_size_inches()[1]*self.figure.dpi
+        self.fontSize = self.vertSize*(ypx/2.0)
+        self.rollText.set_size(self.fontSize)
+        self.pitchText.set_size(self.fontSize)
+        self.yawText.set_size(self.fontSize)
 
     def on_idle(self, event):
+        # Fix Window Scales 
+        self.rescaleX()
+        
+        # Recalculate Horizon Polygons
+        self.calcHorizonPoints()
+        
+        # Update Roll, Pitch, Yaw Text Locations
+        self.updateRPYLocations()
+        
+        # Update Pitch Markers
+        self.adjustPitchmarkers()
+        
+        # Update Matplotlib Plot
+        self.canvas.draw()
+        self.canvas.Refresh()
+        
+        
         time.sleep(0.05)
  
     def on_timer(self, event):
@@ -103,6 +234,26 @@ class HorizonFrame(wx.Frame):
                 # Update Displayed Text
                 self.updateAttitudeText()
                 
-   
+                # Recalculate Horizon Polygons
+                self.calcHorizonPoints()
+                
+                # Update Pitch Markers
+                self.adjustPitchmarkers()
+                
+                # Update Matplotlib Plot
+                self.canvas.draw()
+                self.canvas.Refresh()
+                
         self.Refresh()
         self.Update()
+                
+    def on_KeyPress(self,event):
+        if event.GetKeyCode() == wx.WXK_UP:
+            self.dist10deg += 0.1
+            print 'Dist per 10 deg: %.1f' % self.dist10deg      
+        elif event.GetKeyCode() == wx.WXK_DOWN:
+            self.dist10deg -= 0.1
+            if self.dist10deg < 0:
+                self.dist10deg = 0
+            print 'Dist per 10 deg: %.1f' % self.dist10deg      
+

--- a/MAVProxy/modules/lib/wxhorizon_ui.py
+++ b/MAVProxy/modules/lib/wxhorizon_ui.py
@@ -1,9 +1,10 @@
 import time
-from wxhorizon_util import Attitude
+from wxhorizon_util import Attitude, VFR_HUD
 from wx_loader import wx
 import math
 
 import matplotlib
+from MAVProxy.modules.lib.wxhorizon_util import VFR_HUD
 matplotlib.use('wxAgg')
 from matplotlib.backends.backend_wxagg import FigureCanvasWxAgg as FigureCanvas
 from matplotlib.figure import Figure
@@ -32,6 +33,9 @@ class HorizonFrame(wx.Frame):
         self.roll = 0   # Degrees
         self.yaw = 0    # Degrees
         
+        # Initialise HUD Info
+        self.heading = 0 # 0-360
+        
         # History Values
         self.oldRoll = 0 # Degrees
     
@@ -48,6 +52,40 @@ class HorizonFrame(wx.Frame):
         self.panel = wx.Panel(self)
         
         # Create Matplotlib Panel
+        self.createPlotPanel()
+
+        # Fix Axes - vertical is of length 2, horizontal keeps the same lengthscale
+        self.rescaleX()
+        
+        # Create Horizon Polygons
+        self.createHorizonPolygons()
+        
+        # Markers (temporary)
+        #self.axes.plot([-1,-1,1,1],[-1,1,1,-1],'ro')
+        
+        # Center Pointer Marker
+        self.thick = 0.015
+        self.createCenterPointMarker()
+        
+        # Pitch Markers
+        self.dist10deg = 0.2 # Graph distance per 10 deg
+        self.createPitchMarkers()
+        
+        # Add Roll, Pitch, Yaw Text
+        self.createRPYText()
+        
+        # Create Heading Pointer
+        self.createHeadingPointer()
+        
+        # Create North Pointer
+        self.createNorthPointer()
+        
+        # Show Frame
+        self.Show(True)
+        self.pending = []
+    
+    def createPlotPanel(self):
+        '''Creates the figure and axes for the plotting panel.'''
         self.figure = Figure()
         self.axes = self.figure.add_subplot(111)
         self.canvas = FigureCanvas(self,-1,self.figure)
@@ -58,33 +96,50 @@ class HorizonFrame(wx.Frame):
         self.sizer.Add(self.canvas,1,wx.EXPAND,wx.ALL)
         self.SetSizerAndFit(self.sizer)
         self.Fit()
+        
+    def rescaleX(self):
+        '''Rescales the horizontal axes to make the lengthscales equal.'''
+        self.ratio = self.figure.get_size_inches()[0]/float(self.figure.get_size_inches()[1])
+        self.axes.set_xlim(-self.ratio,self.ratio)
+        self.axes.set_ylim(-1,1)
+    
+    def createHeadingPointer(self):
+        '''Creates the pointer for the current heading.'''
+        self.headingTri = patches.RegularPolygon((0.0,0.80),3,0.05,color='k',zorder=4)
+        self.axes.add_patch(self.headingTri)
+        self.headingText = self.axes.text(0.0,0.675,'0',color='k',size=self.fontSize,horizontalalignment='center',verticalalignment='center',zorder=4)
+    
+    def adjustHeadingPointer(self):
+        '''Adjust the value of the heading pointer.'''
+        self.headingText.set_text(str(self.heading))
+        self.headingText.set_size(self.fontSize) 
+    
+    def createNorthPointer(self):
+        '''Creates the north pointer relative to current heading.'''
+        self.headingNorthTri = patches.RegularPolygon((0.0,0.80),3,0.05,color='k',zorder=4)
+        self.axes.add_patch(self.headingNorthTri)
+        self.headingNorthText = self.axes.text(0.0,0.675,'N',color='k',size=self.fontSize,horizontalalignment='center',verticalalignment='center',zorder=4)    
 
-        # Fix Axes - vertical is of length 2, horizontal keeps the same lengthscale
-        self.rescaleX()
-        
-        # Sky Polygon
-        vertsTop = [[-1,0],[-1,1],[1,1],[1,0],[-1,0]]
-        self.topPolygon = Polygon(vertsTop,facecolor='cyan',edgecolor='none')
-        self.axes.add_patch(self.topPolygon)
-        # Ground Polygon
-        vertsBot = [[-1,0],[-1,-1],[1,-1],[1,0],[-1,0]]
-        self.botPolygon = Polygon(vertsBot,facecolor='brown',edgecolor='none')
-        self.axes.add_patch(self.botPolygon)
-        
-        # Markers
-        self.axes.plot([-1,-1,1,1],[-1,1,1,-1],'ro')
-        
-        # Center Pointer Marker
-        self.thick = 0.015
-        self.axes.add_patch(patches.Rectangle((-0.75,-self.thick),0.5,2.0*self.thick,facecolor='orange',zorder=3))
-        self.axes.add_patch(patches.Rectangle((0.25,-self.thick),0.5,2.0*self.thick,facecolor='orange',zorder=3))
-        self.axes.add_patch(patches.Circle((0,0),radius=self.thick,facecolor='orange',edgecolor='none',zorder=3))
-        
-        # Pitch Markers
-        self.dist10deg = 0.2 # Graph distance per 10 deg
-        self.createPitchmMarkers()
-        
-        # Add Roll, Pitch, Yaw Text
+    def adjustNorthPointer(self):
+        '''Adjust the position and orientation of
+        the north pointer.'''
+        self.headingNorthText.set_size(self.fontSize) 
+        headingRotate = mpl.transforms.Affine2D().rotate_deg_around(0.0,0.0,self.heading)+self.axes.transData
+        self.headingNorthText.set_transform(headingRotate)
+        if (self.heading > 90) and (self.heading < 270):
+            headRot = self.heading-180
+        else:
+            headRot = self.heading
+        self.headingNorthText.set_rotation(headRot)
+        self.headingNorthTri.set_transform(headingRotate)
+        # Adjust if overlapping with heading pointer
+        if (self.heading <= 10.0) or (self.heading >= 350.0):
+            self.headingNorthText.set_text('')
+        else:
+            self.headingNorthText.set_text('N')
+    
+    def createRPYText(self):
+        '''Creates the text for roll, pitch and yaw.'''
         self.vertSize = 0.09
         ypx = self.figure.get_size_inches()[1]*self.figure.dpi
         self.fontSize = self.vertSize*(ypx/2.0)
@@ -96,23 +151,56 @@ class HorizonFrame(wx.Frame):
         self.pitchText.set_path_effects([PathEffects.withStroke(linewidth=1,foreground='k')])
         self.yawText.set_path_effects([PathEffects.withStroke(linewidth=1,foreground='k')])
         
-        # Show Frame
-        self.Show(True)
-        self.pending = []
+    def updateRPYLocations(self):
+        '''Update the locations of rol, pitch, yaw text.'''
+        leftPos = self.axes.get_xlim()[0]
+        # Locations
+        self.rollText.set_position((leftPos+(self.vertSize/10.0),-0.97+(2*self.vertSize)-(self.vertSize/10.0)))
+        self.pitchText.set_position((leftPos+(self.vertSize/10.0),-0.97+self.vertSize-(0.5*self.vertSize/10.0)))
+        self.yawText.set_position((leftPos+(self.vertSize/10.0),-0.97))
+        # Font Size
+        ypx = self.figure.get_size_inches()[1]*self.figure.dpi
+        self.fontSize = self.vertSize*(ypx/2.0)
+        self.rollText.set_size(self.fontSize)
+        self.pitchText.set_size(self.fontSize)
+        self.yawText.set_size(self.fontSize)
         
-    def calcPitchMarkerWidth(self,i):
-        '''Calculates the width of a pitch marker.'''
-        if (i % 3) == 0:
-            if i == 0:
-                width = 1.5
-            else:
-                width = 0.9
-        else:
-            width = 0.6
-            
-        return width
+    def updateRPYText(self):
+        'Updates the displayed Roll, Pitch, Yaw Text'
+        self.rollText.set_text('Roll:   %.2f' % self.roll)
+        self.pitchText.set_text('Pitch: %.2f' % self.pitch)
+        self.yawText.set_text('Yaw:   %.2f' % self.yaw)
         
-    def createPitchmMarkers(self):
+    def createCenterPointMarker(self):
+        '''Creates the center pointer in the middle of the screen.'''
+        self.axes.add_patch(patches.Rectangle((-0.75,-self.thick),0.5,2.0*self.thick,facecolor='orange',zorder=3))
+        self.axes.add_patch(patches.Rectangle((0.25,-self.thick),0.5,2.0*self.thick,facecolor='orange',zorder=3))
+        self.axes.add_patch(patches.Circle((0,0),radius=self.thick,facecolor='orange',edgecolor='none',zorder=3))
+        
+    def createHorizonPolygons(self):
+        '''Creates the two polygons to show the sky and ground.'''
+        # Sky Polygon
+        vertsTop = [[-1,0],[-1,1],[1,1],[1,0],[-1,0]]
+        self.topPolygon = Polygon(vertsTop,facecolor='dodgerblue',edgecolor='none')
+        self.axes.add_patch(self.topPolygon)
+        # Ground Polygon
+        vertsBot = [[-1,0],[-1,-1],[1,-1],[1,0],[-1,0]]
+        self.botPolygon = Polygon(vertsBot,facecolor='brown',edgecolor='none')
+        self.axes.add_patch(self.botPolygon)
+        
+    def calcHorizonPoints(self):
+        '''Updates the verticies of the patches for the ground and sky.'''
+        self.ratio = self.figure.get_size_inches()[0]/float(self.figure.get_size_inches()[1])
+        ydiff = math.tan(math.radians(-self.roll))*float(self.ratio)
+        pitchdiff = self.dist10deg*(self.pitch/10.0)
+        # Sky Polygon
+        vertsTop = [(-self.ratio,ydiff-pitchdiff),(-self.ratio,1),(self.ratio,1),(self.ratio,-ydiff-pitchdiff),(-self.ratio,ydiff-pitchdiff)]       
+        self.topPolygon.set_xy(vertsTop)
+        # Ground Polygon
+        vertsBot = [(-self.ratio,ydiff-pitchdiff),(-self.ratio,-1),(self.ratio,-1),(self.ratio,-ydiff-pitchdiff),(-self.ratio,ydiff-pitchdiff)]       
+        self.botPolygon.set_xy(vertsBot)  
+    
+    def createPitchMarkers(self):
         '''Creates the rectangle patches for the pitch indicators.'''
         self.pitchPatches = []
         # Major Lines (multiple of 10 deg)
@@ -135,6 +223,18 @@ class HorizonFrame(wx.Frame):
             self.pitchLabelsRight[i].set_path_effects([PathEffects.withStroke(linewidth=1,foreground='k')])
             i += 1
         
+    def calcPitchMarkerWidth(self,i):
+        '''Calculates the width of a pitch marker.'''
+        if (i % 3) == 0:
+            if i == 0:
+                width = 1.5
+            else:
+                width = 0.9
+        else:
+            width = 0.6
+            
+        return width
+        
     def adjustPitchmarkers(self):
         '''Adjusts the location and orientation of pitch markers.'''
         pitchdiff = self.dist10deg*(self.pitch/10.0)
@@ -156,47 +256,11 @@ class HorizonFrame(wx.Frame):
                 self.pitchLabelsRight[i].set_rotation(self.roll)
                 self.pitchLabelsLeft[i].set_transform(rollRotate)
                 self.pitchLabelsRight[i].set_transform(rollRotate)
-                i += 1
-        
-    def rescaleX(self):
-        '''Rescales the horizontal axes to make the lengthscales equal.'''
-        self.ratio = self.figure.get_size_inches()[0]/float(self.figure.get_size_inches()[1])
-        self.axes.set_xlim(-self.ratio,self.ratio)
-        self.axes.set_ylim(-1,1)
-        
-    def calcHorizonPoints(self):
-        '''Updates the verticies of the patches for the ground and sky.'''
-        self.ratio = self.figure.get_size_inches()[0]/float(self.figure.get_size_inches()[1])
-        ydiff = math.tan(math.radians(-self.roll))*float(self.ratio)
-        pitchdiff = self.dist10deg*(self.pitch/10.0)
-        # Sky Polygon
-        vertsTop = [(-self.ratio,ydiff-pitchdiff),(-self.ratio,1),(self.ratio,1),(self.ratio,-ydiff-pitchdiff),(-self.ratio,ydiff-pitchdiff)]       
-        self.topPolygon.set_xy(vertsTop)
-        # Ground Polygon
-        vertsBot = [(-self.ratio,ydiff-pitchdiff),(-self.ratio,-1),(self.ratio,-1),(self.ratio,-ydiff-pitchdiff),(-self.ratio,ydiff-pitchdiff)]       
-        self.botPolygon.set_xy(vertsBot)       
-        
-    def updateAttitudeText(self):
-        'Updates the displayed attitude Text'
-        self.rollText.set_text('Roll:   %.2f' % self.roll)
-        self.pitchText.set_text('Pitch: %.2f' % self.pitch)
-        self.yawText.set_text('Yaw:   %.2f' % self.yaw)
-
-    def updateRPYLocations(self):
-        '''Update the locations of rol, pitch, yaw text.'''
-        leftPos = self.axes.get_xlim()[0]
-        # Locations
-        self.rollText.set_position((leftPos+(self.vertSize/10.0),-0.97+(2*self.vertSize)-(self.vertSize/10.0)))
-        self.pitchText.set_position((leftPos+(self.vertSize/10.0),-0.97+self.vertSize-(0.5*self.vertSize/10.0)))
-        self.yawText.set_position((leftPos+(self.vertSize/10.0),-0.97))
-        # Font Size
-        ypx = self.figure.get_size_inches()[1]*self.figure.dpi
-        self.fontSize = self.vertSize*(ypx/2.0)
-        self.rollText.set_size(self.fontSize)
-        self.pitchText.set_size(self.fontSize)
-        self.yawText.set_size(self.fontSize)
-
+                i += 1 
+    
+    # =============== Event Bindings =============== #    
     def on_idle(self, event):
+        '''To adjust text and positions on rescaling the window.'''
         # Fix Window Scales 
         self.rescaleX()
         
@@ -209,6 +273,10 @@ class HorizonFrame(wx.Frame):
         # Update Pitch Markers
         self.adjustPitchmarkers()
         
+        # Update Heading and North Pointer
+        self.adjustHeadingPointer()
+        self.adjustNorthPointer()
+        
         # Update Matplotlib Plot
         self.canvas.draw()
         self.canvas.Refresh()
@@ -217,6 +285,7 @@ class HorizonFrame(wx.Frame):
         time.sleep(0.05)
  
     def on_timer(self, event):
+        '''Main Loop.'''
         state = self.state
         if state.close_event.wait(0.001):
             self.timer.Stop()
@@ -232,7 +301,7 @@ class HorizonFrame(wx.Frame):
                 self.yaw = obj.yaw*180/math.pi
                 
                 # Update Displayed Text
-                self.updateAttitudeText()
+                self.updateRPYText()
                 
                 # Recalculate Horizon Polygons
                 self.calcHorizonPoints()
@@ -243,17 +312,25 @@ class HorizonFrame(wx.Frame):
                 # Update Matplotlib Plot
                 self.canvas.draw()
                 self.canvas.Refresh()
+            
+            if isinstance(obj,VFR_HUD):
+                self.heading = obj.heading
+                
+                # Update Heading North Pointer
+                self.adjustHeadingPointer()
+                self.adjustNorthPointer()
                 
         self.Refresh()
         self.Update()
                 
     def on_KeyPress(self,event):
+        '''To adjust the distance between pitch markers.'''
         if event.GetKeyCode() == wx.WXK_UP:
             self.dist10deg += 0.1
             print 'Dist per 10 deg: %.1f' % self.dist10deg      
         elif event.GetKeyCode() == wx.WXK_DOWN:
             self.dist10deg -= 0.1
-            if self.dist10deg < 0:
-                self.dist10deg = 0
+            if self.dist10deg <= 0:
+                self.dist10deg = 0.1
             print 'Dist per 10 deg: %.1f' % self.dist10deg      
 

--- a/MAVProxy/modules/lib/wxhorizon_util.py
+++ b/MAVProxy/modules/lib/wxhorizon_util.py
@@ -12,5 +12,9 @@ class VFR_HUD():
         self.groundspeed = hudMsg.groundspeed
         self.heading = hudMsg.heading
         self.throttle = hudMsg.throttle
-        self.alt = hudMsg.alt
         self.climbRate = hudMsg.climb
+        
+class Global_Position_INT():
+    '''Altitude relative to ground (GPS).'''
+    def __init__(self,gpsINT):
+        self.relAlt = gpsINT.relative_alt/1000.0

--- a/MAVProxy/modules/lib/wxhorizon_util.py
+++ b/MAVProxy/modules/lib/wxhorizon_util.py
@@ -1,0 +1,6 @@
+class Attitude():
+    '''The current Attitude Data'''
+    def __init__(self, attitudeMsg):
+        self.pitch = attitudeMsg.pitch
+        self.roll = attitudeMsg.roll
+        self.yaw = attitudeMsg.yaw

--- a/MAVProxy/modules/lib/wxhorizon_util.py
+++ b/MAVProxy/modules/lib/wxhorizon_util.py
@@ -4,3 +4,13 @@ class Attitude():
         self.pitch = attitudeMsg.pitch
         self.roll = attitudeMsg.roll
         self.yaw = attitudeMsg.yaw
+
+class VFR_HUD():
+    '''HUD Information.'''
+    def __init__(self,hudMsg):
+        self.airspeed = hudMsg.airspeed
+        self.groundspeed = hudMsg.groundspeed
+        self.heading = hudMsg.heading
+        self.throttle = hudMsg.throttle
+        self.alt = hudMsg.alt
+        self.climbRate = hudMsg.climb

--- a/MAVProxy/modules/lib/wxhorizon_util.py
+++ b/MAVProxy/modules/lib/wxhorizon_util.py
@@ -18,3 +18,10 @@ class Global_Position_INT():
     '''Altitude relative to ground (GPS).'''
     def __init__(self,gpsINT):
         self.relAlt = gpsINT.relative_alt/1000.0
+        
+class BatteryInfo():
+    '''Voltage, current and remaning battery.'''
+    def __init__(self,batMsg):
+        self.voltage = batMsg.voltage_battery/1000.0 # Volts
+        self.current = batMsg.current_battery/100.0 # Amps
+        self.batRemain = batMsg.battery_remaining # %

--- a/MAVProxy/modules/lib/wxhorizon_util.py
+++ b/MAVProxy/modules/lib/wxhorizon_util.py
@@ -25,3 +25,24 @@ class BatteryInfo():
         self.voltage = batMsg.voltage_battery/1000.0 # Volts
         self.current = batMsg.current_battery/100.0 # Amps
         self.batRemain = batMsg.battery_remaining # %
+        
+class FlightState():
+    '''Mode and arm state.'''
+    def __init__(self,mode,armState):
+        self.mode = mode
+        self.armState = armState
+        
+class WaypointInfo():
+    '''Current and final waypoint numbers, and the distance
+    to the current waypoint.'''
+    def __init__(self,current,final,currentDist,nextWPTime,wpBearing):
+        self.current = current
+        self.final = final
+        self.currentDist = currentDist
+        self.nextWPTime = nextWPTime
+        self.wpBearing = wpBearing
+        
+        
+        
+        
+        

--- a/MAVProxy/modules/mavproxy_horizon.py
+++ b/MAVProxy/modules/mavproxy_horizon.py
@@ -6,7 +6,7 @@
 
 from MAVProxy.modules.lib import wxhorizon
 from MAVProxy.modules.lib import mp_module
-from MAVProxy.modules.lib.wxhorizon_util import Attitude, VFR_HUD, Global_Position_INT, BatteryInfo
+from MAVProxy.modules.lib.wxhorizon_util import Attitude, VFR_HUD, Global_Position_INT, BatteryInfo, FlightState, WaypointInfo
 
 
 class HorizonModule(mp_module.MPModule):
@@ -14,7 +14,15 @@ class HorizonModule(mp_module.MPModule):
         # Define module load/unload reference and window title
         super(HorizonModule, self).__init__(mpstate, "horizon", "Horizon Indicator", public=True)
         self.mpstate.horizonIndicator = wxhorizon.HorizonIndicator(title='Horizon Indicator')
-
+        self.oldMode = ''
+        self.armed = False
+        self.currentWP = 0
+        self.finalWP = 0
+        self.currentDist = 0
+        self.nextWPTime = 0
+        self.speed = 0
+        self.wpBearing = 0
+        
     def unload(self):
         '''unload module'''
         self.mpstate.horizonIndicator.close()
@@ -22,6 +30,7 @@ class HorizonModule(mp_module.MPModule):
     def mavlink_packet(self, msg):
         '''handle an incoming mavlink packet'''
         msgType = msg.get_type()
+        master = self.master
         if msgType == 'ATTITUDE':
             # Send attitude information down pipe
             self.mpstate.horizonIndicator.parent_pipe_send.send(Attitude(msg))
@@ -32,7 +41,33 @@ class HorizonModule(mp_module.MPModule):
             # Send altitude information down pipe
             self.mpstate.horizonIndicator.parent_pipe_send.send(Global_Position_INT(msg))
         elif msgType == 'SYS_STATUS':
+            # Mode and Arm State
             self.mpstate.horizonIndicator.parent_pipe_send.send(BatteryInfo(msg))
+        elif msgType in ['WAYPOINT_CURRENT', 'MISSION_CURRENT']:
+            # Waypoints
+            self.currentWP = msg.seq
+            self.finalWP = self.module('wp').wploader.count()
+            self.mpstate.horizonIndicator.parent_pipe_send.send(WaypointInfo(self.currentWP,self.finalWP,self.currentDist,self.nextWPTime,self.wpBearing))
+        elif msgType == 'NAV_CONTROLLER_OUTPUT':
+            self.currentDist = msg.wp_dist
+            self.speed = master.field('VFR_HUD', 'airspeed', 30)
+            if self.speed > 1:
+                self.nextWPTime = self.currentDist / self.speed
+            else:
+                self.nextWPTime = '-'
+            self.wpBearing = msg.target_bearing
+            self.mpstate.horizonIndicator.parent_pipe_send.send(WaypointInfo(self.currentWP,self.finalWP,self.currentDist,self.nextWPTime,self.wpBearing))
+
+        # Update state and mode information
+        updateState = False
+        if self.oldMode != master.flightmode:
+            self.oldMode = master.flightmode
+            updateState = True
+        if self.armed != master.motors_armed():
+            self.armed = master.motors_armed()
+            updateState = True
+        if updateState:
+            self.mpstate.horizonIndicator.parent_pipe_send.send(FlightState(master.flightmode,master.motors_armed()))
         
 def init(mpstate):
     '''initialise module'''

--- a/MAVProxy/modules/mavproxy_horizon.py
+++ b/MAVProxy/modules/mavproxy_horizon.py
@@ -6,7 +6,7 @@
 
 from MAVProxy.modules.lib import wxhorizon
 from MAVProxy.modules.lib import mp_module
-from MAVProxy.modules.lib.wxhorizon_util import Attitude, VFR_HUD, Global_Position_INT
+from MAVProxy.modules.lib.wxhorizon_util import Attitude, VFR_HUD, Global_Position_INT, BatteryInfo
 
 
 class HorizonModule(mp_module.MPModule):
@@ -21,16 +21,18 @@ class HorizonModule(mp_module.MPModule):
 
     def mavlink_packet(self, msg):
         '''handle an incoming mavlink packet'''
-        if msg.get_type() == 'ATTITUDE':
+        msgType = msg.get_type()
+        if msgType == 'ATTITUDE':
             # Send attitude information down pipe
             self.mpstate.horizonIndicator.parent_pipe_send.send(Attitude(msg))
-        elif msg.get_type() == 'VFR_HUD':
+        elif msgType == 'VFR_HUD':
             # Send HUD information down pipe
             self.mpstate.horizonIndicator.parent_pipe_send.send(VFR_HUD(msg))
-        elif msg.get_type() == 'GLOBAL_POSITION_INT':
+        elif msgType == 'GLOBAL_POSITION_INT':
             # Send altitude information down pipe
             self.mpstate.horizonIndicator.parent_pipe_send.send(Global_Position_INT(msg))
-                
+        elif msgType == 'SYS_STATUS':
+            self.mpstate.horizonIndicator.parent_pipe_send.send(BatteryInfo(msg))
         
 def init(mpstate):
     '''initialise module'''

--- a/MAVProxy/modules/mavproxy_horizon.py
+++ b/MAVProxy/modules/mavproxy_horizon.py
@@ -6,7 +6,7 @@
 
 from MAVProxy.modules.lib import wxhorizon
 from MAVProxy.modules.lib import mp_module
-from MAVProxy.modules.lib.wxhorizon_util import Attitude, VFR_HUD
+from MAVProxy.modules.lib.wxhorizon_util import Attitude, VFR_HUD, Global_Position_INT
 
 
 class HorizonModule(mp_module.MPModule):
@@ -27,6 +27,9 @@ class HorizonModule(mp_module.MPModule):
         elif msg.get_type() == 'VFR_HUD':
             # Send HUD information down pipe
             self.mpstate.horizonIndicator.parent_pipe_send.send(VFR_HUD(msg))
+        elif msg.get_type() == 'GLOBAL_POSITION_INT':
+            # Send altitude information down pipe
+            self.mpstate.horizonIndicator.parent_pipe_send.send(Global_Position_INT(msg))
                 
         
 def init(mpstate):

--- a/MAVProxy/modules/mavproxy_horizon.py
+++ b/MAVProxy/modules/mavproxy_horizon.py
@@ -6,7 +6,7 @@
 
 from MAVProxy.modules.lib import wxhorizon
 from MAVProxy.modules.lib import mp_module
-from MAVProxy.modules.lib.wxhorizon_util import Attitude
+from MAVProxy.modules.lib.wxhorizon_util import Attitude, VFR_HUD
 
 
 class HorizonModule(mp_module.MPModule):
@@ -24,7 +24,11 @@ class HorizonModule(mp_module.MPModule):
         if msg.get_type() == 'ATTITUDE':
             # Send attitude information down pipe
             self.mpstate.horizonIndicator.parent_pipe_send.send(Attitude(msg))
-
+        elif msg.get_type() == 'VFR_HUD':
+            # Send HUD information down pipe
+            self.mpstate.horizonIndicator.parent_pipe_send.send(VFR_HUD(msg))
+                
+        
 def init(mpstate):
     '''initialise module'''
     return HorizonModule(mpstate)

--- a/MAVProxy/modules/mavproxy_horizon.py
+++ b/MAVProxy/modules/mavproxy_horizon.py
@@ -1,0 +1,30 @@
+"""
+  MAVProxy console
+
+  uses lib/console.py for display
+"""
+
+from MAVProxy.modules.lib import wxhorizon
+from MAVProxy.modules.lib import mp_module
+from MAVProxy.modules.lib.wxhorizon_util import Attitude
+
+
+class HorizonModule(mp_module.MPModule):
+    def __init__(self, mpstate):
+        # Define module load/unload reference and window title
+        super(HorizonModule, self).__init__(mpstate, "horizon", "Horizon Indicator", public=True)
+        self.mpstate.horizonIndicator = wxhorizon.HorizonIndicator(title='Horizon Indicator')
+
+    def unload(self):
+        '''unload module'''
+        self.mpstate.horizonIndicator.close()
+
+    def mavlink_packet(self, msg):
+        '''handle an incoming mavlink packet'''
+        if msg.get_type() == 'ATTITUDE':
+            # Send attitude information down pipe
+            self.mpstate.horizonIndicator.parent_pipe_send.send(Attitude(msg))
+
+def init(mpstate):
+    '''initialise module'''
+    return HorizonModule(mpstate)


### PR DESCRIPTION
An artificial horizon display for MAVProxy aiming to improve the situational awareness of the aircraft.

Features
- Artificial horizon responds to the roll and pitch of the aircraft
- The distance between the pitch markers can be changed by using the up and down arrow keys when the module has focus
- Heading points for the current heading, north and the next target point (green pointer)
- Current mode and arm state (green/red)
- Battery information, voltage, current draw, percentage. NOTE: In SITL this works for ArduCopter but not ArduPlane, as it seems that ArduPlane doesn't simulate the battery. In this case the bar defaults to black.
- Current airspeed, altitude (above ground) and climb rates

![image](https://cloud.githubusercontent.com/assets/11292914/20426712/7a39f316-add4-11e6-92e6-1e0e34d11697.png)
