### PR TITLE
BATTERY: Ensure PX4 compatibility

### DIFF
--- a/MAVProxy/modules/mavproxy_battery.py
+++ b/MAVProxy/modules/mavproxy_battery.py
@@ -44,7 +44,7 @@ class BatteryModule(mp_module.MPModule):
                                                               self.vcell_to_battery_percent(self.per_cell)))
 
     def battery_report(self):
-        batt_mon = int(self.get_mav_param('BATT_MONITOR',0))
+        batt_mon = int(self.get_mav_param('BATT_MONITOR',4)) # Default of 4 ensures PX4 compatibility
 
         #report voltage level only
         battery_string = ''


### PR DESCRIPTION
PX4 autopilots does not have the BATT_MONITOR parameter. These autopilots still report useful battery information! This PR ensures that the console will correctly report battery information when the parameter is not present but battery information is available.