### PR TITLE
Add explicit closing of ports in mpstate.mav_outputs list

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -1223,6 +1223,13 @@ if __name__ == '__main__':
 
     def quit_handler(signum = None, frame = None):
         #print('Signal handler called with signal', signum)
+        for mav_port in mpstate.mav_outputs:
+            try:
+                #Attempt immediate shutdown of ports in mpstate.mav_outputs list
+                mav_port.listen.shutdown(mavutil.socket.SHUT_RDWR)
+                mav_port.close()
+            except AttributeError:
+                pass
         if mpstate.status.exit:
             print('Clean shutdown impossible, forcing an exit')
             sys.exit(0)


### PR DESCRIPTION
When UDP ports in the `mpstate.mav_output` list are not closed explicitly, they can hang for an extended period of time before they get cleaned up. This causes port already in use errors if MAVProxy is relaunched too quickly.