### PR TITLE
mavproxy_log: construct bytearray rather than string from downloaded data

### DIFF
--- a/MAVProxy/modules/mavproxy_log.py
+++ b/MAVProxy/modules/mavproxy_log.py
@@ -53,8 +53,7 @@ class LogModule(mp_module.MPModule):
             self.download_file.seek(m.ofs)
             self.download_ofs = m.ofs
         if m.count != 0:
-            data = m.data[:m.count]
-            s = ''.join(str(chr(x)) for x in data)
+            s = bytearray(m.data[:m.count])
             self.download_file.write(s)
             self.download_set.add(m.ofs // 90)
             self.download_ofs += m.count


### PR DESCRIPTION

master: 286kB/s 255kB/s 270kB/s 276kB/s 264kB/s 245kB/s 265kB/s

bytearray(...)
300kB/s 288kB/s 314kB/s 330kB/s 332kB/s 308kB/s