### PR TITLE
Fix mision editor closing issues

### DIFF
--- a/MAVProxy/modules/mavproxy_misseditor/__init__.py
+++ b/MAVProxy/modules/mavproxy_misseditor/__init__.py
@@ -24,6 +24,8 @@ class MissionEditorModule(mp_module.MPModule):
 
     def idle_task(self):
         self.me_main.idle_task()
+        if self.me_main.needs_unloading:
+            self.needs_unloading = True
 
     def mavlink_packet(self, m):
         self.me_main.mavlink_packet(m)

--- a/MAVProxy/modules/mavproxy_misseditor/mission_editor.py
+++ b/MAVProxy/modules/mavproxy_misseditor/mission_editor.py
@@ -181,7 +181,7 @@ class MissionEditorMain(object):
         self.mavlink_message_queue = multiproc.Queue()
         self.mavlink_message_queue_handler = threading.Thread(target=self.mavlink_message_queue_handler)
         self.mavlink_message_queue_handler.start()
-
+        self.needs_unloading = False
 
     def mavlink_message_queue_handler(self):
         while not self.time_to_quit:


### PR DESCRIPTION
Done incorrectly the mission editor stuffs your  command-line input to MAVProxy (infinite loop in unload, separate PR to fix that up)

Testing for this is:

module load misseditor # window appears
module unload misseditor # window disappears
module load misseditor # window appears again
<click close on that window>
module load misseditor # window appears yet again

@Akshath-Singhal several of these fixes are applicable to the parameter editor
