### PR TITLE
Layout: Fixed bug in Windows OS

### DIFF
--- a/MAVProxy/modules/lib/win_layout.py
+++ b/MAVProxy/modules/lib/win_layout.py
@@ -77,7 +77,7 @@ def layout_filename(fallback):
                 os.mkdir(dirname)
             except Exception:
                 pass
-    elif 'LOCALAPPDATA' in os.environ and not opts.setup:
+    elif 'LOCALAPPDATA' in os.environ:
         dirname = os.path.join(os.environ['LOCALAPPDATA'], "MAVProxy")
     else:
         return None


### PR DESCRIPTION
As per https://discuss.ardupilot.org/t/automatic-layout-of-windows-in-mavproxy/34435/10?u=stephendade, the automatic window layout under the Windows OS is broken. This patch fixes that.