### PR TITLE
"arm check foo" changes

### DIFF
--- a/MAVProxy/modules/mavproxy_arm.py
+++ b/MAVProxy/modules/mavproxy_arm.py
@@ -6,21 +6,41 @@ import time, os
 from MAVProxy.modules.lib import mp_module
 from pymavlink import mavutil
 
+# note that the number of bits here is contrained by the float
+# transport mechanism.  25 bits is the limit.  Given the transport
+# limit, if all bits are set, or all but the lowest bit it set, it is
+# reasonable to set the mask to "all" for simplicity.
 arming_masks = {
-    "all"     : 0x0001,
-    "baro"    : 0x0002,
-    "compass" : 0x0004,
-    "gps"     : 0x0008,
-    "ins"     : 0x0010,
-    "params"  : 0x0020,
-    "rc"      : 0x0040,
-    "voltage" : 0x0080,
-    "battery" : 0x0100,
-    "airspeed": 0x0200,
-    "logging" : 0x0400,
-    "switch"  : 0x0800,
-    "gps_config": 0x1000,
-    }
+    "all"     :    1 <<  0,
+    "baro"    :    1 <<  1,
+    "compass" :    1 <<  2,
+    "gps"     :    1 <<  3,
+    "ins"     :    1 <<  4,
+    "params"  :    1 <<  5,
+    "rc"      :    1 <<  6,
+    "voltage" :    1 <<  7,
+    "battery" :    1 <<  8,
+    "airspeed":    1 <<  9,
+    "logging" :    1 << 10,
+    "switch"  :    1 << 11,
+    "gps_config":  1 << 12,
+    "system":      1 << 13,
+    "mission":     1 << 14,
+    "rangefinder": 1 << 15,
+    "unknown16":   1 << 16,
+    "unknown17":   1 << 17,
+    "unknown18":   1 << 18,
+    "unknown19":   1 << 19,
+    "unknown20":   1 << 20,
+    "unknown21":   1 << 21,
+    "unknown22":   1 << 22,
+    "unknown23":   1 << 23,
+    "unknown24":   1 << 24,
+}
+# on the assumption we may not always know about all arming bits, we
+# use this "full" mask to transition from using 0x1 (all checks
+# enabled) to having checks disabled by turning its bit off.
+full_arming_mask = 0b1111111111111111111111110
 
 class ArmModule(mp_module.MPModule):
     def __init__(self, mpstate):
@@ -41,7 +61,7 @@ class ArmModule(mp_module.MPModule):
 
     def cmd_arm(self, args):
         '''arm commands'''
-        usage = "usage: arm <check|uncheck|list|throttle|safetyon|safetyoff|safetystatus>"
+        usage = "usage: arm <check|uncheck|list|throttle|safetyon|safetyoff|safetystatus|bits>"
 
         if len(args) <= 0:
             print(usage)
@@ -52,16 +72,17 @@ class ArmModule(mp_module.MPModule):
                 print("usage: arm check " + self.checkables())
                 return
 
-            arming_mask = int(self.get_mav_param("ARMING_CHECK",0))
+            arming_mask = int(self.get_mav_param("ARMING_CHECK"))
             name = args[1].lower()
             if name == 'all':
-                for name in arming_masks.keys():
-                    arming_mask |= arming_masks[name]
+                arming_mask = 1
             elif name in arming_masks:
                 arming_mask |= arming_masks[name]
             else:
                 print("unrecognized arm check:", name)
                 return
+            if (arming_mask & ~0x1) == full_arming_mask:
+                arming_mask = 0x1
             self.param_set("ARMING_CHECK", arming_mask)
             return
 
@@ -70,11 +91,13 @@ class ArmModule(mp_module.MPModule):
                 print("usage: arm uncheck " + self.checkables())
                 return
 
-            arming_mask = int(self.get_mav_param("ARMING_CHECK",0))
+            arming_mask = int(self.get_mav_param("ARMING_CHECK"))
             name = args[1].lower()
             if name == 'all':
                 arming_mask = 0
             elif name in arming_masks:
+                if arming_mask == arming_masks["all"]:
+                    arming_mask = full_arming_mask
                 arming_mask &= ~arming_masks[name]
             else:
                 print("unrecognized arm check:", args[1])
@@ -84,12 +107,17 @@ class ArmModule(mp_module.MPModule):
             return
 
         if args[0] == "list":
-            arming_mask = int(self.get_mav_param("ARMING_CHECK",0))
+            arming_mask = int(self.get_mav_param("ARMING_CHECK"))
             if arming_mask == 0:
                 print("NONE")
-            for name in arming_masks.keys():
+            for name in sorted(arming_masks, key=lambda(x) : arming_masks[x]):
                 if arming_masks[name] & arming_mask:
                     print(name)
+            return
+
+        if args[0] == "bits":
+            for mask in sorted(arming_masks, key=lambda(x) : arming_masks[x]):
+                print("%s" % mask)
             return
 
         if args[0] == "throttle":
@@ -156,7 +184,7 @@ class ArmModule(mp_module.MPModule):
 
     def all_checks_enabled(self):
         ''' returns true if the UAV is skipping any arming checks'''
-        arming_mask = int(self.get_mav_param("ARMING_CHECK",0))
+        arming_mask = int(self.get_mav_param("ARMING_CHECK"))
         if arming_mask == 1:
             return True
         for bit in arming_masks.values():


### PR DESCRIPTION
These changes disambiguate some "arm check" uses.

Now:
`arm check all` - sets ARMING_CHECK to 1 (rather than bits individually)
`arm uncheck all` - sets ARMING_CHECK to 0
`arm uncheck LOGGING` - IF ARMING_CHECK was "1", sets it to zero then sets all bits we know about (https://github.com/ArduPilot/MAVProxy/blob/master/MAVProxy/modules/mavproxy_arm.py#L9), *then* sets LOGGING bit to zero.

In the third case, I'm wondering if we should set the first 28 bits or so to 1 instead (rather than just the bits we know about), so newer arming checks aren't disabled by `arm uncheck FOO`.
