### PR TITLE
mavproxy.py: limit the time we will wait for module unload method to …

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -391,7 +391,13 @@ def unload_module(modname):
     for (m,pm) in mpstate.modules:
         if m.name == modname:
             if hasattr(m, 'unload'):
-                m.unload()
+                t = threading.Thread(target=lambda : m.unload(), name="unload %s" % modname)
+                t.start()
+                t.join(timeout=5)
+                if t.isAlive():
+                    print("unload on module %s did not complete" % m.name)
+                    mpstate.modules.remove((m,pm))
+                    return False
             mpstate.modules.remove((m,pm))
             print("Unloaded module %s" % modname)
             return True


### PR DESCRIPTION
…complete

In the case that a module's unload method does not return we completely
lose MAVProxy's text input, which is not great.
