### PR TITLE
MODULE_SPEECH: Adding macOS say backend

### DIFF
--- a/MAVProxy/modules/mavproxy_speech.py
+++ b/MAVProxy/modules/mavproxy_speech.py
@@ -7,6 +7,8 @@ from MAVProxy.modules.lib import mp_module
 class SpeechModule(mp_module.MPModule):
     def __init__(self, mpstate):
         super(SpeechModule, self).__init__(mpstate, "speech", "speech output")
+        self.add_command('speech', self.cmd_speech, "text-to-speech", ['<test>'])
+
         self.old_mpstate_say_function = self.mpstate.functions.say
         self.mpstate.functions.say = self.say
         try:
@@ -18,7 +20,7 @@ class SpeechModule(mp_module.MPModule):
         except AttributeError:
             self.settings.append(('speech_voice', str, ''))
         self.kill_speech_dispatcher()
-        for (backend_name,backend) in [("speechd",self.say_speechd), ("espeak",self.say_espeak), ("speech", self.say_speech)]:
+        for (backend_name,backend) in [("speechd",self.say_speechd), ("espeak",self.say_espeak), ("speech", self.say_speech), ("say", self.say_say)]:
             try:
                 backend("")
                 self.say_backend = backend
@@ -78,6 +80,11 @@ class SpeechModule(mp_module.MPModule):
         import speech
         speech.say(text)
 
+    def say_say(self, text, priority='important'):
+        '''speak some text using macOS say command'''
+        import subprocess
+        subprocess.check_call(["say",text])
+
     def say(self, text, priority='important'):
         '''speak some text'''
         ''' http://cvs.freebsoft.org/doc/speechd/ssip.html see 4.3.1 for priorities'''
@@ -92,6 +99,17 @@ class SpeechModule(mp_module.MPModule):
             # say some statustext values
             if msg.text.startswith("Tuning: "):
                 self.say(msg.text[8:])
+
+    def cmd_speech(self, args):
+        '''speech commands'''
+        usage = "usage: speech <test>"
+        if len(args) < 1:
+            print(usage)
+            return
+
+        if args[0] == "test":
+            self.say("Testing speech output")
+
 
 def init(mpstate):
     '''initialise module'''

--- a/MAVProxy/modules/mavproxy_speech.py
+++ b/MAVProxy/modules/mavproxy_speech.py
@@ -102,13 +102,16 @@ class SpeechModule(mp_module.MPModule):
 
     def cmd_speech(self, args):
         '''speech commands'''
-        usage = "usage: speech <test>"
+        usage = "usage: speech <say>"
         if len(args) < 1:
             print(usage)
             return
 
-        if args[0] == "test":
-            self.say("Testing speech output")
+        if args[0] == "say":
+            if len(args) < 2:
+                print("usage: speech say <text to say>")
+                return
+            self.say(" ".join(args[1::]))
 
 
 def init(mpstate):


### PR DESCRIPTION
This is a pretty simple commit.

It adds the 'say' backend, the default text-to-speech engine on mac.

It also adds a skeleton command line command to test the speech engine.