### PR TITLE
mp_slipmap_ui: correct zooming using mouse wheel

### DIFF
--- a/MAVProxy/modules/mavproxy_map/mp_slipmap_ui.py
+++ b/MAVProxy/modules/mavproxy_map/mp_slipmap_ui.py
@@ -543,13 +543,16 @@ class MPSlipMapPanel(wx.Panel):
 
     def on_mouse_wheel(self, event):
         '''handle mouse wheel zoom changes'''
-        rotation = event.GetWheelRotation() / event.GetWheelDelta()
-        if rotation > 0:
-            zoom = 1.0/(1.1 * rotation)
-        elif rotation < 0:
-            zoom = 1.1 * (-rotation)
-        else:
+        # >>> print -1/120
+        # -1
+        wheel_rotation = event.GetWheelRotation()
+        rotation = abs(wheel_rotation) // event.GetWheelDelta()
+        if rotation == 0:
             return
+        zoom = 1.1 * rotation
+        if wheel_rotation > 0:
+            # zooming out
+            zoom = 1.0/zoom
         self.change_zoom(zoom)
         self.redraw_map()
 


### PR DESCRIPTION
Zooming out was always triggering on any amount of rotation due to
(-1/120) being round to -1.

We were always redrawing the map even if we didn't change the zoom level.

Python3 was misbehaving because / was returning a floating point result
for the two integers being divided (Python2 returning an integer).