### PR TITLE
mavproxy_log: correct handling of no-logs-on-vehicle case

### DIFF
--- a/MAVProxy/modules/mavproxy_log.py
+++ b/MAVProxy/modules/mavproxy_log.py
@@ -37,6 +37,9 @@ class LogModule(mp_module.MPModule):
             tstring = ''
         else:
             tstring = time.ctime(m.time_utc)
+        if m.num_logs == 0:
+            print("No logs")
+            return
         self.entries[m.id] = m
         print("Log %u  numLogs %u lastLog %u size %u %s" % (m.id, m.num_logs, m.last_log_num, m.size, tstring))
 


### PR DESCRIPTION
you still get an answer back from the vehicle, even if there are not
logs.  The id will not be relevant.