### PR TITLE
rccsetup: set parameters SERVOx_[TRIM|MIN|MAX]

### DIFF
--- a/MAVProxy/modules/mavproxy_rcsetup.py
+++ b/MAVProxy/modules/mavproxy_rcsetup.py
@@ -32,6 +32,11 @@ class RCSetupModule(mp_module.MPModule):
             self.param_set('RC%u_MAX' % i, self.rc_cal[i][1], 5)
             self.console.writeln("Set: RC%u_MAX=%u" % (i, self.rc_cal[i][1]))
 
+            self.param_set('SERVO%u_MIN' % i, self.rc_cal[i][0], 5)
+            self.console.writeln("Set: SERVO%u_MIN=%u" % (i, self.rc_cal[i][0]))
+            self.param_set('SERVO%u_MAX' % i, self.rc_cal[i][1], 5)
+            self.console.writeln("Set: SERVO%u_MAX=%u" % (i, self.rc_cal[i][1]))
+
     def get_cal_min(self, channel):
         return self.rc_cal[channel][0]
 
@@ -75,7 +80,11 @@ class RCSetupModule(mp_module.MPModule):
             return
         m = self.status.msgs['RC_CHANNELS_RAW']
         for ch in range(1,5):
-            self.param_set('RC%u_TRIM' % ch, getattr(m, 'chan%u_raw' % ch))
+            ch_trim = getattr(m, 'chan%u_raw' % ch)
+            self.param_set('RC%u_TRIM' % ch, ch_trim)
+            self.console.writeln("Set: RC%u_TRIM=%u" % (ch, ch_trim))
+            self.param_set('SERVO%u_TRIM' % ch, ch_trim)
+            self.console.writeln("Set: SERVO%u_TRIM=%u" % (ch, ch_trim))
 
 
     def unload(self):
@@ -98,9 +107,11 @@ class RCSetupModule(mp_module.MPModule):
                 if self.get_cal_min(i) > v:
                     self.set_cal_min(i,v)
                     self.console.writeln("Calibrating: RC%u_MIN=%u" % (i, v))
+                    self.console.writeln("Calibrating: SERVO%u_MIN=%u" % (i, v))
                 if self.get_cal_max(i) < v:
                     self.set_cal_max(i,v)
                     self.console.writeln("Calibrating: RC%u_MAX=%u" % (i, v))
+                    self.console.writeln("Calibrating: SERVO%u_MAX=%u" % (i, v))
 
     def print_cal_usage(self):
         print("Usage rccal <start|done>")


### PR DESCRIPTION
During a calibration it is now needed to set SERVOx_[TRIM|MIN|MAX] to
the same values as RCx_[TRIM|MIN|MAX].

Also add messages during trim calibration.