### PR TITLE
Windows - fixed pathing error and added yaml module

### DIFF
--- a/MAVProxy/modules/lib/mp_util.py
+++ b/MAVProxy/modules/lib/mp_util.py
@@ -222,7 +222,10 @@ def PILTowx(pimg):
 
 def dot_mavproxy(name=None):
     '''return a path to store mavproxy data'''
-    dir = os.path.join(os.environ['HOME'], '.mavproxy')
+    if 'HOME' not in os.environ:
+        dir = os.path.join(os.environ['LOCALAPPDATA'], '.mavproxy')
+    else:
+        dir = os.path.join(os.environ['HOME'], '.mavproxy')
     mkdir_p(dir)
     if name is None:
         return dir

--- a/windows/mavproxy.spec
+++ b/windows/mavproxy.spec
@@ -28,7 +28,7 @@ MAVProxyAny = Analysis(['mavproxy.py'],
                             'pygame.transform', 'pygame.surface', 'pygame.bufferproxy', 'wx._grid',
                             'wx.lib.agw.genericmessagedialog', 'wx.lib.wordwrap', 'wx.lib.buttons',
                             'wx.lib.embeddedimage', 'wx.lib.imageutils', 'wx.lib.agw.aquabutton', 
-                            'wx.lib.agw.gradientbutton', 'wxversion', 'UserList', 'UserString'],
+                            'wx.lib.agw.gradientbutton', 'wxversion', 'UserList', 'UserString', 'yaml', 'yaml.error', 'yaml.tokens', 'yaml.events', 'yaml.nodes', 'yaml.loader', 'yaml.dumper', 'yaml.reader', 'yaml.scanner', 'yaml.parser', 'yaml.composer', 'yaml.constructor', 'yaml.resolver', 'yaml.emitter', 'yaml.serializer', 'yaml.representer'],
              hookspath=None,
              runtime_hooks=None)
 MAVExpAny = Analysis(['.\\tools\\MAVExplorer.py'],


### PR DESCRIPTION
os.environ['HOME'] crashes under Windows, so we need to use os.environ['LOCALAPPDATA'] instead.

Also added a whole bunch of yaml libraries to the Windows build (required by the joystick module).