### PR TITLE
Change firmware.ardupilot url to https

### DIFF
--- a/MAVProxy/modules/mavproxy_firmware.py
+++ b/MAVProxy/modules/mavproxy_firmware.py
@@ -335,7 +335,7 @@ fw download releasetype=OFFICIAL frame=quad platform=PX4-v2
                 self.downloaders_lock.release()
                 return
 
-            for url in ['http://firmware.ardupilot.org/manifest.json']:
+            for url in ['https://firmware.ardupilot.org/manifest.json']:
                 filename = self.make_safe_filename_from_url(url)
                 path = mp_util.dot_mavproxy("manifest-%s" % filename)
                 self.downloaders[url] = threading.Thread(target=self.download_url, args=(url, path))

--- a/MAVProxy/modules/mavproxy_map/srtm.py
+++ b/MAVProxy/modules/mavproxy_map/srtm.py
@@ -64,7 +64,7 @@ class InvalidTileError(Exception):
 
 class SRTMDownloader():
     """Automatically download SRTM tiles."""
-    def __init__(self, server="firmware.ardupilot.org",
+    def __init__(self, server="https://firmware.ardupilot.org",
                  directory="/SRTM/",
                  cachedir=None,
                  offline=0,


### PR DESCRIPTION
Found this while trying to fix this error - 
```
Traceback (most recent call last):
  File "/usr/lib/python2.7/multiprocessing/process.py", line 267, in _bootstrap
    self.run()
  File "/usr/lib/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/home/rajat/.local/lib/python2.7/site-packages/MAVProxy/modules/mavproxy_map/srtm.py", line 173, in createFileListHTTP
    parser.feed(data)
  File "/usr/lib/python2.7/HTMLParser.py", line 116, in feed
    self.rawdata = self.rawdata + data
TypeError: cannot concatenate 'str' and 'NoneType' objects
```

Tested on Ubuntu 18.04, Python2, MAVProxy 1.8.17 (latest master)

This was not a blocking problem, since SITL was still working