### PR TITLE
Python 3.8 / Windows Fix

### DIFF
--- a/MAVProxy/modules/lib/rline.py
+++ b/MAVProxy/modules/lib/rline.py
@@ -12,6 +12,10 @@ from pymavlink import mavutil
 if platform.system() == 'Darwin':
     import gnureadline as readline
 elif platform.system() == 'Windows' and sys.version_info >= (3, 0):
+    # Python 3.8 defaults to Proactor event loop, which doesn't work well
+    if sys.version_info >= (3, 8):
+        import asyncio
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
     from prompt_toolkit import prompt, PromptSession
     from prompt_toolkit.completion import Completer, Completion
     from prompt_toolkit.shortcuts import CompleteStyle

--- a/windows/mavproxy.spec
+++ b/windows/mavproxy.spec
@@ -19,7 +19,7 @@ MAVProxyAny = Analysis(['mavproxy.py'],
                       ('modules\\mavproxy_joystick\\joysticks\\*.*', 'MAVProxy\\modules\\mavproxy_joystick\\joysticks' )],
              hookspath=None,
              runtime_hooks=None,
-             excludes= ['sphinx', 'docutils', 'alabaster'])
+             excludes= ['sphinx', 'docutils', 'alabaster', 'FixTk', 'tcl', 'tk', '_tkinter', 'tkinter', 'Tkinter'])
 MAVExpAny = Analysis(['.\\tools\\MAVExplorer.py'],
              pathex=[os.path.abspath('.')],
              # for some unknown reason these hidden imports don't pull in
@@ -34,7 +34,7 @@ MAVExpAny = Analysis(['.\\tools\\MAVExplorer.py'],
              datas= [ ('tools\\graphs\\*.*', 'MAVProxy\\tools\\graphs' ) ],
              hookspath=None,
              runtime_hooks=None,
-             excludes= ['sphinx', 'docutils', 'alabaster'])
+             excludes= ['sphinx', 'docutils', 'alabaster', 'FixTk', 'tcl', 'tk', '_tkinter', 'tkinter', 'Tkinter'])
 # MERGE( (MAVProxyAny, 'mavproxy', 'mavproxy'), (MAVExpAny, 'MAVExplorer', 'MAVExplorer') )
 MAVProxy_pyz = PYZ(MAVProxyAny.pure)
 MAVProxy_exe = EXE(MAVProxy_pyz,


### PR DESCRIPTION
Fix and enhancement:

- Fixed a text console failure on Python 3.8 / Windows. This is due to the prompt_toolkit library using asyncio, which was changed in Python 3.8 (see https://github.com/tornadoweb/tornado/issues/2608)
- Removed tcl/tk from Windows build as we don't use in Windows MAVProxy.