### PR TITLE
Map - Fix error on brightness change

### DIFF
--- a/MAVProxy/modules/mavproxy_map/mp_slipmap.py
+++ b/MAVProxy/modules/mavproxy_map/mp_slipmap.py
@@ -34,7 +34,7 @@ class MPSlipMap():
                  service="MicrosoftSat",
                  max_zoom=19,
                  debug=False,
-                 brightness=1.0,
+                 brightness=0,
                  elevation=False,
                  download=True,
                  show_flightmode_legend=True):

--- a/MAVProxy/modules/mavproxy_map/mp_slipmap_ui.py
+++ b/MAVProxy/modules/mavproxy_map/mp_slipmap_ui.py
@@ -407,7 +407,7 @@ class MPSlipMapPanel(wx.Panel):
         self.map_img = state.mt.area_to_image(state.lat, state.lon,
                                               state.width, state.height, state.ground_width)
         if state.brightness != 1.0:
-            self.map_img = self.map_img*state.brightness
+            np.multiply(self.map_img,state.brightness, out=self.map_img, casting='unsafe')
 
 
         # find display bounding box

--- a/MAVProxy/modules/mavproxy_map/mp_slipmap_ui.py
+++ b/MAVProxy/modules/mavproxy_map/mp_slipmap_ui.py
@@ -82,9 +82,13 @@ class MPSlipMapFrame(wx.Frame):
         elif ret.returnkey == 'gotoPosition':
             state.panel.enter_position()
         elif ret.returnkey == 'increaseBrightness':
-            state.brightness *= 1.25
+            state.brightness += 20
+            if state.brightness > 255:
+                state.brightness = 255
         elif ret.returnkey == 'decreaseBrightness':
-            state.brightness /= 1.25
+            state.brightness -= 20
+            if state.brightness < -255:
+                state.brightness = -255
         state.need_redraw = True
 
     def find_object(self, key, layers):
@@ -406,10 +410,13 @@ class MPSlipMapPanel(wx.Panel):
         # get the new map
         self.map_img = state.mt.area_to_image(state.lat, state.lon,
                                               state.width, state.height, state.ground_width)
-        if state.brightness != 1.0:
-            np.multiply(self.map_img,state.brightness, out=self.map_img, casting='unsafe')
-
-
+        if state.brightness != 0: # valid state.brightness range is [-255, 255]
+            brightness = np.uint8(np.abs(state.brightness))
+            if state.brightness > 0:
+                self.map_img = np.where((255 - self.map_img) < brightness, 255, self.map_img + brightness)
+            else:
+                self.map_img = np.where((255 + self.map_img) < brightness, 0, self.map_img - brightness)
+            
         # find display bounding box
         (lat2,lon2) = self.coordinates(state.width-1, state.height-1)
         bounds = (lat2, state.lon, state.lat-lat2, lon2-state.lon)


### PR DESCRIPTION
When changing the brightness of the map (multiplying self.map_img and state.brightness), the resulting image array was being cast to dtype float64. This change ensures that the map_img remains a uint8 dtype, fixing the CV2 error.