### PR TITLE
Add support for macOS Catalina / Python3.8+

### DIFF
--- a/MAVProxy/modules/lib/mp_image.py
+++ b/MAVProxy/modules/lib/mp_image.py
@@ -171,12 +171,12 @@ class MPImage():
 
     def poll(self):
         '''check for events, returning one event'''
-        if self.out_queue.qsize() <= 0:
+        if self.out_queue.empty():
             return None
         evt = self.out_queue.get()
         while isinstance(evt, win_layout.WinLayout):
             win_layout.set_layout(evt, self.set_layout)
-            if self.out_queue.qsize() == 0:
+            if self.out_queue.empty():
                 return None
             evt = self.out_queue.get()
         return evt
@@ -349,7 +349,7 @@ class MPImagePanel(wx.Panel):
         '''the redraw timer ensures we show new map tiles as they
         are downloaded'''
         state = self.state
-        while state.in_queue.qsize():
+        while not state.in_queue.empty():
             try:
                 obj = state.in_queue.get()
             except Exception:

--- a/MAVProxy/modules/lib/multiproc.py
+++ b/MAVProxy/modules/lib/multiproc.py
@@ -62,14 +62,11 @@ import platform, os, sys
 # we use billiard (and forking disable) on MacOS, and also if USE_BILLIARD environment
 # is set. Using USE_BILLIARD allows for debugging of the crazy forking disable approach on
 # a saner platform
-if platform.system() == 'Darwin' or os.environ.get('USE_BILLIARD',None) is not None:
-    # as of Python3.8 the default start method for macOS is spawn
-    if sys.version_info >= (3, 8):
-        from multiprocessing import Process, freeze_support, Pipe, Semaphore, Event, Lock
-        Queue = PipeQueue
-    else:
-        from billiard import Process, forking_enable, freeze_support, Pipe, Semaphore, Event, Lock
-        forking_enable(False)
-        Queue = PipeQueue
+# As of Python 3.8 the default start method for macOS is spawn and billiard is not required.
+if ((platform.system() == 'Darwin' or os.environ.get('USE_BILLIARD',None) is not None)
+    and sys.version_info < (3, 8)):
+    from billiard import Process, forking_enable, freeze_support, Pipe, Semaphore, Event, Lock
+    forking_enable(False)
+    Queue = PipeQueue
 else:
     from multiprocessing import Process, freeze_support, Pipe, Semaphore, Event, Lock, Queue

--- a/MAVProxy/modules/mavproxy_map/mp_slipmap.py
+++ b/MAVProxy/modules/mavproxy_map/mp_slipmap.py
@@ -144,9 +144,9 @@ class MPSlipMap():
         '''move an object on the map'''
         self.object_queue.put(SlipPosition(key, latlon, layer, rotation, label, colour))
 
-    def event_count(self):
-        '''return number of events waiting to be processed'''
-        return self.event_queue.qsize()
+    def event_queue_empty(self):
+        '''return True if there are no events waiting to be processed'''
+        return self.event_queue.empty()
 
     def set_layout(self, layout):
         '''set window layout'''
@@ -154,12 +154,12 @@ class MPSlipMap():
     
     def get_event(self):
         '''return next event or None'''
-        if self.event_queue.qsize() == 0:
+        if self.event_queue.empty():
             return None
         evt = self.event_queue.get()
         while isinstance(evt, win_layout.WinLayout):
             win_layout.set_layout(evt, self.set_layout)
-            if self.event_queue.qsize() == 0:
+            if self.event_queue.empty():
                 return None
             evt = self.event_queue.get()
         return evt
@@ -170,7 +170,7 @@ class MPSlipMap():
 
     def check_events(self):
         '''check for events, calling registered callbacks as needed'''
-        while self.event_count() > 0:
+        while not self.event_queue_empty():
             event = self.get_event()
             for callback in self._callbacks:
                 callback(event)
@@ -243,7 +243,7 @@ if __name__ == "__main__":
         sm.add_object(SlipIcon('icon - %s' % str(flag), (float(lat),float(lon)), icon, layer=3, rotation=0, follow=False))
 
     while sm.is_alive():
-        while sm.event_count() > 0:
+        while not sm.event_queue_empty():
             obj = sm.get_event()
             if not opts.verbose:
                 continue

--- a/MAVProxy/modules/mavproxy_misseditor/missionEditorFrame.py
+++ b/MAVProxy/modules/mavproxy_misseditor/missionEditorFrame.py
@@ -248,7 +248,7 @@ class MissionEditorFrame(wx.Frame):
         event_processed = False
         queue_access_start_time = time.time()
         self.gui_event_queue_lock.acquire()
-        while self.gui_event_queue.qsize() > 0 and (time.time() < queue_access_start_time) < 0.6:
+        while (not self.gui_event_queue.empty()) and (time.time() < queue_access_start_time) < 0.6:
             event_processed = True
             event = self.gui_event_queue.get()
             try:

--- a/MAVProxy/modules/mavproxy_misseditor/mission_editor.py
+++ b/MAVProxy/modules/mavproxy_misseditor/mission_editor.py
@@ -38,7 +38,7 @@ class MissionEditorEventThread(threading.Thread):
             queue_access_start_time = time.time()
             self.event_queue_lock.acquire()
             request_read_after_processing_queue = False
-            while self.event_queue.qsize() > 0 and (time.time() - queue_access_start_time) < 0.6:
+            while (not self.event_queue.empty()) and (time.time() - queue_access_start_time) < 0.6:
                 event = self.event_queue.get()
 
                 if isinstance(event, win_layout.WinLayout):

--- a/MAVProxy/modules/mavproxy_paramedit/param_editor.py
+++ b/MAVProxy/modules/mavproxy_paramedit/param_editor.py
@@ -36,7 +36,7 @@ class ParamEditorEventThread(threading.Thread):
 
     def run(self):
         while not self.time_to_quit:
-            while (self.event_queue.qsize() > 0):
+            while not self.event_queue.empty():
                 try:
                     event = self.event_queue.get(block=False)
                     event_type = event.get_type()

--- a/MAVProxy/modules/mavproxy_paramedit/param_editor_frame.py
+++ b/MAVProxy/modules/mavproxy_paramedit/param_editor_frame.py
@@ -247,7 +247,7 @@ class ParamEditorFrame(wx.Frame):
 
     def time_to_process_gui_events(self, evt):
         event_processed = False
-        while self.gui_event_queue.qsize() > 0:
+        while not self.gui_event_queue.empty():
             event_processed = True
             try:
                 event = self.gui_event_queue.get(block=False)


### PR DESCRIPTION
On macOS use `multiprocessing` instead of `billiard` if the Python version >= 3.8.
The custom Queue is still required as macOS does not implement functions needed to support `multiprocessing.Queue.qsize()`.