### PR TITLE
Named datalinks

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -723,7 +723,7 @@ def check_link_status():
         mpstate.status.heartbeat_error = True
     for master in mpstate.mav_master:
         if not master.linkerror and (tnow > master.last_message + 5 or master.portdead):
-            say("link %u down" % (master.linknum+1))
+            say("link %s down" % (mp_module.MPModule.link_label(master)))
             master.linkerror = True
 
 def send_heartbeat(master):

--- a/MAVProxy/modules/lib/mp_module.py
+++ b/MAVProxy/modules/lib/mp_module.py
@@ -150,3 +150,11 @@ class MPModule(object):
             prompt = self.settings.vehicle_name + ':' + prompt
         self.mpstate.rl.set_prompt(prompt)
             
+    @staticmethod
+    def link_label(link):
+        '''return a link label as a string'''
+        if hasattr(link, 'label'):
+            label = link.label
+        else:
+            label = str(link.linknum+1)
+        return label

--- a/MAVProxy/modules/lib/rline.py
+++ b/MAVProxy/modules/lib/rline.py
@@ -3,6 +3,7 @@ readline handling for mavproxy
 '''
 
 import sys, glob, os, platform
+import re
 
 rline_mpstate = None
 redisplay = None
@@ -158,7 +159,7 @@ def complete(text, state):
         return last_clist[state]
 
     # split the command so far
-    cmd = readline.get_line_buffer().split()
+    cmd = re.split(" +", readline.get_line_buffer())
 
     if len(cmd) != 0 and cmd[0] in rline_mpstate.completions:
         # we have a completion rule for this command

--- a/MAVProxy/modules/mavproxy_console.py
+++ b/MAVProxy/modules/mavproxy_console.py
@@ -324,7 +324,7 @@ class ConsoleModule(mp_module.MPModule):
                 self.max_link_num = len(self.mpstate.mav_master)
             for m in self.mpstate.mav_master:
                 linkdelay = (self.mpstate.status.highest_msec - m.highest_msec)*1.0e-3
-                linkline = "Link %u " % (m.linknum+1)
+                linkline = "Link %s " % (self.link_label(m))
                 fg = 'dark green'
                 if m.linkerror:
                     linkline += "down"


### PR DESCRIPTION
This PR is based on Samuel's https://github.com/ArduPilot/MAVProxy/pull/394/commits

It:
 - adds a command to change the link attributes
 - corrects an issue in rline
 - adds the labels to tab completion

@SamuelDudley I have a concern about the way we're storing these link attributes.  Because we're throwing them directly into the connection object itself, there's the risk of blatting an existing attribute (e.g. `conn.mav`.  Thoughts?
