### PR TITLE
Joystick: support Logicool Gamepad F310

### DIFF
--- a/MAVProxy/modules/mavproxy_joystick/joysticks/logicool-f310.yml
+++ b/MAVProxy/modules/mavproxy_joystick/joysticks/logicool-f310.yml
@@ -1,0 +1,53 @@
+description: >
+  Support for the Logicool F310 joystick.
+match:
+  - 'Logicool Dual Action'
+controls:
+  - channel: 1
+    type: axis
+    id: 2
+  - channel: 2
+    type: axis
+    id: 1
+  - channel: 3
+    type: axis
+    id: 3
+    invert: true
+  - channel: 4
+    type: axis
+    id: 0
+
+  # This maps the A, B, X, and Y buttons onto channel 5, providing
+  # a convenient way to select between four different flight modes.
+  # The PWM values here are for flight modes 1-4.
+  - channel: 5
+    type: multibutton
+    buttons:
+      - id: 0
+        value: 1200
+      - id: 1
+        value: 1300
+      - id: 2
+        value: 1400
+      - id: 3
+        value: 1500
+      - id: 5
+        value: 1700
+      - id: 4
+        value: 1800
+
+  # A hat operates like a toggle switch.  When an axis goes positive,
+  # it sets the `high` value, and when an axis goes negative it sets the
+  # `low` value.  When the hat is centered it does not change the
+  # current channel value. This configuration maps the hat X axis to
+  # channel 7 and the Y axis to channel 8; these are useful along with
+  # the CH7_OPT and CH8_OPT APM parameters.
+  - channel: 7
+    type: hat
+    id: 0
+    axis: x
+  - channel: 8
+    type: hat
+    id: 0
+    axis: y
+


### PR DESCRIPTION
It won't detect my gamepad(Logicool Gamepad F310) bought in Japan. This PR is may useful for Japanese users.