### PR TITLE
fix corrupted tlog files from line ending mangling on Windows

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -671,9 +671,9 @@ def log_paths():
 def open_telemetry_logs(logpath_telem, logpath_telem_raw):
     '''open log files'''
     if opts.append_log or opts.continue_mode:
-        mode = 'a'
+        mode = 'ab'
     else:
-        mode = 'w'
+        mode = 'wb'
 
     try:
         mpstate.logfile = open(logpath_telem, mode=mode)


### PR DESCRIPTION
@peterbarker 

This fixes the insanity with the tlog files for windows.  Linux obviously didn't exhibit the problem.

Dunno if there are other cases.  The log module looks like it does it right (I was initially confused with the lods module vs tlog writing in the mavproxy.py).

#535 