### PR TITLE
A few Windows compatibility fixes

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -1001,8 +1001,15 @@ if __name__ == '__main__':
 
     #version information
     if opts.version:
-        import pkg_resources
-        version = pkg_resources.require("mavproxy")[0].version
+        #pkg_resources doesn't work in the windows exe build, so read the version file
+        try:
+            import pkg_resources
+            version = pkg_resources.require("mavproxy")[0].version
+        except:
+            start_script = os.path.join(os.environ['LOCALAPPDATA'], "MAVProxy", "version.txt")
+            f = open(start_script, 'r')
+            version = f.readline()
+
         print("MAVProxy is a modular ground station using the mavlink protocol")
         print("MAVProxy Version: " + version)
         sys.exit(1)

--- a/MAVProxy/modules/lib/mp_menu.py
+++ b/MAVProxy/modules/lib/mp_menu.py
@@ -284,7 +284,7 @@ class MPMenuCallFileDialog(object):
             dlg = wx.FileDialog(None, self.title, '', "", self.wildcard, flagsMapped[0]|flagsMapped[1])
         if dlg.ShowModal() != wx.ID_OK:
             return None
-        return dlg.GetPath().encode('utf8')
+        return "\"" + dlg.GetPath().encode('utf8') + "\""
 
 class MPMenuCallTextDialog(object):
     '''used to create a value dialog callback'''

--- a/MAVProxy/modules/mavproxy_fence.py
+++ b/MAVProxy/modules/mavproxy_fence.py
@@ -200,7 +200,7 @@ class FenceModule(mp_module.MPModule):
         try:
             self.fenceloader.target_system = self.target_system
             self.fenceloader.target_component = self.target_component
-            self.fenceloader.load(filename)
+            self.fenceloader.load(filename.strip('"'))
         except Exception as msg:
             print("Unable to load %s - %s" % (filename, msg))
             return
@@ -282,7 +282,7 @@ class FenceModule(mp_module.MPModule):
 
         if filename is not None:
             try:
-                self.fenceloader.save(filename)
+                self.fenceloader.save(filename.strip('"'))
             except Exception as msg:
                 print("Unable to save %s - %s" % (filename, msg))
                 return
@@ -293,7 +293,7 @@ class FenceModule(mp_module.MPModule):
                 self.console.writeln("lat=%f lng=%f" % (p.lat, p.lng))
         if self.status.logdir != None:
             fencetxt = os.path.join(self.status.logdir, 'fence.txt')
-            self.fenceloader.save(fencetxt)
+            self.fenceloader.save(fencetxt.strip('"'))
             print("Saved fence to %s" % fencetxt)
         self.have_list = True
 

--- a/MAVProxy/modules/mavproxy_kmlread.py
+++ b/MAVProxy/modules/mavproxy_kmlread.py
@@ -245,8 +245,7 @@ class KmlReadModule(mp_module.MPModule):
     def readkmz(self, filename):
         '''reads in a kmz file and returns xml nodes'''
         #Strip quotation marks if neccessary
-        if filename.startswith('"') and filename.endswith('"'):
-            filename = filename[1:-1]
+        filename.strip('"')
         #Open the zip file (as applicable)    
         if filename[-4:] == '.kml':
             fo = open(filename, "r")

--- a/MAVProxy/modules/mavproxy_rally.py
+++ b/MAVProxy/modules/mavproxy_rally.py
@@ -210,7 +210,7 @@ class RallyModule(mp_module.MPModule):
                 return
 
             try:
-                self.rallyloader.load(args[1])
+                self.rallyloader.load(args[1].strip('"'))
             except Exception as msg:
                 print("Unable to load %s - %s" % (args[1], msg))
                 return
@@ -225,7 +225,7 @@ class RallyModule(mp_module.MPModule):
                 print("Usage: rally save filename")
                 return
 
-            self.rallyloader.save(args[1])
+            self.rallyloader.save(args[1].strip('"'))
 
             print("Saved rally file %s" % args[1])
 

--- a/MAVProxy/modules/mavproxy_wp.py
+++ b/MAVProxy/modules/mavproxy_wp.py
@@ -202,7 +202,8 @@ class WPModule(mp_module.MPModule):
         self.wploader.target_system = self.target_system
         self.wploader.target_component = self.target_component
         try:
-            self.wploader.load(filename)
+            #need to remove the leading and trailing quotes in filename
+            self.wploader.load(filename.strip('"'))
         except Exception as msg:
             print("Unable to load %s - %s" % (filename, msg))
             return
@@ -244,7 +245,8 @@ class WPModule(mp_module.MPModule):
     def save_waypoints(self, filename):
         '''save waypoints to a file'''
         try:
-            self.wploader.save(filename)
+            #need to remove the leading and trailing quotes in filename
+            self.wploader.save(filename.strip('"'))
         except Exception as msg:
             print("Failed to save %s - %s" % (filename, msg))
             return

--- a/MAVProxy/tools/MAVExplorer.py
+++ b/MAVProxy/tools/MAVExplorer.py
@@ -438,7 +438,7 @@ def cmd_loadfile(args):
     if not os.path.exists(fileargs):
         print("Error loading file ", fileargs);
         return
-    loadfile(fileargs)
+    loadfile(fileargs.strip('"'))
 
 def loadfile(args):
     '''load a log file (path given by arg)'''


### PR DESCRIPTION
- Fixed the ``--version`` commandline argument as reported in https://discuss.ardupilot.org/t/mavproxy-version-check-error/29348/6
- If there's spaces in a file path, MAVProxy/Explorer can't load or save the file. Fixed by adding (optional) quotations around the path returned by ``MPMenuCallFileDialog``