### PR TITLE
MAVExplorer.py: use 'sorted()' instead of '.sort()' for Python3 compatibility

### DIFF
--- a/MAVProxy/tools/MAVExplorer.py
+++ b/MAVProxy/tools/MAVExplorer.py
@@ -542,8 +542,7 @@ def process_stdin(line):
     cmd = args[0]
     if cmd == 'help':
         k = command_map.keys()
-        k.sort()
-        for cmd in k:
+        for cmd in sorted(k):
             (fn, help) = command_map[cmd]
             print("%-15s : %s" % (cmd, help))
         return


### PR DESCRIPTION
Without this, I get an error when I type "help" in the console.