### PR TITLE
CI - Added Appveyor for building Windows installers

### DIFF
--- a/MAVProxy/modules/mavproxy_map/mp_tile.py
+++ b/MAVProxy/modules/mavproxy_map/mp_tile.py
@@ -551,9 +551,13 @@ def mp_icon(filename):
 		stream = pkg_resources.resource_stream(name, "data/%s" % filename).read()
 		raw = np.fromstring(stream, dtype=np.uint8)
 	except Exception:
-		stream = open(os.path.join(__file__, 'data', filename)).read()
-		raw = np.fromstring(stream, dtype=np.uint8)
-		
+		try:
+			stream = open(os.path.join(__file__, 'data', filename)).read()
+			raw = np.fromstring(stream, dtype=np.uint8)
+		except Exception:
+			#we're in a Windows exe, where pkg_resources doesn't work
+			import pkgutil
+			raw = pkgutil.get_data( 'MAVProxy', 'modules//mavproxy_map//data//' + filename)
 	img = cv2.imdecode(raw, cv2.IMREAD_COLOR)
 	return img
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,102 @@
+environment:
+  global:
+    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+    # /E:ON and /V:ON options are not enabled in the batch script intepreter
+    # See: http://stackoverflow.com/a/13751649/163740
+    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
+
+  matrix:
+    # Pre-installed Python versions, which Appveyor may upgrade to
+    # a later point release.
+    # See: https://www.appveyor.com/docs/installed-software#python
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.x" # currently 2.7.15
+      PYTHON_ARCH: "32"
+
+
+install:
+  # If there is a newer build queued for the same PR, cancel this one.
+  # The AppVeyor 'rollout builds' option is supposed to serve the same
+  # purpose but it is problematic because it tends to cancel builds pushed
+  # directly to master instead of just PR builds (or the converse).
+  # credits: JuliaLang developers.
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+          throw "There are newer queued builds for this pull request, failing early." }
+
+
+  # Check that we have the expected version and architecture for Python
+  - "python --version"
+  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+  
+  # Install the build dependencies of the project. If some dependencies contain
+  # compiled extensions and are not provided as pre-built wheel packages,
+  # pip will build them from source using the MSVC compiler matching the
+  # target Python version and architecture
+  - "pip install -U pywin32 lxml pymavlink numpy matplotlib pyserial opencv-python pyreadline PyYAML Pygame Pillow"
+  - "pip install pyinstaller setuptools packaging"
+  
+  #We're using Inno Setup to build an installer
+  - cinst -y InnoSetup
+  
+  #Wxpython3
+  - ps: |
+      $InstallersFolder = $Env:APPVEYOR_BUILD_FOLDER + "\_build\installers\"
+      New-Item $InstallersFolder -type directory | Out-Null
+      $WXInstaller = $InstallersFolder + "wxPython3.0-win32-3.0.2.0-py27.exe"
+      $WXURL = "http://downloads.sourceforge.net/wxpython/wxPython3.0-win32-3.0.2.0-py27.exe"
+      Start-FileDownload $WXURL -Timeout 60000 -FileName $WXInstaller
+      "    Installing..."
+      Start-Process $WXInstaller -Arg "/VERYSILENT /SUPPRESSMSGBOXES" -NoNewWindow -Wait
+      "    Done."
+  
+  #Debug for getting a list of what packages/version were used for this build
+  - "pip list"
+  
+build_script:
+  # Build the compiled extension
+  - "python setup.py build install"
+  
+
+
+test_script:
+  # Run the project tests and store results in .xml log
+
+      
+after_test:
+  # If tests are successful, create binary packages for the project.
+  #run pyinstaller
+  - "cd .\\MAVProxy"
+  - "copy ..\\windows\\mavproxy.spec"
+  - "%PYTHON%\\Scripts\\pyinstaller --clean mavproxy.spec"
+  - "del mavproxy.spec"
+  - "cd ..\\"
+  
+  #create version txt file
+  - "cd  .\\windows\\"
+  - "for /f \"tokens=*\" %%a in ( \'python returnVersion.py\' ) do ( set VERSION=%%a )"
+  - "@echo off"
+  - "@echo %VERSION%> version.txt"
+  - "@echo on"
+  - "cd ..\\"
+  
+  #run setup
+  - "cd  .\\windows\\"
+  - "ISCC.exe /dMyAppVersion=%VERSION% mavproxy.iss"
+  - "cd ..\\"
+  
+
+artifacts:
+  # Archive the generated packages in the ci.appveyor.com build report.
+  - path: MAVProxy\dist\
+    name: WindowsCompiledFiles
+  - path: windows\Output\
+    name: WindowsInstaller
+
+#on_success:
+#  - TODO: upload the content of dist/*.whl to a public wheelhouse
+#
+
+on_finish:
+  # Upload test results to AppVeyor

--- a/windows/MAVProxyWinBuild.bat
+++ b/windows/MAVProxyWinBuild.bat
@@ -3,8 +3,6 @@ rem This assumes Python is installed in C:\Python27
 rem   If it is not, change the PYTHON_LOCATION environment variable accordingly
 rem This assumes InnoSetup is installed in C:\Program Files (x86)\Inno Setup 5
 rem   If it is not, change the INNOSETUP environment variable accordingly
-rem This requires Pyinstaller==2.1, setuptools==19.2 and packaging==14.2
-rem and lxml >= 3.7.2
 SETLOCAL enableextensions
 
 if "%PYTHON_LOCATION%" == "" (set "PYTHON_LOCATION=C:\Python27")
@@ -20,6 +18,7 @@ for /f "tokens=*" %%a in (
 rem -----build the changelog-----
 "%PYTHON_LOCATION%\python" createChangelog.py
 
+ 
 rem -----Upgrade pymavlink if needed-----
 if exist "..\..\pymavlink" (
  rem Rebuild and use pymavlink from pymavlink sources if available
@@ -42,7 +41,7 @@ cd ..\
 "%PYTHON_LOCATION%\python" setup.py clean build install
 cd .\MAVProxy
 copy ..\windows\mavproxy.spec
-"%PYTHON_LOCATION%\Scripts\pyinstaller" --clean mavproxy.spec
+"%PYTHON_LOCATION%\Scripts\pyinstaller" -y --clean mavproxy.spec
 del mavproxy.spec
 
 rem -----Create version Info-----

--- a/windows/mavproxy.iss
+++ b/windows/mavproxy.iss
@@ -41,6 +41,7 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 [Files]
 Source: "..\MAVProxy\dist\mavproxy\mavproxy.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\MAVProxy\dist\mavproxy\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "..\MAVProxy\dist\MAVExplorer\MAVExplorer.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\MAVProxy\dist\MAVExplorer\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 Source: "..\windows\mavinit.scr"; DestDir: "{localappdata}\MAVProxy"; Flags: ignoreversion
@@ -55,7 +56,6 @@ Name: "{commondesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: 
 Name: "{group}\Documentation"; Filename: "http://ardupilot.github.io/MAVProxy/"
 Name: "{group}\Startup Examples"; Filename: "{app}\Examples"
 Name: "{group}\Ardupilot MAVProxy Forum"; Filename: "http://discuss.ardupilot.org/c/ground-control-software/mavproxy"
-Name: "{group}\Download Updates"; Filename: "http://firmware.ap.ardupilot.org/Tools/MAVProxy/"
 Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Parameters: "--map --console --load-module=graph"
 
 [Run]

--- a/windows/mavproxy.spec
+++ b/windows/mavproxy.spec
@@ -1,63 +1,38 @@
 # -*- mode: python -*-
 # spec file for pyinstaller to build mavproxy for windows
+from PyInstaller.utils.hooks import collect_submodules, collect_data_files
+
 MAVProxyAny = Analysis(['mavproxy.py'],
              pathex=[os.path.abspath('.')],
              # for some unknown reason these hidden imports don't pull in
              # all the needed pieces, so we also import them in mavproxy.py
              hiddenimports=['cv2', 'wx', 'pylab', 
                             'numpy', 'dateutil', 'matplotlib',
-                            'pymavlink.mavwp', 'pymavlink.mavutil', 
-                            'pyreadline', 'pymavlink.dialects.v20.ardupilotmega',
-                            'pymavlink.dialects.v10.ardupilotmega',
-                            'pymavlink.dialects.v20.common', 'pymavlink.dialects.v10.common',
-                            'pymavlink.dialects.v20.ASLUAV', 'pymavlink.dialects.v10.ASLUAV',
-                            'pymavlink.dialects.v20.autoquad', 'pymavlink.dialects.v10.autoquad',
-                            'pymavlink.dialects.v20.matrixpilot', 'pymavlink.dialects.v10.matrixpilot',
-                            'pymavlink.dialects.v20.minimal', 'pymavlink.dialects.v10.minimal',
-                            'pymavlink.dialects.v20.paparazzi', 'pymavlink.dialects.v10.paparazzi',
-                            'pymavlink.dialects.v20.slugs', 'pymavlink.dialects.v10.slugs',
-                            'pymavlink.dialects.v20.standard', 'pymavlink.dialects.v10.standard',
-                            'pymavlink.dialects.v20.ualberta', 'pymavlink.dialects.v10.ualberta',
-                            'pymavlink.dialects.v20.uAvionix', 'pymavlink.dialects.v10.uAvionix', 
-                            'HTMLParser', 'wx.grid', 'pygame', 'pygame.base',
-                            'pygame.constants', 'pygame.version', 'pygame.rect', 'pygame.compat', 
-                            'pygame.rwobject', 'pygame.surflock', 'pygame.color', 'pygame.colordict', 
-                            'pygame.cdrom', 'pygame.cursors', 'pygame.display', 'pygame.draw', 
-                            'pygame.event', 'pygame.image', 'pygame.joystick', 'pygame.key', 
-                            'pygame.mouse', 'pygame.sprite', 'pygame.threads', 'pygame.time', 
-                            'pygame.transform', 'pygame.surface', 'pygame.bufferproxy', 'wx._grid',
+                            'HTMLParser', 'wx.grid', 'wx._grid',
                             'wx.lib.agw.genericmessagedialog', 'wx.lib.wordwrap', 'wx.lib.buttons',
                             'wx.lib.embeddedimage', 'wx.lib.imageutils', 'wx.lib.agw.aquabutton', 
-                            'wx.lib.agw.gradientbutton', 'wxversion', 'UserList', 'UserString', 'yaml', 'yaml.error', 'yaml.tokens', 'yaml.events', 'yaml.nodes', 'yaml.loader', 'yaml.dumper', 'yaml.reader', 'yaml.scanner', 'yaml.parser', 'yaml.composer', 'yaml.constructor', 'yaml.resolver', 'yaml.emitter', 'yaml.serializer', 'yaml.representer',
-                            'six','packaging', 'packaging.version', 'packaging.specifiers'],
-
+                            'wx.lib.agw.gradientbutton', 'wxversion', 'UserList', 'UserString',
+                            'six','packaging', 'packaging.version', 'packaging.specifiers'] + collect_submodules('MAVProxy.modules') + 
+                            collect_submodules('pymavlink') + collect_submodules('yaml') + collect_submodules('pygame'),
+             datas= [ ('modules\\mavproxy_map\\data\\*.*', 'MAVProxy\\modules\\mavproxy_map\\data' ) ],
              hookspath=None,
-             runtime_hooks=None)
+             runtime_hooks=None,
+             excludes= ['sphinx', 'docutils', 'alabaster'])
 MAVExpAny = Analysis(['.\\tools\\MAVExplorer.py'],
              pathex=[os.path.abspath('.')],
              # for some unknown reason these hidden imports don't pull in
              # all the needed pieces, so we also import them in mavproxy.py
              hiddenimports=['cv2', 'wx', 'pylab', 
                             'numpy', 'dateutil', 'matplotlib',
-                            'pymavlink.mavwp', 'pymavlink.mavutil', 'pymavlink.dialects.v20.ardupilotmega',
-                            'pymavlink.dialects.v10.ardupilotmega',
-                            'pymavlink.dialects.v20.common', 'pymavlink.dialects.v10.common',
-                            'pymavlink.dialects.v20.ASLUAV', 'pymavlink.dialects.v10.ASLUAV',
-                            'pymavlink.dialects.v20.autoquad', 'pymavlink.dialects.v10.autoquad',
-                            'pymavlink.dialects.v20.matrixpilot', 'pymavlink.dialects.v10.matrixpilot',
-                            'pymavlink.dialects.v20.minimal', 'pymavlink.dialects.v10.minimal',
-                            'pymavlink.dialects.v20.paparazzi', 'pymavlink.dialects.v10.paparazzi',
-                            'pymavlink.dialects.v20.slugs', 'pymavlink.dialects.v10.slugs',
-                            'pymavlink.dialects.v20.standard', 'pymavlink.dialects.v10.standard',
-                            'pymavlink.dialects.v20.ualberta', 'pymavlink.dialects.v10.ualberta',
-                            'pymavlink.dialects.v20.uAvionix', 'pymavlink.dialects.v10.uAvionix', 
                             'pyreadline', 'HTMLParser', 'wx.grid', 'wx._grid',
                             'wx.lib.agw.genericmessagedialog', 'wx.lib.wordwrap', 'wx.lib.buttons',
                             'wx.lib.embeddedimage', 'wx.lib.imageutils', 'wx.lib.agw.aquabutton', 
-                            'wx.lib.agw.gradientbutton', 'FileDialog', 'Dialog', 'UserList', 'UserString'],
+                            'wx.lib.agw.gradientbutton', 'FileDialog', 'Dialog', 'UserList', 'UserString'] + collect_submodules('pymavlink'),
+             datas= [ ('tools\\graphs\\*.*', 'MAVProxy\\tools\\graphs' ) ],
              hookspath=None,
-             runtime_hooks=None)
-MERGE( (MAVProxyAny, 'mavproxy', 'mavproxy'), (MAVExpAny, 'MAVExplorer', 'MAVExplorer') )
+             runtime_hooks=None,
+             excludes= ['sphinx', 'docutils', 'alabaster'])
+# MERGE( (MAVProxyAny, 'mavproxy', 'mavproxy'), (MAVExpAny, 'MAVExplorer', 'MAVExplorer') )
 MAVProxy_pyz = PYZ(MAVProxyAny.pure)
 MAVProxy_exe = EXE(MAVProxy_pyz,
           MAVProxyAny.scripts,


### PR DESCRIPTION
A couple of things in here:
-Appveyor config file for building Windows installers
-Now using Pyinstaller 3.x for building exe's
-Small updates in MAVProxy/MAVExplorere to support the above

Note this requires an admin to enable Appveyor for this MAVProxy repo.

For reference, see https://ci.appveyor.com/project/stephendade/mavproxy for an example of the outputs.