### PR TITLE
Support dbl left clicking of urls in console window

### DIFF
--- a/MAVProxy/modules/lib/wxconsole_ui.py
+++ b/MAVProxy/modules/lib/wxconsole_ui.py
@@ -3,7 +3,7 @@ import os
 import mp_menu
 from wxconsole_util import Value, Text
 from wx_loader import wx
-import webbrowser # handle url's in console window
+import webbrowser # Support opening URLs from console window
 
 class ConsoleFrame(wx.Frame):
     """ The main frame of the console"""
@@ -36,7 +36,7 @@ class ConsoleFrame(wx.Frame):
         self.timer.Start(100)
 
         self.Bind(wx.EVT_IDLE, self.on_idle)
-        self.Bind(wx.EVT_TEXT_URL, self.on_text_URL)
+        self.Bind(wx.EVT_TEXT_URL, self.on_text_url)
 
         self.Show(True)
         self.pending = []
@@ -50,12 +50,12 @@ class ConsoleFrame(wx.Frame):
         ret.call_handler()
         state.child_pipe_send.send(ret)
     
-    def on_text_URL(self, event):
-        mouseEvent = event.GetMouseEvent()
-        if mouseEvent.LeftDClick():
-            urlStart = event.GetURLStart()
-            urlEnd = event.GetURLEnd()
-            url = self.control.GetRange(urlStart, urlEnd)
+    def on_text_url(self, event):
+        mouse_event = event.GetMouseEvent()
+        if mouse_event.LeftDClick():
+            url_start = event.GetURLStart()
+            url_end = event.GetURLEnd()
+            url = self.control.GetRange(url_start, url_end)
             try:
                 browser_controller = webbrowser.get('google-chrome')
                 browser_controller.open_new_tab(url)

--- a/MAVProxy/modules/lib/wxconsole_ui.py
+++ b/MAVProxy/modules/lib/wxconsole_ui.py
@@ -3,7 +3,6 @@ import os
 import mp_menu
 from wxconsole_util import Value, Text
 from wx_loader import wx
-import webbrowser # Support opening URLs from console window
 
 class ConsoleFrame(wx.Frame):
     """ The main frame of the console"""
@@ -49,17 +48,24 @@ class ConsoleFrame(wx.Frame):
             return
         ret.call_handler()
         state.child_pipe_send.send(ret)
-    
+
     def on_text_url(self, event):
+        '''handle double clicks on URL text'''
+        try:
+            import webbrowser
+        except ImportError:
+            return
         mouse_event = event.GetMouseEvent()
         if mouse_event.LeftDClick():
             url_start = event.GetURLStart()
             url_end = event.GetURLEnd()
             url = self.control.GetRange(url_start, url_end)
             try:
+                # attempt to use google-chrome
                 browser_controller = webbrowser.get('google-chrome')
                 browser_controller.open_new_tab(url)
-            except:
+            except webbrowser.Error:
+                # use the system configured default browser
                 webbrowser.open_new_tab(url)
 
     def on_idle(self, event):

--- a/MAVProxy/modules/lib/wxconsole_ui.py
+++ b/MAVProxy/modules/lib/wxconsole_ui.py
@@ -3,6 +3,7 @@ import os
 import mp_menu
 from wxconsole_util import Value, Text
 from wx_loader import wx
+import webbrowser # handle url's in console window
 
 class ConsoleFrame(wx.Frame):
     """ The main frame of the console"""
@@ -19,8 +20,7 @@ class ConsoleFrame(wx.Frame):
         self.menu = None
         self.menu_callback = None
 
-        self.control = wx.TextCtrl(self.panel, style=wx.TE_MULTILINE | wx.TE_READONLY)
-
+        self.control = wx.TextCtrl(self.panel, style=wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_AUTO_URL)
 
         self.vbox = wx.BoxSizer(wx.VERTICAL)
         # start with one status row
@@ -36,6 +36,7 @@ class ConsoleFrame(wx.Frame):
         self.timer.Start(100)
 
         self.Bind(wx.EVT_IDLE, self.on_idle)
+        self.Bind(wx.EVT_TEXT_URL, self.on_text_URL)
 
         self.Show(True)
         self.pending = []
@@ -48,6 +49,18 @@ class ConsoleFrame(wx.Frame):
             return
         ret.call_handler()
         state.child_pipe_send.send(ret)
+    
+    def on_text_URL(self, event):
+        mouseEvent = event.GetMouseEvent()
+        if mouseEvent.LeftDClick():
+            urlStart = event.GetURLStart()
+            urlEnd = event.GetURLEnd()
+            url = self.control.GetRange(urlStart, urlEnd)
+            try:
+                browser_controller = webbrowser.get('google-chrome')
+                browser_controller.open_new_tab(url)
+            except:
+                webbrowser.open_new_tab(url)
 
     def on_idle(self, event):
         time.sleep(0.05)


### PR DESCRIPTION
This PR adds support for click-able hyperlinks in the console window. When double left clicked (or wx event equivalent) a new tab is opened to the url address. This PR is to support the MAVCesium module [issue](https://github.com/SamuelDudley/MAVCesium/issues/4) but I feel it could also be a useful tool to direct users to support pages, documentation or FW downloads.

![screenshot from 2017-02-20 21 53 26](https://cloud.githubusercontent.com/assets/8290680/23123157/32b55e7c-f7b7-11e6-8ae2-5d49d2746383.png)
