### PR TITLE
modules: cmdlong velocity mask fix

### DIFF
--- a/MAVProxy/modules/mavproxy_cmdlong.py
+++ b/MAVProxy/modules/mavproxy_cmdlong.py
@@ -222,7 +222,7 @@ class CmdlongModule(mp_module.MPModule):
                                       1,  # target system
                                       0,  # target component
                                       8,  # coordinate frame MAV_FRAME_BODY_NED
-                                      455,      # type mask (vel only)
+                                      4039,     # type mask (vel only)
                                       0, 0, 0,  # position x,y,z
                                       x_mps, y_mps, z_mps,  # velocity x,y,z
                                       0, 0, 0,  # accel x,y,z


### PR DESCRIPTION
This PR fixes a small problem with the mavproxy_cmdlong module's velocity command.

this command sends the [SET_POSITION_TARGET_LOCAL_NED](https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_LOCAL_NED ) message but it was not setting some of the [ignore bits](https://mavlink.io/en/messages/common.html#POSITION_TARGET_TYPEMASK) correctly.

In particular it was missing:

- FORCE_SET = 512
- YAW_IGNORE = 1024
- YAW_RATE_IGNORE = 2048

So to add these we increase 455 to 4039.

This has been tested in SITL and it work