### PR TITLE
Module horizon: fix for macOS / Python 3.9

### DIFF
--- a/MAVProxy/modules/lib/wxhorizon.py
+++ b/MAVProxy/modules/lib/wxhorizon.py
@@ -24,6 +24,7 @@ class HorizonIndicator():
         '''child process - this holds all the GUI elements'''
         self.parent_pipe_send.close()
         
+        from MAVProxy.modules.lib import wx_processguard
         from MAVProxy.modules.lib.wx_loader import wx
         from MAVProxy.modules.lib.wxhorizon_ui import HorizonFrame
         # Create wx application


### PR DESCRIPTION
One line fix to get the horizon module working on macOS / Python 3.9

This addresses the following error message:

```
MAV> module load horizon
MAV> Loaded module horizon
Cannot access wx from main thread.
  File "<string>", line 1, in <module>
  File "/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/multiprocessing/spawn.py", line 116, in spawn_main
    exitcode = _main(fd, parent_sentinel)
  File "/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/multiprocessing/spawn.py", line 129, in _main
    return self._bootstrap(parent_sentinel)
  File "/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/Volumes/MacPro2_DV1/Code/ardupilot/MAVProxy/MAVProxy/modules/lib/wxhorizon.py", line 28, in child_task
    from MAVProxy.modules.lib.wx_loader import wx
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 790, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/Volumes/MacPro2_DV1/Code/ardupilot/MAVProxy/MAVProxy/modules/lib/wx_loader.py", line 6, in <module>
    print(traceback.print_stack())
None
Process Process-4:
Traceback (most recent call last):
  File "/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/Volumes/MacPro2_DV1/Code/ardupilot/MAVProxy/MAVProxy/modules/lib/wxhorizon.py", line 28, in child_task
    from MAVProxy.modules.lib.wx_loader import wx
  File "/Volumes/MacPro2_DV1/Code/ardupilot/MAVProxy/MAVProxy/modules/lib/wx_loader.py", line 7, in <module>
    raise Exception('Cannot access wx from main thread')
Exception: Cannot access wx from main thread
```