### PR TITLE
General speech capabilities for MAVLink messages

### DIFF
--- a/MAVProxy/modules/mavproxy_speech.py
+++ b/MAVProxy/modules/mavproxy_speech.py
@@ -10,7 +10,7 @@ class SpeechModule(mp_module.MPModule):
         self.add_command('speech', self.cmd_speech, "text-to-speech", ['<test>'])
 
         self.old_mpstate_say_function = self.mpstate.functions.say
-        self.mpstate.functions.say = self.say
+        self.mpstate.functions.say = self.print_and_say
         try:
             self.settings.set('speech', 1)
         except AttributeError:
@@ -101,12 +101,16 @@ class SpeechModule(mp_module.MPModule):
             if msg.text.startswith("Tuning: "):
                 self.say(msg.text[8:])
 
+    def print_and_say(self, text, priority='important'):
+        self.console.writeln(text)
+        self.say(text, priority)
+
     def say(self, text, priority='important'):
         '''speak some text'''
         ''' http://cvs.freebsoft.org/doc/speechd/ssip.html see 4.3.1 for priorities'''
-        self.console.writeln(text)
         if self.settings.speech and self.say_backend is not None:
             self.say_backend(text, priority=priority)
+
 
     #
     # Command line configuration commands.
@@ -124,6 +128,9 @@ class SpeechModule(mp_module.MPModule):
                 print("usage: speech say <text to say>")
                 return
             self.say(" ".join(args[1::]))
+        else:
+            print(usage)
+            return
 
 
 def init(mpstate):


### PR DESCRIPTION
This PR adds general speech capabilties to MAVProxy's CLI.
Any MAVLink message entry can be announced in multiple ways.

Three types of announcements are supported:
- Periodic (the default)
- Conditional. Announces when value leaves expected range.
- On Change. Announces when a value changes.

Individual announces as well as the entire speech engine can be enabled or disables.
Individual announces can be added on-the-fly or removed.

Configuration happens through the speech CLI command.
`usage: speech <say|list|enable|disable|every|add|remove>`

**Suggested usage:** Add initialization commands to .mavinit.scr

**Example commands:**
    `module load mavproxy_speech`
    `speech add ALTITUDE altitude_relative -r 30 -n "altitude"`
    `speech add VFR_HUD airspeed -r 10 -f %0.0f -s 1.0 -n "airspeed"`


**Known limitations:**
- The current backend is blocking. 
- There are no unit conversions built-it. 
- There's no sense of priority between messages.

**Attribution:**
This work is done under the gracious support of FlightWave, where I'm using these tools during our flight testing.