### PR TITLE
Dataflash_logger: add setting to automatically rotate logs on disarm

### DIFF
--- a/MAVProxy/modules/mavproxy_dataflash_logger.py
+++ b/MAVProxy/modules/mavproxy_dataflash_logger.py
@@ -222,7 +222,7 @@ class dataflash_logger(mp_module.MPModule):
             self.armed = isarmed
             dsrmrot = self.get_mav_param('LOG_FILE_DSRMROT', 0)
             if not self.armed and dsrmrot == 1:
-                self.rotate_log()          
+                self.rotate_log()
                 
         if self.log_settings.verbose:
             self.idle_print_status()

--- a/MAVProxy/modules/mavproxy_dataflash_logger.py
+++ b/MAVProxy/modules/mavproxy_dataflash_logger.py
@@ -53,7 +53,6 @@ class dataflash_logger(mp_module.MPModule):
 
         self.log_settings = mp_settings.MPSettings(
             [('verbose', bool, False),
-             ('disarm_rotate', bool, False),
              ('df_target_system', int, 0),
              ('df_target_component', int, mavutil.mavlink.MAV_COMP_ID_LOG)]
         )
@@ -220,7 +219,8 @@ class dataflash_logger(mp_module.MPModule):
         armed = self.master.motors_armed()
         if armed != self.status.armed:
             self.status.armed = armed
-            if not armed and disarm_rotate:
+            dsrmrot = self.get_mav_param('LOG_DSRMROT', 0)
+            if not armed and dsrmrot == 1:
                 self.rotate_log()                
                 
         if self.log_settings.verbose:

--- a/MAVProxy/modules/mavproxy_dataflash_logger.py
+++ b/MAVProxy/modules/mavproxy_dataflash_logger.py
@@ -54,6 +54,7 @@ class dataflash_logger(mp_module.MPModule):
 
         self.log_settings = mp_settings.MPSettings(
             [('verbose', bool, False),
+             ('rotate_on_disarm', bool, False),
              ('df_target_system', int, 0),
              ('df_target_component', int, mavutil.mavlink.MAV_COMP_ID_LOG)]
         )
@@ -220,8 +221,7 @@ class dataflash_logger(mp_module.MPModule):
         isarmed = self.master.motors_armed()
         if self.armed != isarmed:
             self.armed = isarmed
-            dsrmrot = self.get_mav_param('LOG_FILE_DSRMROT', 0)
-            if not self.armed and dsrmrot == 1:
+            if not self.armed and self.log_settings.rotate_on_disarm:
                 self.rotate_log()
                 
         if self.log_settings.verbose:

--- a/MAVProxy/modules/mavproxy_dataflash_logger.py
+++ b/MAVProxy/modules/mavproxy_dataflash_logger.py
@@ -50,6 +50,7 @@ class dataflash_logger(mp_module.MPModule):
         self.missing_found = 0
         self.abandoned = 0
         self.dropped = 0
+        self.armed = False
 
         self.log_settings = mp_settings.MPSettings(
             [('verbose', bool, False),
@@ -216,12 +217,12 @@ class dataflash_logger(mp_module.MPModule):
 
     def idle_task_started(self):
         '''called in idle task only when logging is started'''
-        armed = self.master.motors_armed()
-        if armed != self.status.armed:
-            self.status.armed = armed
-            dsrmrot = self.get_mav_param('LOG_DSRMROT', 0)
-            if not armed and dsrmrot == 1:
-                self.rotate_log()                
+        isarmed = self.master.motors_armed()
+        if self.armed != isarmed:
+            self.armed = isarmed
+            dsrmrot = self.get_mav_param('LOG_FILE_DSRMROT', 0)
+            if not self.armed and dsrmrot == 1:
+                self.rotate_log()          
                 
         if self.log_settings.verbose:
             self.idle_print_status()

--- a/MAVProxy/modules/mavproxy_devop.py
+++ b/MAVProxy/modules/mavproxy_devop.py
@@ -44,6 +44,8 @@ class DeviceOpModule(mp_module.MPModule):
         address = int(args[2],base=0)
         reg = int(args[3],base=0)
         count = int(args[4],base=0)
+        if sys.version_info.major >= 3:
+            name = bytearray(name, 'ascii')
         self.master.mav.device_op_read_send(self.target_system,
                                             self.target_component,
                                             self.request_id,
@@ -73,6 +75,8 @@ class DeviceOpModule(mp_module.MPModule):
         bytes = [0]*128
         for i in range(count):
             bytes[i] = int(args[i],base=0)
+        if sys.version_info.major >= 3:
+            name = bytearray(name, 'ascii')
         self.master.mav.device_op_write_send(self.target_system,
                                              self.target_component,
                                              self.request_id,


### PR DESCRIPTION
This will make the dataflash-over-mavlink module automatically rotate logs when the vehicle disarms if the ArduPilot parameter `LOG_FILE_DSRMROT` is set. Tested with ArduCopter 3.6.9.

My change is pretty naive, so let me know if there's a smarter way to do this.