### PR TITLE
Upversioned required pymavlink to 2.2.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pymavlink>=1.1.73
+pymavlink>=2.2.8
 pyserial>=3.0

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ on how to use MAVProxy.''',
       # as that breaks the pip install. It seems that pip is not smart enough to
       # use the system versions of these dependencies, so it tries to download and install
       # large numbers of modules like numpy etc which may be already installed
-      install_requires=['pymavlink>=1.1.73',
+      install_requires=['pymavlink>=2.2.8',
                         'pyserial>=3.0'],
       scripts=['MAVProxy/mavproxy.py',
                'MAVProxy/tools/mavflightview.py',


### PR DESCRIPTION
Based on comments in #486 - MAVProxy will crash if it uses any pymavlink older than 2.2.8, so makes sense (and makes the install much smoother) to make this the minimum required pymavlink.