### PR TITLE
Feature/sail module

### DIFF
--- a/MAVProxy/modules/lib/wxsaildash.py
+++ b/MAVProxy/modules/lib/wxsaildash.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+
+"""
+  MAVProxy sailing dashboard
+"""
+
+from MAVProxy.modules.lib import multiproc
+import time
+
+class SailingDashboard(object):
+    '''
+    A sailing dashboard for MAVProxy
+    '''
+
+    def __init__(self, title="MAVProxy: Sailing Dashboard"):
+        self.title = title
+
+        # create a pipe for communication from the module to the GUI
+        self.child_pipe_recv, self.parent_pipe_send = multiproc.Pipe(duplex=False)
+        self.close_event = multiproc.Event()
+        self.close_event.clear()
+
+        # create and start the child process
+        self.child = multiproc.Process(target=self.child_task)
+        self.child.start()
+
+        # prevent the parent from using the child connection
+        self.child_pipe_recv.close()
+
+    def child_task(self):
+        '''The child process hosts the GUI elements'''
+
+        # prevent the child from using the parent connection
+        self.parent_pipe_send.close()
+
+        from MAVProxy.modules.lib import wx_processguard
+        from MAVProxy.modules.lib.wx_loader import wx
+        from MAVProxy.modules.lib.wxsaildash_ui import SailingDashboardFrame 
+
+        # create the wx application and pass self as the state
+        app = wx.App()
+        app.frame = SailingDashboardFrame(state=self, title=self.title, size=(800, 300))
+        app.frame.SetDoubleBuffered(True)
+        app.frame.Show()
+        app.MainLoop()
+
+        # trigger a close event when the main app window is closed.
+        # the event is monitored by the MAVProxy module which will
+        # flag the module for unloading
+        self.close_event.set()
+
+    def close(self):
+        '''Close the GUI'''
+
+        # trigger a close event which is monitored by the 
+        # child gui process - it will close allowing the 
+        # process to be joined
+        self.close_event.set()
+        if self.is_alive():
+            self.child.join(timeout=2.0)
+
+    def is_alive(self):
+        '''Check if the GUI process is alive'''
+
+        return self.child.is_alive()
+
+if __name__ == "__main__":
+    '''A stand alone test for the sailing dashboard'''
+
+    multiproc.freeze_support()
+    sail_dash = SailingDashboard()
+    while sail_dash.is_alive():
+        print('sailing dashboard is alive')
+        time.sleep(0.5)
+
+

--- a/MAVProxy/modules/lib/wxsaildash_ui.py
+++ b/MAVProxy/modules/lib/wxsaildash_ui.py
@@ -1,0 +1,357 @@
+"""
+  MAVProxy sailing dashboard gui elements
+"""
+
+from MAVProxy.modules.lib.wx_loader import wx
+from MAVProxy.modules.lib.wxsaildash_util import WindReference, SpeedUnit, WindAngleAndSpeed, WaterSpeedAndHeading
+
+import wx.lib.agw.speedmeter as SM
+
+import math
+import time
+
+class SailingDashboardFrame(wx.Frame):
+    '''The main frame of the sailing dashboard'''
+
+    def __init__(self, state, title, size):
+        super(SailingDashboardFrame, self).__init__(None, title=title, size=size)
+        self._state = state
+        self._title = title
+
+        # control update rate
+        self._timer = wx.Timer(self)
+        self._fps = 10.0
+        self._start_time = time.time()
+
+        # events
+        self.Bind(wx.EVT_TIMER, self.OnTimer, self._timer)
+        self.Bind(wx.EVT_IDLE, self.OnIdle)
+        self.Bind(wx.EVT_CHAR_HOOK, self.OnKeyPress)
+
+        # restart the timer
+        self._timer.Start(milliseconds=100)
+
+        # create wind meters for true and apparent wind
+        self._wind_meter1 = WindMeter(self)
+        self._wind_meter1.SetWindReference(WindReference.RELATIVE)
+        self._wind_meter1.SetWindSpeedUnit(SpeedUnit.KNOTS)
+        self._wind_meter1.SetWindAngle(0)
+        self._wind_meter1.SetWindSpeed(0)
+
+        self._wind_meter2 = WindMeter(self)
+        self._wind_meter2.SetWindReference(WindReference.TRUE)
+        self._wind_meter2.SetWindSpeedUnit(SpeedUnit.KNOTS)
+        self._wind_meter2.SetWindAngle(0)
+        self._wind_meter2.SetWindSpeed(0)
+
+        # instrument display
+        self._instr1 = InstrumentDisplay(self)
+        self._instr1.label = "AWS"
+        self._instr1.unit = "kn"
+        self._instr1.value = 0.0
+
+        self._instr2 = InstrumentDisplay(self)
+        self._instr2.label = "TWS"
+        self._instr2.unit = "kn"
+        self._instr2.value = 0.0
+
+        self._instr3 = InstrumentDisplay(self)
+        self._instr3.label = "STW"
+        self._instr3.unit = "kn"
+        self._instr3.value = 0.0
+
+        self._instr4 = InstrumentDisplay(self)
+        self._instr4.label = "AWA"
+        self._instr4.unit = "deg"
+        self._instr4.value = 0.0
+
+        self._instr5 = InstrumentDisplay(self)
+        self._instr5.label = "TWA"
+        self._instr5.unit = "deg"
+        self._instr5.value = 0.0
+
+        self._instr6 = InstrumentDisplay(self)
+        self._instr6.label = "HDT"
+        self._instr6.unit = "deg"
+        self._instr3.value = 0.0
+
+        # instrument panel sizers
+        self._instr_sizer1 = wx.BoxSizer(wx.VERTICAL) 
+        self._instr_sizer1.Add(self._instr1, 1, wx.EXPAND)
+        self._instr_sizer1.Add(self._instr2, 1, wx.EXPAND)
+        self._instr_sizer1.Add(self._instr3, 1, wx.EXPAND)
+
+        self._instr_sizer2 = wx.BoxSizer(wx.VERTICAL) 
+        self._instr_sizer2.Add(self._instr4, 1, wx.EXPAND)
+        self._instr_sizer2.Add(self._instr5, 1, wx.EXPAND)
+        self._instr_sizer2.Add(self._instr6, 1, wx.EXPAND)
+
+        # top level sizers
+        self._top_sizer = wx.BoxSizer(wx.HORIZONTAL) 
+        self._top_sizer.Add(self._wind_meter1, 2, wx.EXPAND)
+        self._top_sizer.Add(self._wind_meter2, 2, wx.EXPAND)        
+        self._top_sizer.Add(self._instr_sizer1, 1, wx.EXPAND)
+        self._top_sizer.Add(self._instr_sizer2, 1, wx.EXPAND)
+        
+        # layout sizers
+        self.SetSizer(self._top_sizer)
+        self.SetAutoLayout(1)
+        # self.sizer.Fit(self)
+
+    def OnIdle(self, event):
+        '''Handle idle events
+        
+            - e.g. managed scaling when window resized if needed
+        ''' 
+        
+        pass
+
+    def OnTimer(self, event):
+        '''Handle timed tasks'''
+        
+        # check for close events
+        if self._state.close_event.wait(timeout=0.001):
+            # stop the timer and destroy the window - this ensures
+            # the window is closed whhen the module is unloaded
+            self._timer.Stop()
+            self.Destroy()
+            return
+
+        # receive data from the module
+        while self._state.child_pipe_recv.poll():
+            obj_list = self._state.child_pipe_recv.recv()
+            for obj in obj_list:
+                if isinstance(obj, WindAngleAndSpeed):
+                    if obj.wind_reference == WindReference.RELATIVE:
+                        # apparent wind meter
+                        self._wind_meter1.SetWindReference(obj.wind_reference)
+                        self._wind_meter1.SetWindAngle(obj.wind_angle)
+                        self._wind_meter1.SetWindSpeed(obj.wind_speed)
+                        self._wind_meter1.SetWindSpeedUnit(obj.wind_speed_unit)
+
+                        # apparent wind displays    
+                        self._instr1.value = obj.wind_speed
+                        self._instr4.value = obj.wind_angle
+
+                    elif obj.wind_reference == WindReference.TRUE:
+                        # apparent wind meter
+                        self._wind_meter2.SetWindReference(obj.wind_reference)
+                        self._wind_meter2.SetWindAngle(obj.wind_angle)
+                        self._wind_meter2.SetWindSpeed(obj.wind_speed)
+                        self._wind_meter2.SetWindSpeedUnit(obj.wind_speed_unit)
+
+                        # apparent wind displays    
+                        self._instr2.value = obj.wind_speed
+                        self._instr5.value = obj.wind_angle
+
+                elif isinstance(obj, WaterSpeedAndHeading):
+                    # water speed and heading     
+                    self._instr3.value = obj.water_speed
+                    self._instr6.value = obj.heading_true
+
+
+        # reset counters
+        self._start_time = time.time()
+
+    def OnKeyPress(self, event):
+        '''Handle keypress events'''
+
+        pass
+
+class WindMeter(SM.SpeedMeter):
+    ''' 
+    class: `WindMeter` is a custom `SpeedMeter`for displaying true or apparent wind 
+    '''
+
+    def __init__(self, *args, **kwargs):
+        # customise the agw style
+        kwargs.setdefault('agwStyle', SM.SM_DRAW_HAND
+            |SM.SM_DRAW_PARTIAL_SECTORS
+            |SM.SM_DRAW_SECONDARY_TICKS
+            |SM.SM_DRAW_MIDDLE_TEXT)
+
+        # initialise super class
+        super(WindMeter, self).__init__(*args, **kwargs)
+
+        # non-public attributes 
+        self._wind_reference = WindReference.RELATIVE
+        self._wind_speed = 0
+        self._wind_speed_unit = SpeedUnit.KNOTS
+
+        # colours
+        dial_colour = wx.ColourDatabase().Find('DARK SLATE GREY')
+        port_arc_colour = wx.ColourDatabase().Find('RED')
+        stbd_arc_colour = wx.ColourDatabase().Find('GREEN')
+        bottom_arc_colour = wx.ColourDatabase().Find('TAN')
+        self.SetSpeedBackground(dial_colour)
+
+        # set lower limit to 2.999/2 to prevent the partial sectors from filling
+        # the entire dial
+        self.SetAngleRange(- 2.995/2 * math.pi, math.pi/2)
+
+        # create the intervals
+        intervals = range(0, 361, 20)
+        self.SetIntervals(intervals)
+
+        # assign colours to sectors
+        colours = [dial_colour] \
+            + [stbd_arc_colour] * 2 \
+            + [dial_colour] * 4 \
+            + [bottom_arc_colour] * 4 \
+            + [dial_colour] * 4 \
+            + [port_arc_colour] * 2 \
+            + [dial_colour]
+        self.SetIntervalColours(colours)
+
+        # assign the ticks, colours and font
+        ticks = ['0', '20', '40', '60', '80', '100', '120', '140', '160', '180', '-160', '-140', '-120', '-100', '-80', '-60', '-40', '-20', '']
+        self.SetTicks(ticks)
+        self.SetTicksColour(wx.WHITE)
+        self.SetNumberOfSecondaryTicks(1)
+        self.SetTicksFont(wx.Font(12, wx.FONTFAMILY_SWISS, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL))
+
+        # set the colour for the first hand indicator
+        self.SetHandColour(wx.Colour(210, 210, 210))
+        self.SetHandStyle("Hand")
+
+        # do not draw the external (container) arc
+        self.DrawExternalArc(False)
+
+        # initialise the meter to zero
+        self.SetWindAngle(0.0)
+
+        # wind speed display
+        self.SetMiddleTextColour(wx.WHITE)
+        self.SetMiddleTextFont(wx.Font(24, wx.FONTFAMILY_SWISS, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL))
+        self.SetWindSpeed(0.0)
+
+    def SetWindAngle(self, wind_angle):
+        '''Set the wind angle
+
+            The wind angle is measured with respect to the front of the vehicle, so: 
+                -180 <= wind_angle <= 180
+        '''
+        
+        # Convert the wind angle to the meter interval [0 - 360] 
+        dial_value = wind_angle 
+        if wind_angle < 0:
+            dial_value += 360
+
+        self.SetSpeedValue(dial_value)
+
+    def SetWindSpeed(self, wind_speed):
+        '''Set the wind speed'''
+
+        self._wind_speed = wind_speed
+        
+        reference_code = None
+        if self._wind_reference == WindReference.RELATIVE:
+            reference_code ='AWS'
+        elif self._wind_reference == WindReference.TRUE:
+            reference_code ='TWS'
+        else:
+            reference_code ='INVALID'
+
+        unit_code = None
+        if self._wind_speed_unit == SpeedUnit.KPH:
+            unit_code ='kph'
+        elif self._wind_speed_unit == SpeedUnit.MPH:
+            unit_code ='mph'
+        elif self._wind_speed_unit == SpeedUnit.KNOTS:
+            unit_code ='kn'
+        else:
+            unit_code ='INVALID'
+
+        txt = reference_code + "  {:.2f}".format(self._wind_speed) + ' ' + unit_code
+        self.SetMiddleText(txt)
+
+    def SetWindReference(self, reference):
+        '''Set the wind reference (i.e relative(apparent) or true)'''
+
+        if not (reference == WindReference.RELATIVE or reference == WindReference.TRUE):
+            raise Exception("Invalid wind reference. Must be 'RELATIVE' or 'TRUE'")
+            
+        self._wind_reference = reference
+
+    def SetWindSpeedUnit(self, unit):
+        '''Set the wind speed units'''
+        
+        if not (unit == SpeedUnit.KPH or unit == SpeedUnit.MPH or unit == SpeedUnit.KNOTS):
+            raise Exception("Invalid wind speed unit. Must be 'KPH' or 'MPH' or 'KNOTS'")
+            
+        self._wind_speed_unit = unit
+
+class InstrumentDisplay(wx.Panel):
+    '''
+    class: `InstrumentDisplay` is a panel for displaying sailing instrument data
+    '''
+
+    def __init__(self, *args, **kwargs):
+        # customise the style
+        kwargs.setdefault('style', wx.TE_READONLY)
+
+        # initialise super class
+        super(InstrumentDisplay, self).__init__(*args, **kwargs)
+
+        # set the background colour (also for text controls)
+        # self.SetBackgroundColour(wx.WHITE)
+
+        # text controls
+        self._label_text = wx.TextCtrl(self, style=wx.BORDER_NONE)
+        self._label_text.SetFont(wx.Font(12, wx.FONTFAMILY_SWISS, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL))
+        self._label_text.SetBackgroundColour(self.GetBackgroundColour())
+        self._label_text.ChangeValue("---")
+
+        self._value_text = wx.TextCtrl(self, style=wx.BORDER_NONE|wx.TE_CENTRE)
+        self._value_text.SetFont(wx.Font(36, wx.FONTFAMILY_SWISS, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL))
+        self._value_text.SetBackgroundColour(self.GetBackgroundColour())
+        self._value_text.ChangeValue("-.-")
+        self._value_text.SetMinSize((60, 30))
+
+        self._unit_text = wx.TextCtrl(self, style=wx.BORDER_NONE|wx.TE_RIGHT)
+        self._unit_text.SetFont(wx.Font(12, wx.FONTFAMILY_SWISS, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL))
+        self._unit_text.SetBackgroundColour(self.GetBackgroundColour())
+        self._unit_text.ChangeValue("--")
+
+        # value text needs a nested sizer to centre vertically
+        self._value_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        self._value_sizer.Add(self._value_text,
+            wx.SizerFlags(1).Align(wx.ALIGN_CENTRE_VERTICAL).Border(wx.ALL, 0))
+
+        # top level sizers
+        self._top_sizer = wx.BoxSizer(wx.VERTICAL) 
+        self._top_sizer.Add(self._label_text,
+            wx.SizerFlags(0).Align(wx.ALIGN_TOP|wx.ALIGN_LEFT).Border(wx.ALL, 2))
+        self._top_sizer.Add(self._value_sizer,
+            wx.SizerFlags(1).Expand().Border(wx.ALL, 1))
+        self._top_sizer.Add(self._unit_text,
+            wx.SizerFlags(0).Align(wx.ALIGN_RIGHT).Border(wx.ALL, 2))
+
+        # layout sizers
+        self._top_sizer.SetSizeHints(self)
+        self.SetSizer(self._top_sizer)
+        self.SetAutoLayout(True)
+
+    @property
+    def label(self):
+        return self._label_text.GetValue()
+
+    @label.setter
+    def label(self, label):
+        self._label_text.ChangeValue(label)
+
+    @property
+    def value(self):
+        return self._value_text.GetValue()
+
+    @value.setter
+    def value(self, value):
+        self._value_text.ChangeValue("{:.2f}".format(value))
+
+    @property
+    def unit(self):
+        return self._unit_text.GetValue()
+
+    @unit.setter
+    def unit(self, unit):
+        self._unit_text.ChangeValue(unit)

--- a/MAVProxy/modules/lib/wxsaildash_util.py
+++ b/MAVProxy/modules/lib/wxsaildash_util.py
@@ -1,0 +1,42 @@
+'''
+MAVProxy sailing dashboard utility classes
+'''
+
+import enum
+
+class WindReference(enum.Enum):
+    '''
+    An enumeration for the wind reference (either RELATIVE or TRUE)
+    '''
+
+    RELATIVE = 1
+    TRUE = 2
+
+class SpeedUnit(enum.Enum):
+    '''
+    An enumeration for the units of speed: kph, mph, or knots
+    '''
+
+    KPH = 1
+    MPH = 2
+    KNOTS = 3
+
+class WindAngleAndSpeed(object):
+    '''
+    Wind angle and speed attributes
+    '''
+
+    def __init__(self, reference, angle, speed, unit):
+        self.wind_reference = reference
+        self.wind_angle = angle
+        self.wind_speed = speed
+        self.wind_speed_unit = unit
+
+class WaterSpeedAndHeading(object):
+    '''
+    Water speed and heading attributes
+    '''
+
+    def __init__(self, water_speed, heading_true):
+        self.water_speed = water_speed
+        self.heading_true = heading_true

--- a/MAVProxy/modules/mavproxy_sail.py
+++ b/MAVProxy/modules/mavproxy_sail.py
@@ -1,0 +1,200 @@
+'''
+MAVProxy sailing dashboard module
+Rhys Mainwaring
+November 2020
+'''
+
+from pymavlink import mavutil
+
+from MAVProxy.modules.lib import mp_module
+from MAVProxy.modules.lib import mp_util
+from MAVProxy.modules.lib import mp_settings
+from MAVProxy.modules.lib.mp_settings import MPSetting
+from MAVProxy.modules.lib.wxsaildash import SailingDashboard
+from MAVProxy.modules.lib.wxsaildash_util import WindReference, SpeedUnit, WindAngleAndSpeed, WaterSpeedAndHeading
+
+import time
+
+class SailModule(mp_module.MPModule):
+    '''SailModule provides a dashboard to display sailing instrument data'''
+
+    def __init__(self, mpstate):
+        super(SailModule, self).__init__(mpstate, "sail", "sailing module")
+
+        # dashboard GUI
+        self.sail_dash = SailingDashboard(title="Sailing Dashboard")
+
+        # mavlink messages
+        self.wind = None
+        self.vfr_hud = None
+
+        # data
+        self.wnd_ang_app = 0.0
+        self.wnd_spd_app = 0.0
+        self.wnd_dir_tru = 0.0
+        self.wnd_ang_tru = 0.0
+        self.wnd_spd_tru = 0.0
+        self.heading = 0.0
+        self.ground_speed = 0.0
+
+        # control update rate to GUI
+        self._msg_list = []
+        self._fps = 10.0
+        self._last_send = 0.0
+        self._send_delay = (1.0/self._fps) * 0.9
+
+        # commands
+        self.add_command('sail', self.cmd_sail, "sailing dashboard")
+
+    def cmd_sail(self, args):
+        '''Control behaviour of the module'''
+
+        if len(args) == 0:
+            print(self.usage())
+        elif args[0] == "status":
+            print(self.status())
+        else:
+            print(self.usage())
+
+    def usage(self):
+        '''Show help on command line options'''
+
+        return "Usage: sail <status>"
+
+    def status(self):
+        '''Returns information about the sailing state'''
+
+        return({
+            "SAIL": {
+                "wnd_ang_app": self.wnd_ang_app,
+                "wnd_spd_app": self.wnd_spd_app
+                },
+            "WIND": {
+                "direction": self.wind.direction,
+                "speed": self.wind.speed,
+                "speed_z": self.wind.speed_z
+                },
+            "VFR_HUD": {
+                "airspeed": self.vfr_hud.airspeed,
+                "groundspeed": self.vfr_hud.groundspeed,
+                "heading": self.vfr_hud.heading,
+                "throttle": self.vfr_hud.throttle,
+                "alt": self.vfr_hud.alt,
+                "climb": self.vfr_hud.climb
+                },
+            })
+
+    def mavlink_packet(self, m):
+        '''Handle a mavlink packet'''
+
+        if m.get_type() == 'NAMED_VALUE_FLOAT':
+            if m.name == 'AppWndDir':
+                self.wnd_ang_app = m.value
+            elif m.name == 'AppWndSpd':
+                self.wnd_spd_app = m.value
+
+            # apparent wind: convert speed units and append to msg list
+            angle = self.wnd_ang_app
+            speed = self.wnd_spd_app
+            reference = WindReference.RELATIVE
+            unit = SpeedUnit.KNOTS
+            speed = SailModule._convert_speed_units('m/s', SpeedUnit.KNOTS, speed)
+            self._msg_list.append(WindAngleAndSpeed(reference, angle, speed, unit))
+
+        elif m.get_type() == 'SAIL':
+            self.sail = m
+        elif m.get_type() == 'WIND':
+            self.wind = m
+            self.wnd_dir_tru = m.direction
+            self.wnd_spd_tru = m.speed
+
+            # convert wind direction to angle
+            self.wnd_ang_tru = SailModule._wind_direction_to_angle(self.wnd_dir_tru, self.heading)
+
+            # true wind: convert speed units and append to msg list
+            angle = self.wnd_ang_tru
+            speed = self.wnd_spd_tru
+            reference = WindReference.TRUE
+            unit = SpeedUnit.KNOTS
+            speed = SailModule._convert_speed_units('m/s', SpeedUnit.KNOTS, speed)
+            self._msg_list.append(WindAngleAndSpeed(reference, angle, speed, unit))
+
+        elif m.get_type() == 'VFR_HUD':
+            self.vfr_hud = m
+            self.heading = m.heading
+            self.ground_speed = m.groundspeed
+
+            # water speed and true heading: convert speed units and append to msg list
+            heading_true = self.heading
+            water_speed = SailModule._convert_speed_units('m/s', SpeedUnit.KNOTS, self.ground_speed)
+            self._msg_list.append(WaterSpeedAndHeading(water_speed, heading_true))
+
+    def idle_task(self):
+        '''Idle tasks
+        
+            - check if the GUI has received a close event
+            - periodically send data to the GUI
+        '''
+        # tell MAVProxy to unload the module if the GUI is closed
+        if self.sail_dash.close_event.wait(timeout=0.001):
+            self.needs_unloading = True
+
+        # send message list via pipe to gui at desired update rate
+        if (time.time() - self._last_send) > self._send_delay:
+            # pipe data to GUI
+            self.sail_dash.parent_pipe_send.send(self._msg_list)
+
+            # reset counters etc.
+            self._msg_list = []
+            self._last_send = time.time()
+
+    def unload(self):
+        '''Close the GUI and unload module'''
+
+        # close the gui
+        self.sail_dash.close()
+
+    @staticmethod
+    def _convert_speed_units(from_units, to_units, speed):
+        '''Convert a speed to different units'''
+
+        # use m/s as the reference
+        to_speed = speed
+        if from_units == 'm/s':
+            pass
+        elif from_units == 'kph':
+            to_speed /= 3.6
+        elif from_units == 'mph':
+            to_speed /= 2.23694
+        elif from_units == 'knots':
+            to_speed /= 1.94384
+        else:
+            raise Exception('Invalid source speed units')
+
+        if to_units == SpeedUnit.KPH:
+            to_speed *= 3.6
+        elif to_units == SpeedUnit.MPH:
+            to_speed *= 2.23694
+        elif to_units == SpeedUnit.KNOTS:
+            to_speed *= 1.94384
+        else:
+            raise Exception('Invalid target speed units')
+
+        # print('from_units: {}, to_units: {}, from_speed: {}, to_speed: {}'.format(
+        #     from_units, to_units, speed, to_speed))
+
+        return to_speed
+
+    @staticmethod
+    def _wind_direction_to_angle(wind_dir, heading):
+        '''Convert a wind direction to a wind angle relative to a heading'''
+
+        wind_angle = (wind_dir - heading) % 360
+        wind_angle = wind_angle if wind_angle <= 180 else wind_angle - 360
+        return wind_angle
+
+def init(mpstate):
+    ''' Initialise module'''
+
+    return SailModule(mpstate)
+


### PR DESCRIPTION
This is a dashboard for displaying information relevant to sailing vehicles. The module name is `sail`.

It's an example of a minimal wxPython module that AFAICT works with no errors or warnings on macOS / Python 3.9. I'd wanted a baseline app to start investigations into why some of the other MAVProxy modules are not working on macOS. It borrows heavily from the horizon module in its structure, but does not assign the wxmodule to the mpstate attribute of MPModule. I'm not sure whether this matters or not? (it doesn't appear to).

It's operational but could do with further work to make it production ready - in particular the units are essentially hardcoded rather than driven by the MPSettings which would be better. It also depends on NAMED_VALUE_FLOAT messages for some of the wind data as a dedicated message format for sailing specific info is not yet available in mavlink - I'm not sure what the policy is on this.

It's best viewed using the sailboat sim:

```
sim_vehicle.py -v Rover -f sailboat
``` 

I'd appreciate feedback and any guidance on additional steps necessary to eventually have this PR merged.

![wind_display_mockup](https://user-images.githubusercontent.com/24916364/100158450-18c4d880-2ea4-11eb-9696-a87555fdd8a1.png)
