### PR TITLE
change deprecated isAlive() to is_alive()

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -436,7 +436,7 @@ def unload_module(modname):
                 t = threading.Thread(target=lambda : m.unload(), name="unload %s" % modname)
                 t.start()
                 t.join(timeout=5)
-                if t.isAlive():
+                if t.is_alive():
                     print("unload on module %s did not complete" % m.name)
                     mpstate.modules.remove((m,pm))
                     return False


### PR DESCRIPTION
isAlive() has been deprecated in py3.8 and removed in py3.9. is_alive() has been available since python2.7.

See: https://docs.python.org/3.9/whatsnew/3.9.html (ctrl-f isAlive()) for `isAlive()` removal
and https://docs.python.org/2/library/threading.html for `is_alive()` in python2.6 and above.