### PR TITLE
Support specification of XML filepath for parameters

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -1103,6 +1103,11 @@ if __name__ == '__main__':
     # call this early so that logdir is setup based on --aircraft
     (mpstate.status.logdir, logpath_telem, logpath_telem_raw) = log_paths()
 
+    for module in opts.load_module:
+        modlist = module.split(',')
+        for mod in modlist:
+            process_stdin('module load %s' % (mod))
+
     if not opts.setup:
         # some core functionality is in modules
         standard_modules = opts.default_modules.split(',')
@@ -1114,11 +1119,6 @@ if __name__ == '__main__':
 
     if opts.map:
         process_stdin('module load map')
-
-    for module in opts.load_module:
-        modlist = module.split(',')
-        for mod in modlist:
-            process_stdin('module load %s' % (mod))
 
     start_scripts = []
     if 'HOME' in os.environ and not opts.setup:

--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -14,6 +14,7 @@ import traceback
 import select
 import shlex
 import platform
+import json
 
 from MAVProxy.modules.lib import textconsole
 from MAVProxy.modules.lib import rline
@@ -266,7 +267,21 @@ def cmd_watch(args):
     mpstate.status.watch = args[0]
     print("Watching %s" % mpstate.status.watch)
 
-def load_module(modname, quiet=False):
+def generate_kwargs(args):
+    kwargs = {}
+    module_components = args.split(":{", 1)
+    module_name = module_components[0]
+    if (len(module_components) == 2 and module_components[1].endswith("}")):
+        # assume json
+        try:
+            module_args = "{"+module_components[1]
+            kwargs = json.loads(module_args)
+        except ValueError as e:
+            print('Invalid JSON argument: {0} ({1})'.format(module_args,
+                                                           repr(e)))
+    return (module_name, kwargs)
+
+def load_module(modname, quiet=False, **kwargs):
     '''load a module'''
     modpaths = ['MAVProxy.modules.mavproxy_%s' % modname, modname]
     for (m,pm) in mpstate.modules:
@@ -278,11 +293,14 @@ def load_module(modname, quiet=False):
         try:
             m = import_package(modpath)
             reload(m)
-            module = m.init(mpstate)
+            module = m.init(mpstate, **kwargs)
             if isinstance(module, mp_module.MPModule):
                 mpstate.modules.append((module, m))
                 if not quiet:
-                    print("Loaded module %s" % (modname,))
+                    if kwargs:
+                        print("Loaded module %s with kwargs = %s" % (modname, kwargs))
+                    else:
+                        print("Loaded module %s" % (modname,))
                 return True
             else:
                 ex = "%s.init did not return a MPModule instance" % modname
@@ -320,12 +338,17 @@ def cmd_module(args):
         if len(args) < 2:
             print("usage: module load <name>")
             return
-        load_module(args[1])
+        (modname, kwargs) = generate_kwargs(args[1])
+        try:
+            load_module(modname, **kwargs)
+        except TypeError:
+            print("%s module does not support keyword arguments"% modname)
+            return
     elif args[0] == "reload":
         if len(args) < 2:
             print("usage: module reload <name>")
             return
-        modname = args[1]
+        (modname, kwargs) = generate_kwargs(args[1])
         pmodule = None
         for (m,pm) in mpstate.modules:
             if m.name == modname:
@@ -340,8 +363,11 @@ def cmd_module(args):
             except ImportError:
                 clear_zipimport_cache()
                 reload(pmodule)
-            if load_module(modname, quiet=True):
-                print("Reloaded module %s" % modname)
+            try:
+                if load_module(modname, quiet=True, **kwargs):
+                    print("Reloaded module %s" % modname)
+            except TypeError:
+                print("%s module does not support keyword arguments" % modname)
     elif args[0] == "unload":
         if len(args) < 2:
             print("usage: module unload <name>")
@@ -1092,7 +1118,7 @@ if __name__ == '__main__':
     for module in opts.load_module:
         modlist = module.split(',')
         for mod in modlist:
-            process_stdin('module load %s' % mod)
+            process_stdin('module load %s' % (mod))
 
     start_scripts = []
     if 'HOME' in os.environ and not opts.setup:

--- a/MAVProxy/modules/mavproxy_param.py
+++ b/MAVProxy/modules/mavproxy_param.py
@@ -20,6 +20,7 @@ class ParamState:
         self.vehicle_name = vehicle_name
         self.parm_file = parm_file
         self.fetch_set = None
+        self.xml_filepath = None
 
     def handle_mavlink_packet(self, master, m):
         '''handle an incoming mavlink packet'''
@@ -87,14 +88,24 @@ class ParamState:
         except Exception as e:
             print(e)
 
+    def param_use_xml_filepath(self, filepath):
+        self.xml_filepath = filepath
+
     def param_help_tree(self):
         '''return a "help tree", a map between a parameter and its metadata.  May return None if help is not available'''
-        if self.vehicle_name is None:
-            print("Unknown vehicle type")
-            return None
-        path = mp_util.dot_mavproxy("%s.xml" % self.vehicle_name)
+        if self.xml_filepath is not None:
+            print("param: using xml_filepath=%s" % self.xml_filepath)
+            path = self.xml_filepath
+        else:
+            if self.vehicle_name is None:
+                print("Unknown vehicle type")
+                return None
+            path = mp_util.dot_mavproxy("%s.xml" % self.vehicle_name)
+            if not os.path.exists(path):
+                print("Please run 'param download' first (vehicle_name=%s)" % self.vehicle_name)
+                return None
         if not os.path.exists(path):
-            print("Please run 'param download' first (vehicle_name=%s)" % self.vehicle_name)
+            print("Param XML (%s) does not exist" % path)
             return None
         xml = open(path).read()
         from lxml import objectify
@@ -109,6 +120,9 @@ class ParamState:
                 n = p.get('name')
                 htree[n] = p
         return htree
+
+    def param_set_xml_filepath(self, args):
+        self.xml_filepath = args[0]
 
     def param_apropos(self, args):
         '''search parameter help for a keyword, list those parameters'''
@@ -262,6 +276,8 @@ class ParamState:
             self.param_apropos(args[1:])
         elif args[0] == "help":
             self.param_help(args[1:])
+        elif args[0] == "set_xml_filepath":
+            self.param_set_xml_filepath(args[1:])
         elif args[0] == "show":
             if len(args) > 1:
                 pattern = args[1]
@@ -275,18 +291,22 @@ class ParamState:
 
 
 class ParamModule(mp_module.MPModule):
-    def __init__(self, mpstate):
+    def __init__(self, mpstate, **kwargs):
         super(ParamModule, self).__init__(mpstate, "param", "parameter handling", public = True)
         self.pstate = ParamState(self.mav_param, self.logdir, self.vehicle_name, 'mav.parm')
         self.add_command('param', self.cmd_param, "parameter handling",
                          ["<download|status>",
                           "<set|show|fetch|help|apropos> (PARAMETER)",
-                          "<load|save|diff> (FILENAME)"])
+                          "<load|save|diff> (FILENAME)",
+                          "<set_xml_filepath> (FILEPATH)"
+                         ])
         if self.continue_mode and self.logdir != None:
             parmfile = os.path.join(self.logdir, 'mav.parm')
             if os.path.exists(parmfile):
                 mpstate.mav_param.load(parmfile)
                 self.pstate.mav_param_set = set(self.mav_param.keys())
+
+        self.pstate.xml_filepath = kwargs.get("xml-filepath", None)
 
     def mavlink_packet(self, m):
         '''handle an incoming mavlink packet'''
@@ -301,6 +321,6 @@ class ParamModule(mp_module.MPModule):
         '''control parameters'''
         self.pstate.handle_command(self.master, self.mpstate, args)
 
-def init(mpstate):
+def init(mpstate, **kwargs):
     '''initialise module'''
-    return ParamModule(mpstate)
+    return ParamModule(mpstate, **kwargs)


### PR DESCRIPTION
So instead of downloading from the interwebs based on the sort of vehicle we're connecting to, you can directly specify a file to use.

This will be used by an option to `sim_vehicle.py` so your parameters are always fresh.
