### PR TITLE
Link: add optional human recognizable link names

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -697,7 +697,7 @@ def check_link_status():
         mpstate.status.heartbeat_error = True
     for master in mpstate.mav_master:
         if not master.linkerror and (tnow > master.last_message + 5 or master.portdead):
-            say("link %u down" % (master.linknum+1))
+            say("link %s down" % (mp_module.MPModule.link_string(master)))
             master.linkerror = True
 
 def send_heartbeat(master):

--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -697,7 +697,7 @@ def check_link_status():
         mpstate.status.heartbeat_error = True
     for master in mpstate.mav_master:
         if not master.linkerror and (tnow > master.last_message + 5 or master.portdead):
-            say("link %s down" % (mp_module.MPModule.link_string(master)))
+            say("link %s down" % (mp_module.MPModule.link_label(master)))
             master.linkerror = True
 
 def send_heartbeat(master):

--- a/MAVProxy/modules/lib/mp_module.py
+++ b/MAVProxy/modules/lib/mp_module.py
@@ -151,10 +151,10 @@ class MPModule(object):
         self.mpstate.rl.set_prompt(prompt)
             
     @staticmethod
-    def link_string(link):
-        '''return a link description as a string'''
-        if link.handle:
-            description = link.handle
+    def link_label(link):
+        '''return a link label as a string'''
+        if link.label:
+            label = link.label
         else:
-            description = str(link.linknum+1)
-        return description
+            label = str(link.linknum+1)
+        return label

--- a/MAVProxy/modules/lib/mp_module.py
+++ b/MAVProxy/modules/lib/mp_module.py
@@ -150,3 +150,11 @@ class MPModule(object):
             prompt = self.settings.vehicle_name + ':' + prompt
         self.mpstate.rl.set_prompt(prompt)
             
+    @staticmethod
+    def link_string(link):
+        '''return a link description as a string'''
+        if link.handle:
+            description = link.handle
+        else:
+            description = str(link.linknum+1)
+        return description

--- a/MAVProxy/modules/lib/mp_module.py
+++ b/MAVProxy/modules/lib/mp_module.py
@@ -153,7 +153,7 @@ class MPModule(object):
     @staticmethod
     def link_label(link):
         '''return a link label as a string'''
-        if link.label:
+        if hasattr(link, 'label'):
             label = link.label
         else:
             label = str(link.linknum+1)

--- a/MAVProxy/modules/mavproxy_console.py
+++ b/MAVProxy/modules/mavproxy_console.py
@@ -324,7 +324,7 @@ class ConsoleModule(mp_module.MPModule):
                 self.max_link_num = len(self.mpstate.mav_master)
             for m in self.mpstate.mav_master:
                 linkdelay = (self.mpstate.status.highest_msec - m.highest_msec)*1.0e-3
-                linkline = "Link %s " % (self.link_string(m))
+                linkline = "Link %s " % (self.link_label(m))
                 fg = 'dark green'
                 if m.linkerror:
                     linkline += "down"

--- a/MAVProxy/modules/mavproxy_console.py
+++ b/MAVProxy/modules/mavproxy_console.py
@@ -324,7 +324,7 @@ class ConsoleModule(mp_module.MPModule):
                 self.max_link_num = len(self.mpstate.mav_master)
             for m in self.mpstate.mav_master:
                 linkdelay = (self.mpstate.status.highest_msec - m.highest_msec)*1.0e-3
-                linkline = "Link %u " % (m.linknum+1)
+                linkline = "Link %s " % (self.link_string(m))
                 fg = 'dark green'
                 if m.linkerror:
                     linkline += "down"

--- a/MAVProxy/modules/mavproxy_link.py
+++ b/MAVProxy/modules/mavproxy_link.py
@@ -110,7 +110,7 @@ class LinkModule(mp_module.MPModule):
             except AttributeError as e:
                 # some mav objects may not have a "signing" attribute
                 pass
-            print("link %s %s (%u packets, %.2fs delay, %u lost, %.1f%% loss%s)" % (self.link_string(master),
+            print("link %s %s (%u packets, %.2fs delay, %u lost, %.1f%% loss%s)" % (self.link_label(master),
                                                                                     status,
                                                                                     self.status.counters['MasterIn'][master.linknum],
                                                                                     linkdelay,
@@ -123,8 +123,8 @@ class LinkModule(mp_module.MPModule):
         print("%u links" % len(self.mpstate.mav_master))
         for i in range(len(self.mpstate.mav_master)):
             conn = self.mpstate.mav_master[i]
-            if conn.handle is not None:
-                print("%u (%s): %s" % (i, conn.handle, conn.address))
+            if conn.label is not None:
+                print("%u (%s): %s" % (i, conn.label, conn.address))
             else:
                 print("%u: %s" % (i, conn.address))
 
@@ -148,11 +148,11 @@ class LinkModule(mp_module.MPModule):
             conn.mav.set_send_callback(self.master_send_callback, conn)
         conn.linknum = len(self.mpstate.mav_master)
         try:
-            handle = link_components[1]
-            handle = handle.rstrip(')')
-            conn.handle = handle
+            label = link_components[1]
+            label = label.rstrip(')')
+            conn.label = label
         except:
-            conn.handle = None
+            conn.label = None
         conn.linkerror = False
         conn.link_delayed = False
         conn.last_heartbeat = 0
@@ -186,7 +186,7 @@ class LinkModule(mp_module.MPModule):
             return
         for i in range(len(self.mpstate.mav_master)):
             conn = self.mpstate.mav_master[i]
-            if str(i) == device or conn.address == device or conn.handle == device:
+            if str(i) == device or conn.address == device or conn.label == device:
                 print("Removing link %s" % conn.address)
                 try:
                     try:
@@ -327,7 +327,7 @@ class LinkModule(mp_module.MPModule):
         if mtype in activityPackets:
             if master.linkerror:
                 master.linkerror = False
-                self.say("link %s OK" % (self.link_string(master)))
+                self.say("link %s OK" % (self.link_label(master)))
             self.status.last_message = time.time()
             master.last_message = self.status.last_message
 
@@ -346,7 +346,7 @@ class LinkModule(mp_module.MPModule):
                 self.say("heartbeat OK")
             if master.linkerror:
                 master.linkerror = False
-                self.say("link %s OK" % (self.link_string(master)))
+                self.say("link %s OK" % (self.link_label(master)))
             self.status.last_heartbeat = time.time()
             master.last_heartbeat = self.status.last_heartbeat
 


### PR DESCRIPTION
#### EDITED 07/12/2017
When using multiple master links it can become confusing (at least for me!) as to what hardware (RFD, 3G,  Microhard, VPN, Iridium, WIFI, etc..) is attached to each link number (Link 1, 2, 3, etc...). This PR adds an optional label to a link which replaces the link number in the console.

Example of adding a master link called 'RFD900x': `--master=/dev/ttyUSB0:'{"label":"RFD900x"}'`
Example of removing a link called 'RFD900x': `link remove RFD900x`
Example of adding a link called 'FTDI': `link add /dev/ttyUSB0:{"label":"FTDI"}`

_Notes_:

- You can still use the link number to remove links if you don't want to type the label.
- Typing `link list` will show the link number and associated label (if any)

![console](https://cloud.githubusercontent.com/assets/8290680/24227584/11b17c5a-0fbe-11e7-9f7b-72d7e047dbbe.png)

If no json dict with a label key is passed when creating the link it will use the existing link numbering system, making the PR backwards compatible. I'm open to suggestions to improve the implementation and syntax if required.
Cheers,
Sam