### PR TITLE
mavproxy_joystick: fix Logicool joystick matches pattern

### DIFF
--- a/MAVProxy/modules/mavproxy_joystick/joysticks/logicool-f310.yml
+++ b/MAVProxy/modules/mavproxy_joystick/joysticks/logicool-f310.yml
@@ -1,7 +1,7 @@
 description: >
   Support for the Logicool F310 joystick.
 match:
-  - 'Logicool Dual Action'
+  - 'Logicool Logicool Dual Action'
 controls:
   - channel: 1
     type: axis


### PR DESCRIPTION
This will fix the match pattern for the Logitech F310 Joystick that can be purchased in Japan.