### PR TITLE
mavproxy_message: send arbitrary MAVLink messages

### DIFF
--- a/MAVProxy/modules/mavproxy_message.py
+++ b/MAVProxy/modules/mavproxy_message.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+'''
+Arbitrary Message Module
+Peter Barker, September 2017
+
+'''
+
+import os
+import os.path
+import sys
+from pymavlink import mavutil
+import errno
+import time
+
+from MAVProxy.modules.lib import mp_module
+from MAVProxy.modules.lib import mp_util
+from MAVProxy.modules.lib import mp_settings
+
+
+class message(mp_module.MPModule):
+    def __init__(self, mpstate):
+        """Initialise module"""
+        super(message, self).__init__(mpstate, "message", "")
+        self.status_callcount = 0
+        self.boredom_interval = 10 # seconds
+        self.last_bored = time.time()
+
+        self.packets_mytarget = 0
+        self.packets_othertarget = 0
+        self.verbose = False
+
+        self.message_settings = mp_settings.MPSettings(
+            [ ('verbose', bool, False),
+          ])
+        self.add_command('message', self.cmd_message, "message module", [])
+
+    def usage(self):
+        '''show help on command line options'''
+        return "Usage: message TYPE ARG..."
+
+    def cmd_message(self, args):
+        if len(args) == 0:
+            print self.usage()
+        else:
+            packettype = args[0]
+            methodname = packettype.lower() + "_send"
+            transformed = [eval(x) for x in args[1:]]
+            try:
+                method = getattr(self.master.mav, methodname)
+            except AttributeError:
+                print("Unable to find %s" % methodname)
+                return
+            method(*transformed)
+
+def init(mpstate):
+    '''initialise module'''
+    return message(mpstate)
+
+
+# STABILIZE> message MISSION_CLEAR_ALL int(1) int(1)
+# STABILIZE> Got MAVLink msg: MISSION_ACK {target_system : 255, target_component : 0, type : 0}


### PR DESCRIPTION
Parameters are eval'd:

STABILIZE> Loaded module message
STABILIZE> message MISSION_CLEAR_ALL int(1) int(1)
STABILIZE> Got MAVLink msg: MISSION_ACK {target_system : 255,
target_component : 0, type : 0}

STABILIZE> message SET_GPS_GLOBAL_ORIGIN int(1) float(2.0) float(3.0) float(4.0)
STABILIZE> < GPS_GLOBAL_ORIGIN {latitude : 2, longitude : 3, altitude : 0}