### PR TITLE
Add non interactive flag

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -1140,7 +1140,7 @@ if __name__ == '__main__':
     # up on exit
     while (mpstate.status.exit != True):
         try:
-            if (opts.daemon == True or opts.non_interactive == True):
+            if opts.daemon or opts.non_interactive:
                 time.sleep(0.1)
             else:
                 input_loop()

--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -952,6 +952,7 @@ if __name__ == '__main__':
     parser.add_option("--moddebug",  type=int, help="module debug level", default=0)
     parser.add_option("--mission", dest="mission", help="mission name", default=None)
     parser.add_option("--daemon", action='store_true', help="run in daemon mode, do not start interactive shell")
+    parser.add_option("--non-interactive", action='store_true', help="do not start interactive shell")
     parser.add_option("--profile", action='store_true', help="run the Yappi python profiler")
     parser.add_option("--state-basedir", default=None, help="base directory for logs and aircraft directories")
     parser.add_option("--version", action='store_true', help="version information")
@@ -1139,7 +1140,7 @@ if __name__ == '__main__':
     # up on exit
     while (mpstate.status.exit != True):
         try:
-            if opts.daemon:
+            if (opts.daemon == True or opts.non_interactive == True):
                 time.sleep(0.1)
             else:
                 input_loop()

--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -1025,7 +1025,7 @@ if __name__ == '__main__':
         fatalsignals.append(signal.SIGQUIT)
     except Exception:
         pass
-    if opts.daemon: # SIGINT breaks readline parsing - if we are interactive, just let things die
+    if opts.daemon or opts.non_interactive: # SIGINT breaks readline parsing - if we are interactive, just let things die
         fatalsignals.append(signal.SIGINT)
 
     for sig in fatalsignals:


### PR DESCRIPTION
I have added the possibility to run more easily in docker container. The addition of the `--non-interactive` flag will prevent the cli from running, much like the `--daemon` mode, without detaching.

Simple set of changes, seem to work fine for my really minimal use case - your thoughts appreciated here - I'm not experienced with python.

Tested with:
```
mavproxy.py --master=/dev/ttyACM0 --out=udpin:0.0.0.0:14550 --non-interactive --load-module=log,output
```

Thanks :)

