### PR TITLE
CI: Use less storage space

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -94,8 +94,6 @@ for:
       only: 
         - master
     artifacts:
-    - path: MAVProxy\dist\
-      name: WindowsCompiledFiles
     - path: windows\Output\
       name: WindowsInstaller
 


### PR DESCRIPTION
This removes one of the generated artifacts from Appveyor, saving 50% storage.

The removed artifact isn't required, as it's just a capture of part-way through the build process (for debugging purposes, though I've never used it).