### PR TITLE
Update help of "setspeed" command

### DIFF
--- a/MAVProxy/modules/mavproxy_cmdlong.py
+++ b/MAVProxy/modules/mavproxy_cmdlong.py
@@ -161,7 +161,7 @@ class CmdlongModule(mp_module.MPModule):
     def cmd_do_change_speed(self, args):
         '''speed value'''
         if ( len(args) != 1):
-            print("Usage: speed SPEED_VALUE")
+            print("Usage: setspeed SPEED_VALUE")
             return
 
         if (len(args) == 1):


### PR DESCRIPTION
the command is actually called 'setspeed' instead of 'speed'. The help information is showing 'speed' which might be confusion. I assume this was called 'speed' before and refactored, but the help message wasn't updated?