### PR TITLE
mavproxy_map: Fix issue on Windows where tiles and srtm were not cached

### DIFF
--- a/MAVProxy/modules/mavproxy_map/mp_tile.py
+++ b/MAVProxy/modules/mavproxy_map/mp_tile.py
@@ -172,8 +172,11 @@ class MPTile:
             try:
                 cache_path = os.path.join(os.environ['HOME'], '.tilecache')
             except Exception:
-                import tempfile
-                cache_path = os.path.join(tempfile.gettempdir(), 'MAVtilecache')
+                if 'LOCALAPPDATA' in os.environ:
+                    cache_path = os.path.join(os.environ['LOCALAPPDATA'], '.tilecache')
+                else:
+                    import tempfile
+                    cache_path = os.path.join(tempfile.gettempdir(), '.tilecache')
 
         if not os.path.exists(cache_path):
             mp_util.mkdir_p(cache_path)

--- a/MAVProxy/modules/mavproxy_map/srtm.py
+++ b/MAVProxy/modules/mavproxy_map/srtm.py
@@ -23,7 +23,6 @@ import array
 import math
 from MAVProxy.modules.lib import mp_util
 from MAVProxy.modules.lib import multiproc
-import tempfile
 
 childTileDownload = {}
 childFileListDownload = {}
@@ -75,7 +74,11 @@ class SRTMDownloader():
             try:
                 cachedir = os.path.join(os.environ['HOME'], '.tilecache/SRTM')
             except Exception:
-                cachedir = os.path.join(tempfile.gettempdir(), 'MAVProxySRTM')
+                if 'LOCALAPPDATA' in os.environ:
+                    cachedir = os.path.join(os.environ['LOCALAPPDATA'], '.tilecache/SRTM')
+                else:
+                    import tempfile
+                    cachedir = os.path.join(tempfile.gettempdir(), 'MAVProxySRTM')
 
         self.debug = debug
         self.offline = offline
@@ -153,8 +156,10 @@ class SRTMDownloader():
                     encoding = r1.headers.get_content_charset()
                     if encoding is not None:
                         return data.decode(encoding)
-                    return data
-
+                    elif ".zip" in url or ".hgt" in url:
+                        return data
+                    else:
+                        return data.decode('utf-8')
         return None
 
     def createFileListHTTP(self):


### PR DESCRIPTION
Turns out that srtm and tiles were not actually being cached in Windows. Also, fixed some srtm downloading errors.
