### PR TITLE
wp: honour new wp count sent by autopilot

### DIFF
--- a/MAVProxy/modules/mavproxy_wp.py
+++ b/MAVProxy/modules/mavproxy_wp.py
@@ -89,11 +89,11 @@ class WPModule(mp_module.MPModule):
         '''handle an incoming mavlink packet'''
         mtype = m.get_type()
         if mtype in ['WAYPOINT_COUNT','MISSION_COUNT']:
+            self.wploader.expected_count = m.count
             if self.wp_op is None:
                 self.console.error("No waypoint load started")
             else:
                 self.wploader.clear()
-                self.wploader.expected_count = m.count
                 self.console.writeln("Requesting %u waypoints t=%s now=%s" % (m.count,
                                                                                  time.asctime(time.localtime(m._timestamp)),
                                                                                  time.asctime()))


### PR DESCRIPTION
If someone else has requested waypoints we need to reset
our expected waypoint count, even though we're not doing
the requests

https://github.com/ArduPilot/ardupilot/pull/5595 causes ArduPilot to send these counts if some other GCS (or MAVProxy itself through another codepath (missedit)) resets the waypoint count and mavproxy_wp requests an out-of-bound wwaypoint.

