### PR TITLE
disable periodical setting stream rates if 'mavfwd_rate' is True

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -953,7 +953,8 @@ def periodic_tasks():
     if heartbeat_check_period.trigger():
         check_link_status()
 
-    set_stream_rates()
+    if mpstate.settings.mavfwd_rate == False:
+        set_stream_rates()
 
     mpstate.status.update_bytecounters()
 


### PR DESCRIPTION
While setting `mavfwd_rate` to `True` we assume that we will change stream rates or messages intervals. Therefore this settings shouldn't be overriden every few seconds.