### PR TITLE
mavproxy_link: pretty-print COMMAND_ACK and MISSION_ACK messages

### DIFF
--- a/MAVProxy/modules/mavproxy_link.py
+++ b/MAVProxy/modules/mavproxy_link.py
@@ -586,10 +586,17 @@ class LinkModule(mp_module.MPModule):
                 # cope with wrap
                 self.mpstate.attitude_time_s = att_time
 
-        elif mtype in [ "COMMAND_ACK", "MISSION_ACK" ]:
-            self.mpstate.console.writeln("Got MAVLink msg: %s" % m)
+        elif mtype == "COMMAND_ACK":
+            try:
+                cmd = mavutil.mavlink.enums["MAV_CMD"][m.command].name
+                cmd = cmd[8:]
+                res = mavutil.mavlink.enums["MAV_RESULT"][m.result].name
+                res = res[11:]
+                self.mpstate.console.writeln("Got COMMAND_ACK: %s: %s" % (cmd, res))
+            except Exception:
+                self.mpstate.console.writeln("Got MAVLink msg: %s" % m)
 
-            if mtype == "COMMAND_ACK" and m.command == mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION:
+            if m.command == mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION:
                 if m.result == mavutil.mavlink.MAV_RESULT_ACCEPTED:
                     self.say("Calibrated")
                 elif m.result == mavutil.mavlink.MAV_RESULT_FAILED:
@@ -600,6 +607,15 @@ class LinkModule(mp_module.MPModule):
                     self.say("Calibration temporarily rejected")
                 else:
                     self.say("Calibration response (%u)" % m.result)
+        elif mtype == "MISSION_ACK":
+            try:
+                t = mavutil.mavlink.enums["MAV_MISSION_TYPE"][m.mission_type].name
+                t = t[12:]
+                res = mavutil.mavlink.enums["MAV_MISSION_RESULT"][m.type].name
+                res = res[12:]
+                self.mpstate.console.writeln("Got MISSION_ACK: %s: %s" % (t, res))
+            except Exception as e:
+                self.mpstate.console.writeln("Got MAVLink msg: %s" % m)
         else:
             #self.mpstate.console.writeln("Got MAVLink msg: %s" % m)
             pass


### PR DESCRIPTION
This has been hanging around a long time.  Programmed rather defensively with the fancy stuff wrapped in a `try` block.

e.g.:

```
STABILIZE> Loaded 8 waypoints from Tools/autotest/CMAC-circuit.txt
Got MISSION_ACK: TYPE_MISSION: ACCEPTED
Sent waypoint 0 : MISSION_ITEM {target_system : 1, target_component : 0, seq : 0, frame : 0, command : 16, current : 0, autocontinue : 1, param1 : 0.0, param2 : 0.0, param3 : 0.0, param4 : 0.0, x : -35.362938, y : 149.165085, z : 650.0, mission_type : 0}
```

and

```
Got MISSION_ACK: TYPE_MISSION: UNSUPPORTED
```

and
```
LOITER> Got COMMAND_ACK: PREFLIGHT_REBOOT_SHUTDOWN: ACCEPTED
Got COMMAND_ACK: PREFLIGHT_REBOOT_SHUTDOWN: ACCEPTED
Got COMMAND_ACK: PREFLIGHT_REBOOT_SHUTDOWN: FAILED
```

and

```
LOITER> APM: Arming motors
Got COMMAND_ACK: COMPONENT_ARM_DISARM: ACCEPTED
ARMED
```

Previously this looks like:

```
STABILIZE> Got MAVLink msg: COMMAND_ACK {command : 11, result : 0}
LOITER> Mode LOITER
arm throttle
LOITER> APM: PreArm: EKF starting GPS checks
Got MAVLink msg: COMMAND_ACK {command : 400, result : 4}

LOITER> arm throttle
LOITER> APM: PreArm: EKF starting GPS checks
Got MAVLink msg: COMMAND_ACK {command : 400, result : 4}
APM: EKF2 IMU0 origin set
APM: EKF2 IMU1 origin set
APM: PreArm: Need 3D Fix
reboot
LOITER> Got MAVLink msg: COMMAND_ACK {command : 246, result : 0}
Got MAVLink msg: COMMAND_ACK {command : 246, result : 0}
Got MAVLink msg: COMMAND_ACK {command : 246, result : 4}
APM: Initialising ArduPilot
Got MAVLink msg: COMMAND_ACK {command : 246, result : 4}
```
