### PR TITLE
Param: Support non-upper case param names when using param help

### DIFF
--- a/MAVProxy/modules/mavproxy_param.py
+++ b/MAVProxy/modules/mavproxy_param.py
@@ -137,6 +137,7 @@ class ParamState:
             return
 
         for h in args:
+            h = h.upper()
             if h in htree:
                 help = htree[h]
                 print("%s: %s\n" % (h, help.get('humanName')))


### PR DESCRIPTION
Currently "param help gps_type" will error. This PR fixes that issue
by converting the param name to upper case prior to searching the help
tree.