### PR TITLE
MAVExplorer: skip parameter files when looking for graphs

### DIFF
--- a/MAVProxy/tools/MAVExplorer.py
+++ b/MAVProxy/tools/MAVExplorer.py
@@ -258,6 +258,10 @@ def load_graphs():
     for file in gfiles:
         if not os.path.exists(file):
             continue
+        # skip parameter files.  They specify an encoding, and under
+        # Python3 this leads to a warning from etree
+        if os.path.basename(file) in ["ArduSub.xml", "ArduPlane.xml", "APMrover2.xml", "ArduCopter.xml", "AntennaTracker.xml"]:
+            continue
         graphs = load_graph_xml(open(file).read(), file)
         if graphs:
             mestate.graphs.extend(graphs)


### PR DESCRIPTION
Under Python3 looking at these causes a warning as they're specifying an
encoding.

Closes #725 
