### PR TITLE
Paramstatus: Display current status of received parameters to help with param fetch

### DIFF
--- a/MAVProxy/modules/mavproxy_console.py
+++ b/MAVProxy/modules/mavproxy_console.py
@@ -57,6 +57,7 @@ class ConsoleModule(mp_module.MPModule):
         mpstate.console.set_status('AspdError', 'AspdError --', row=3)
         mpstate.console.set_status('FlightTime', 'FlightTime --', row=3)
         mpstate.console.set_status('ETR', 'ETR --', row=3)
+        mpstate.console.set_status('Params', 'Param ---/---', row=3)
 
         mpstate.console.ElevationMap = mp_elevation.ElevationModel()
 
@@ -514,6 +515,10 @@ class ConsoleModule(mp_module.MPModule):
                 alt_error = "%s%s" % (self.height_string(msg.alt_error), alt_error_sign)
             self.console.set_status('AltError', 'AltError %s' % alt_error)
             self.console.set_status('AspdError', 'AspdError %s%s' % (self.speed_string(msg.aspd_error*0.01), aspd_error_sign))
+
+        elif type == 'PARAM_VALUE':
+            rec, tot = self.module('param').param_status()
+            self.console.set_status('Params', 'Param %u/%u' % (rec,tot))
 
 def init(mpstate):
     '''initialise module'''

--- a/MAVProxy/modules/mavproxy_param.py
+++ b/MAVProxy/modules/mavproxy_param.py
@@ -231,6 +231,9 @@ class ParamState:
             else:
                 print("Parameter '%s' not found in documentation" % h)
 
+    def status(self, master, mpstate):
+        return(len(self.mav_param_set), self.mav_param_count)
+
     def handle_command(self, master, mpstate, args):
         '''handle parameter commands'''
         param_wildcard = "*"
@@ -423,6 +426,11 @@ class ParamModule(mp_module.MPModule):
         if sysid in self.pstate:
             return
         self.add_new_target_system(sysid)
+
+    def param_status(self):
+        sysid = self.get_sysid()
+        pset, pcount = self.pstate[sysid].status(self.master, self.mpstate)
+        return (pset, pcount)
         
     def mavlink_packet(self, m):
         '''handle an incoming mavlink packet'''

--- a/MAVProxy/modules/mavproxy_paramedit/param_editor.py
+++ b/MAVProxy/modules/mavproxy_paramedit/param_editor.py
@@ -154,7 +154,7 @@ class ParamEditorMain(object):
             if m.param_id in self.paramchanged:
                 del self.paramchanged[m.param_id.upper()]
             self.gui_event_queue.put(ParamEditorEvent(
-                ph_event.PEGE_WRITE_SUCC, paramid=m.param_id.upper(), paramvalue=m.param_value))
+                ph_event.PEGE_WRITE_SUCC, paramid=m.param_id.upper(), paramvalue=m.param_value, pstatus = self.mpstate.module('param').param_status()))
         if mtype in ['RC_CHANNELS_RAW', 'RC_CHANNELS']:
             if self.mpstate.vehicle_name == 'APMrover2':
                 fltmode_ch = int(self.mpstate.module('param').mav_param['MODE_CH'])

--- a/MAVProxy/modules/mavproxy_paramedit/param_editor_frame.py
+++ b/MAVProxy/modules/mavproxy_paramedit/param_editor_frame.py
@@ -38,6 +38,8 @@ class ParamEditorFrame(wx.Frame):
         self.fetch_params = wx.Button(self, wx.ID_ANY, ("Fetch all"))
         self.write_params = wx.Button(self, wx.ID_ANY, ("Write"))
         self.search_key = wx.TextCtrl(self, wx.ID_ANY, "")
+        self.param_status = (0,0)
+        self.param_label = wx.StaticText(self, wx.ID_ANY, "Status: " + str(self.param_status[0]) + "/ " + str(self.param_status[1]), style=wx.ALIGN_CENTRE)
         self.search_choices = ['All:', 'Actions:TMODE_',
         'Tuning:PILOT_,ATC_,MOT_,ANGLE_,RC_',
         'PosControl:VEL_,POS_,WPNAV_,RTL_',
@@ -148,6 +150,8 @@ class ParamEditorFrame(wx.Frame):
         sizer_6.Add(self.fetch_params, 0, wx.ALIGN_CENTER, 0)
         sizer_6.Add((10, 10), 0, 0, 0)
         sizer_6.Add(self.reset_params, 0, wx.ALIGN_CENTER, 0)
+        sizer_6.Add((10, 10), 0, 0, 0)
+        sizer_6.Add(self.param_label, 0, wx.ALIGN_CENTER, 0)
         sizer_6.Add((10, 10), 0, 0, 0)
         sizer_3.Add(sizer_6, 0, 0, 0)
         sizer_3.Add((10, 10), 0, 0, 0)
@@ -277,6 +281,8 @@ class ParamEditorFrame(wx.Frame):
                 self.get_vehicle_type(event.get_arg("vehicle"))
             self.requires_redraw = True
         elif event.get_type() == ph_event.PEGE_WRITE_SUCC:
+            self.param_status = event.get_arg("pstatus")
+            self.param_label.SetLabel("Status: " + str(self.param_status[0]) + "/ " + str(self.param_status[1]))
             if event.get_arg("paramid") in self.param_received.keys():
                 if event.get_arg("paramid") in self.modified_param.keys():
                     del self.modified_param[event.get_arg("paramid")]


### PR DESCRIPTION
@tridge @peterbarker This displays parameter status both in console and in parameditor modules to prevent user from requesting parameter fetch repeatedly as discussed earlier.

PS : Three different commits for three different modules as suggested earlier.