### PR TITLE
Horizon Module: Performance Improvements. Set horizon fps. Module unload bug fixed.

### DIFF
--- a/MAVProxy/modules/lib/wxhorizon.py
+++ b/MAVProxy/modules/lib/wxhorizon.py
@@ -32,6 +32,7 @@ class HorizonIndicator():
         app.frame.SetDoubleBuffered(True)
         app.frame.Show()
         app.MainLoop()
+        self.close_event.set()   # indicate that the GUI has closed
 
     def close(self):
         '''Close the window.'''

--- a/MAVProxy/modules/lib/wxhorizon_util.py
+++ b/MAVProxy/modules/lib/wxhorizon_util.py
@@ -16,8 +16,9 @@ class VFR_HUD():
         
 class Global_Position_INT():
     '''Altitude relative to ground (GPS).'''
-    def __init__(self,gpsINT):
+    def __init__(self,gpsINT,curTime):
         self.relAlt = gpsINT.relative_alt/1000.0
+        self.curTime = curTime
         
 class BatteryInfo():
     '''Voltage, current and remaning battery.'''
@@ -42,7 +43,10 @@ class WaypointInfo():
         self.nextWPTime = nextWPTime
         self.wpBearing = wpBearing
         
-        
+class FPS():
+    '''Stores intended frame rate information.'''
+    def __init__(self,fps):
+        self.fps = fps # if fps is zero, then the frame rate is unrestricted
         
         
         

--- a/MAVProxy/modules/mavproxy_horizon.py
+++ b/MAVProxy/modules/mavproxy_horizon.py
@@ -6,8 +6,9 @@
 
 from MAVProxy.modules.lib import wxhorizon
 from MAVProxy.modules.lib import mp_module
-from MAVProxy.modules.lib.wxhorizon_util import Attitude, VFR_HUD, Global_Position_INT, BatteryInfo, FlightState, WaypointInfo
+from MAVProxy.modules.lib.wxhorizon_util import Attitude, VFR_HUD, Global_Position_INT, BatteryInfo, FlightState, WaypointInfo, FPS
 
+import time
 
 class HorizonModule(mp_module.MPModule):
     def __init__(self, mpstate):
@@ -22,39 +23,73 @@ class HorizonModule(mp_module.MPModule):
         self.nextWPTime = 0
         self.speed = 0
         self.wpBearing = 0
+        self.msgList = []
+        self.lastSend = 0.0
+        self.fps = 10.0
+        self.sendDelay = (1.0/self.fps)*0.9
+        self.add_command('horizon-fps',self.fpsInformation,"Get or change frame rate for horizon. Usage: horizon-fps set <fps>, horizon-fps get. Set fps to zero to get unrestricted framerate.")
         
     def unload(self):
         '''unload module'''
         self.mpstate.horizonIndicator.close()
             
+    def fpsInformation(self,args):
+        '''fps command'''
+        invalidStr = 'Invalid number of arguments. Usage horizon-fps set <fps> or horizon-fps get. Set fps to zero to get unrestricted framerate.'
+        if len(args)>0:
+            if args[0] == "get":
+                '''Get the current framerate.'''
+                if (self.fps == 0.0):
+                    print 'Horizon Framerate: Unrestricted'
+                else:
+                    print "Horizon Framerate: " + str(self.fps)
+            elif args[0] == "set":
+                if len(args)==2:
+                    self.fps = float(args[1])
+                    if (self.fps != 0):
+                        self.sendDelay = 1.0/self.fps
+                    else:
+                        self.sendDelay = 0.0
+                    self.msgList.append(FPS(self.fps))
+                    if (self.fps == 0.0):
+                        print 'Horizon Framerate: Unrestricted'
+                    else:
+                        print "Horizon Framerate: " + str(self.fps)
+                else:
+                    print invalidStr
+            else:
+                print invalidStr
+        else:
+            print invalidStr
+            
     def mavlink_packet(self, msg):
         '''handle an incoming mavlink packet'''
         msgType = msg.get_type()
-        master = self.master
+        master = self.master       
         if msgType == 'HEARTBEAT':
             # Update state and mode information
             if type(master.motors_armed()) == type(True):
                 self.armed = master.motors_armed()
                 self.mode = master.flightmode
                 # Send Flight State information down pipe
-                self.mpstate.horizonIndicator.parent_pipe_send.send(FlightState(self.mode,self.armed))
+                self.msgList.append(FlightState(self.mode,self.armed))
         elif msgType == 'ATTITUDE':
             # Send attitude information down pipe
-            self.mpstate.horizonIndicator.parent_pipe_send.send(Attitude(msg))
+            self.msgList.append(Attitude(msg))
         elif msgType == 'VFR_HUD':
             # Send HUD information down pipe
-            self.mpstate.horizonIndicator.parent_pipe_send.send(VFR_HUD(msg))
+            self.msgList.append(VFR_HUD(msg))
         elif msgType == 'GLOBAL_POSITION_INT':
             # Send altitude information down pipe
-            self.mpstate.horizonIndicator.parent_pipe_send.send(Global_Position_INT(msg))
+            self.msgList.append(Global_Position_INT(msg,time.time()))
         elif msgType == 'SYS_STATUS':
             # Mode and Arm State
-            self.mpstate.horizonIndicator.parent_pipe_send.send(BatteryInfo(msg))
+            self.msgList.append(BatteryInfo(msg))
         elif msgType in ['WAYPOINT_CURRENT', 'MISSION_CURRENT']:
             # Waypoints
             self.currentWP = msg.seq
             self.finalWP = self.module('wp').wploader.count()
-            self.mpstate.horizonIndicator.parent_pipe_send.send(WaypointInfo(self.currentWP,self.finalWP,self.currentDist,self.nextWPTime,self.wpBearing))
+            self.msgList.append(WaypointInfo(self.currentWP,self.finalWP,self.currentDist,self.nextWPTime,self.wpBearing))
         elif msgType == 'NAV_CONTROLLER_OUTPUT':
             self.currentDist = msg.wp_dist
             self.speed = master.field('VFR_HUD', 'airspeed', 30)
@@ -63,8 +98,18 @@ class HorizonModule(mp_module.MPModule):
             else:
                 self.nextWPTime = '-'
             self.wpBearing = msg.target_bearing
-            self.mpstate.horizonIndicator.parent_pipe_send.send(WaypointInfo(self.currentWP,self.finalWP,self.currentDist,self.nextWPTime,self.wpBearing))
-        
+            self.msgList.append(WaypointInfo(self.currentWP,self.finalWP,self.currentDist,self.nextWPTime,self.wpBearing))
+
+    
+    def idle_task(self):
+        if self.mpstate.horizonIndicator.close_event.wait(0.001):
+            self.needs_unloading = True   # tell MAVProxy to unload this module
+    
+        if (time.time() - self.lastSend) > self.sendDelay:
+            self.mpstate.horizonIndicator.parent_pipe_send.send(self.msgList)
+            self.msgList = []
+            self.lastSend = time.time()
+    
 def init(mpstate):
     '''initialise module'''
     return HorizonModule(mpstate)


### PR DESCRIPTION
The horizon module has been tweaked to give a few performance improvement on lower performance machines. The ability to set the desired frames per second for updating horizon is provided through the use of horizon-fps set <fps> and horizon get commands. 10 fps is the default, but it is suggested that 5 may be appropriate on some machines. Setting to 0 fps will result in the frame rate being unrestricted.
A bug in the module not unloading when the horizon window is closed, and the window not closing when the module is unloaded, has been fixed.