### PR TITLE
update from deprecated `imp` module to `importlib`

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -18,7 +18,13 @@ import platform
 import json
 import struct
 
-from imp import reload
+try:
+    reload
+except NameError:
+    try:
+        from importlib import reload
+    except ImportError:
+        from imp import reload
 
 try:
     import queue as Queue


### PR DESCRIPTION
The `imp` module has been deprecated and will be removed from python. This patch updates the mavproxy code to use the favored `importlib` module.

The `importlib` module is available in both python2.7 and python>3.4.