### PR TITLE
mavproxy_param.py: announce values for correct fetch_one'd parameters

### DIFF
--- a/MAVProxy/modules/mavproxy_param.py
+++ b/MAVProxy/modules/mavproxy_param.py
@@ -14,7 +14,7 @@ class ParamState:
         self.mav_param_set = set()
         self.mav_param_count = 0
         self.param_period = mavutil.periodic_event(1)
-        self.fetch_one = 0
+        self.fetch_one = dict()
         self.mav_param = mav_param
         self.logdir = logdir
         self.vehicle_name = vehicle_name
@@ -38,8 +38,8 @@ class ParamState:
             if m.param_count != -1:
                 self.mav_param_count = m.param_count
             self.mav_param[str(param_id)] = m.param_value
-            if self.fetch_one > 0:
-                self.fetch_one -= 1
+            if param_id in self.fetch_one and self.fetch_one[param_id] > 0:
+                self.fetch_one[param_id] -= 1
                 print("%s = %f" % (param_id, m.param_value))
             if added_new_parameter and len(self.mav_param_set) == m.param_count:
                 print("Received %u parameters" % m.param_count)
@@ -174,7 +174,9 @@ class ParamState:
                 for p in self.mav_param.keys():
                     if fnmatch.fnmatch(p, args[1].upper()):
                         master.param_fetch_one(p)
-                        self.fetch_one += 1
+                        if p not in self.fetch_one:
+                            self.fetch_one[p] = 0
+                        self.fetch_one[p] += 1
                         print("Requested parameter %s" % p)
         elif args[0] == "save":
             if len(args) < 2:


### PR DESCRIPTION
Without this any PARAM_VALUE that comes in is considered a fetch-one
parameter