### PR TITLE
Modules: Force WXPython backend for grapher

### DIFF
--- a/MAVProxy/modules/lib/grapher.py
+++ b/MAVProxy/modules/lib/grapher.py
@@ -5,9 +5,12 @@
 '''
 
 import ast
-import sys, struct, time, os, datetime
+import sys, struct, time, os, datetime, platform
 import math, re
 import matplotlib
+if platform.system() != "Darwin":
+    # on MacOS we can't set WxAgg here as it conflicts with the MacOS version
+    matplotlib.use('WXAgg')
 from math import *
 from pymavlink.mavextra import *
 import pylab


### PR DESCRIPTION
This ensures that the MAVExplorer graphing uses WXPython for rendering, rather than TK.

The live grapher currently forces WXPython (https://github.com/ArduPilot/MAVProxy/blob/master/MAVProxy/modules/lib/live_graph.py#L46), so just copied over the relevent code.

Tested on Windows and Ubuntu20.