### PR TITLE
Windows: Ensure MAVProxy version is stored for installer

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -68,9 +68,7 @@ after_test:
   #create version txt file
   - "cd  .\\windows\\"
   - "for /f \"tokens=*\" %%a in ( \'python returnVersion.py\' ) do ( set VERSION=%%a )"
-  - "@echo off"
-  - "@echo %VERSION%> version.txt"
-  - "@echo on"
+  - "python returnVersion.py > version.txt"
   - "cd ..\\"
   
   # download parameter def files for installer


### PR DESCRIPTION
This fixes a bug where the ``--version`` argument did not work with the Windows installer.

Now fixed:
![Screenshot from 2020-09-12 20-38-15](https://user-images.githubusercontent.com/1731976/92993821-15be7b00-f538-11ea-9f3f-6357c989145b.png)
