### PR TITLE
misseditor: call console on correct object

### DIFF
--- a/MAVProxy/modules/mavproxy_misseditor/mission_editor.py
+++ b/MAVProxy/modules/mavproxy_misseditor/mission_editor.py
@@ -231,7 +231,7 @@ class MissionEditorMain(object):
             if (self.num_wps_expected == 0):
                 #I haven't asked for WPs, or these messages are duplicates
                 #of msgs I've already received.
-                self.console.error("No waypoint load started (from Editor).")
+                self.mpstate.console.error("No waypoint load started (from Editor).")
             #I only clear the mission in the Editor if this was a read event
             elif (self.num_wps_expected == -1):
                 self.gui_event_queue.put(MissionEditorEvent(
@@ -245,7 +245,7 @@ class MissionEditorMain(object):
             #write has been sent by the mission editor:
             elif (self.num_wps_expected > 1):
                 if (m.count != self.num_wps_expected):
-                    self.console.error("Unepxected waypoint count from APM after write (Editor)")
+                    self.mpstate.console.error("Unepxected waypoint count from APM after write (Editor)")
                 #since this is a write operation from the Editor there
                 #should be no need to update number of table rows
 


### PR DESCRIPTION
STABILIZE> Requesting 0 waypoints t=Sat Aug  3 12:44:03 2019 now=Sat Aug  3 12:44:03 2019
Caught exception ('MissionEditorMain' object has no attribute 'console')
  File "/usr/lib/python3.6/threading.py", line 884, in _bootstrap
    self._bootstrap_inner()
  File "/usr/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/home/pbarker/.local/lib/python3.6/site-packages/MAVProxy-1.8.8-py3.6.egg/MAVProxy/modules/mavproxy_misseditor/mission_editor.py", line 203, in mavlink_message_queue_handler