### PR TITLE
setup: Add extras_require configuration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,10 @@ on how to use MAVProxy.''',
                 'MAVProxy.modules.lib.MacOS',
                 'MAVProxy.modules.lib.optparse_gui'],
       install_requires=requirements,
+      extras_require={
+        # restserver module
+        'server': ['flask'],
+      },
       scripts=['MAVProxy/mavproxy.py',
                'MAVProxy/tools/mavflightview.py',
                'MAVProxy/tools/MAVExplorer.py',


### PR DESCRIPTION
extras_require allow users to install mavproxy with some extra functionalities:
Like: `pip install mavproxy[server] --user` to install flask and everything necessary for server functionality 

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>