### PR TITLE
CI: Only keep artifacts for master branch builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -78,13 +78,16 @@ after_test:
   - "ISCC.exe /dMyAppVersion=%VERSION% mavproxy.iss"
   - "cd ..\\"
   
-
-artifacts:
-  # Archive the generated packages in the ci.appveyor.com build report.
-  - path: MAVProxy\dist\
-    name: WindowsCompiledFiles
-  - path: windows\Output\
-    name: WindowsInstaller
+for:
+  -
+    branches:
+      only: 
+        - master
+    artifacts:
+    - path: MAVProxy\dist\
+      name: WindowsCompiledFiles
+    - path: windows\Output\
+      name: WindowsInstaller
 
 #on_success:
 #  - TODO: upload the content of dist/*.whl to a public wheelhouse


### PR DESCRIPTION
Attempt to fix the failing builds - The build files will only be saved for master branch builds.

It may still fail, as there is a 50000MB file limit and Appveyor keeps the last 6 months of builds. We may have to wait until Appveyor cleans up some of these old builds.

[Doesn't appear to be a method to manually remove old builds though :disappointed: ]