### PR TITLE
Module Map: fix possible encoding error

### DIFF
--- a/MAVProxy/modules/lib/mp_menu.py
+++ b/MAVProxy/modules/lib/mp_menu.py
@@ -284,7 +284,7 @@ class MPMenuCallFileDialog(object):
             dlg = wx.FileDialog(None, self.title, '', "", self.wildcard, flagsMapped[0]|flagsMapped[1])
         if dlg.ShowModal() != wx.ID_OK:
             return None
-        return dlg.GetPath()
+        return dlg.GetPath().encode('utf8')
 
 class MPMenuCallTextDialog(object):
     '''used to create a value dialog callback'''


### PR DESCRIPTION
prevent encoding path in unicode when using mission load from map GUI
to reproduce the problem : have a computer in french with Ubuntu 16.04.3 LTS
 , launch SITL, use the map GUI to load a mission file from Téléchargements (Downloads in english). It will crash