### PR TITLE
mavproxy_link: correct output of 'linenoise'

### DIFF
--- a/MAVProxy/modules/mavproxy_link.py
+++ b/MAVProxy/modules/mavproxy_link.py
@@ -377,7 +377,10 @@ class LinkModule(mp_module.MPModule):
             # don't process messages not from our target
             if m.get_type() == "BAD_DATA":
                 if self.mpstate.settings.shownoise and mavutil.all_printable(m.data):
-                    self.mpstate.console.write(str(m.data), bg='red')
+                    out = m.data
+                    if type(m.data) == bytearray:
+                        out = m.data.decode('ascii')
+                    self.mpstate.console.write(out, bg='red')
             return
 
         if self.settings.target_system != 0 and master.target_system != self.settings.target_system:


### PR DESCRIPTION
On python3 we're getting:

bytearray(b'\r')bytearray(b'\n')bytearray(b'\r')bytearray(b'\n')bytearray(b'I')bytearray(b'n')bytearray(b'i')bytearray(b't')bytearray(b' ')bytearray(b'A')bytearray(b'n')bytearray(b't')bytearray(b'e')bytearray(b'n')

Instead of "Init anten", which causes the autotest suite to not work