### PR TITLE
MAVExplorer MagFitUI support for macOS / Windows

### DIFF
--- a/MAVProxy/modules/lib/magfit.py
+++ b/MAVProxy/modules/lib/magfit.py
@@ -4,6 +4,7 @@
 fit best estimate of magnetometer offsets, diagonals, off-diagonals, cmot and scaling using WMM target
 '''
 
+from MAVProxy.modules.lib import wx_processguard
 from MAVProxy.modules.lib.wx_loader import wx
 import sys, time, os, math, copy
 

--- a/MAVProxy/modules/lib/multiproc_util.py
+++ b/MAVProxy/modules/lib/multiproc_util.py
@@ -1,0 +1,151 @@
+'''Multiprocessing utilities
+
+    This module contains utilties for multiprocessing such as
+    custom pickle functions and class wrappers
+'''
+
+import copyreg
+import mmap
+import platform
+import struct
+
+def pickle_struct(s):
+    '''Custom pickle function for struct.Struct'''
+
+    return struct.Struct, (s.format, )
+
+copyreg.pickle(struct.Struct, pickle_struct)
+
+class WrapFileHandle(object):
+    '''Wrap a filehandle object for pickling
+    
+        This is a pickleable wrapper for a filehandle object
+        returned from the builtin function open(file, mode='r', ...)
+
+        The wrapper restores the filehandle seek pointer (offset) and preserves
+        the following arguments to open():
+
+            - name (file)
+            - mode
+            - encoding
+            - errors
+            - newline
+    '''
+    
+    def __init__(self, filehandle):
+        # the filehandle is not pickled
+        self._filehandle = filehandle
+
+        # state for pickling - populated in __getstate__
+        self._name = None
+        self._mode = None
+        self._encoding = None
+        self._errors = None
+        self._newlines = None
+        self._offset = None
+
+        # TODO: these are additional args to open() but it is less 
+        # clear where to acquire their state when persisting
+        # self._buffering = None
+        # self._closefd = None
+        # self._opener = None
+
+    def unwrap(self):
+        '''Returns the encapsulated object'''
+
+        return self._filehandle
+
+    def __getstate__(self):
+        # capture the filehandle state
+        self._name = self._filehandle.name
+        self._mode = self._filehandle.mode
+        self._encoding = self._filehandle.encoding
+        self._errors = self._filehandle.errors
+        self._newlines = self._filehandle.newlines
+        self._offset = self._filehandle.tell()
+        
+        # copy the dict since we change it
+        odict = self.__dict__.copy()
+
+        # remove the _filehandle entry
+        del odict['_filehandle']
+
+        return odict
+
+    def __setstate__(self, dict):
+        # reopen file
+        name = dict['_name']
+        mode = dict['_mode']
+        encoding = dict['_encoding']
+        errors = dict['_errors']
+        newlines = dict['_newlines']
+        filehandle = open(name, mode=mode, encoding=encoding, errors=errors, newline=newlines)
+        
+        # set the seek pointer
+        offset = dict['_offset']
+        filehandle.seek(offset)
+
+        # update attributes
+        self.__dict__.update(dict)
+
+        # restore the filehandle
+        self._filehandle = filehandle  
+
+class WrapMMap(object):
+    '''Wrap a memory map object for pickling
+    
+        This is a pickleable wrapper for a mmap.mmap object
+        returned from the builtin function mmap.mmap(fileno, length, ...)
+
+        The wrapper restores the mmap's seek pointer (offset).    
+    '''
+
+    # mmap does not retain the filehandle and data_len as attributes
+    # when it is constructed, so it is necessary to pass them as args
+    # to the wrapper 
+    def __init__(self, mm, filehandle, data_len):
+        # the mmap is not pickled
+        self._mm = mm
+
+        # state for pickling - populated in __getstate__
+        self._filehandle = WrapFileHandle(filehandle)
+        self._data_len = data_len
+        self._offset = None
+
+    def unwrap(self):
+        '''Returns the encapsulated object'''
+
+        return self._mm
+
+    def __getstate__(self):
+        # capture the mmap state
+        self._offset = self._mm.tell()
+        
+        # copy the dict since we change it
+        odict = self.__dict__.copy()
+
+        # remove the _mm entry
+        del odict['_mm']
+
+        return odict
+
+    def __setstate__(self, dict):
+        # reopen mmap
+        filehandle = dict['_filehandle'].unwrap()
+        data_len = dict['_data_len']
+
+        mm = None
+        if platform.system() == "Windows":
+            mm = mmap.mmap(filehandle.fileno(), data_len, None, mmap.ACCESS_READ)
+        else:
+            mm = mmap.mmap(filehandle.fileno(), data_len, mmap.MAP_PRIVATE, mmap.PROT_READ)
+
+        # set the seek pointer
+        offset = dict['_offset']
+        mm.seek(offset)
+
+        # update attributes
+        self.__dict__.update(dict)
+
+        # restore the mmap
+        self._mm = mm  

--- a/MAVProxy/tools/MAVExplorer.py
+++ b/MAVProxy/tools/MAVExplorer.py
@@ -29,11 +29,8 @@ from MAVProxy.modules.lib.graphdefinition import GraphDefinition
 from lxml import objectify
 import pkg_resources
 from builtins import input
-import copyreg
 import datetime
 import matplotlib
-import mmap
-import struct
 
 grui = []
 last_xlim = None
@@ -43,133 +40,6 @@ flightmodes = None
 
 # Global var to hold the GUI menu element
 TopMenu = None
-
-################################################################################
-# Custom pickling for multiprocessing
-
-def pickle_struct(s):
-    '''Custom pickle function for struct.Struct'''
-
-    return struct.Struct, (s.format, )
-
-copyreg.pickle(struct.Struct, pickle_struct)
-
-class WrapFileHandle(object):
-    '''Wrap a filehandle object for pickling'''
-    
-    def __init__(self, filehandle):
-        # the filehandle is not pickled
-        self._filehandle = filehandle
-
-        # state for pickling - populated in __getstate__
-        self._name = None
-        self._mode = None
-        self._encoding = None
-        self._errors = None
-        self._newlines = None
-        self._offset = None
-
-        # TODO: these are additional args to open() but it is less 
-        # clear where to acquire their state when persisting
-        # self._buffering = None
-        # self._closefd = None
-        # self._opener = None
-
-    def unwrap(self):
-        '''Returns the encapsulated object'''
-
-        return self._filehandle
-
-    def __getstate__(self):
-        # capture the filehandle state
-        self._name = self._filehandle.name
-        self._mode = self._filehandle.mode
-        self._encoding = self._filehandle.encoding
-        self._errors = self._filehandle.errors
-        self._newlines = self._filehandle.newlines
-        self._offset = self._filehandle.tell()
-        
-        # copy the dict since we change it
-        odict = self.__dict__.copy()
-
-        # remove the _filehandle entry
-        del odict['_filehandle']
-
-        return odict
-
-    def __setstate__(self, dict):
-        # reopen file
-        name = dict['_name']
-        mode = dict['_mode']
-        encoding = dict['_encoding']
-        errors = dict['_errors']
-        newlines = dict['_newlines']
-        filehandle = open(name, mode=mode, encoding=encoding, errors=errors, newline=newlines)
-        
-        # set the seek pointer
-        offset = dict['_offset']
-        filehandle.seek(offset)
-
-        # update attributes
-        self.__dict__.update(dict)
-
-        # restore the filehandle
-        self._filehandle = filehandle  
-
-class WrapMMap(object):
-    '''Wrap a memory map object for pickling'''
-
-    # mmap does not retain the filehandle and data_len as attributes
-    # when it is constructed, so it is necessary to pass them as args
-    # to the wrapper 
-    def __init__(self, mm, filehandle, data_len):
-        # the mmap is not pickled
-        self._mm = mm
-
-        # state for pickling - populated in __getstate__
-        self._filehandle = WrapFileHandle(filehandle)
-        self._data_len = data_len
-        self._offset = None
-
-    def unwrap(self):
-        '''Returns the encapsulated object'''
-
-        return self._mm
-
-    def __getstate__(self):
-        # capture the mmap state
-        self._offset = self._mm.tell()
-        
-        # copy the dict since we change it
-        odict = self.__dict__.copy()
-
-        # remove the _mm entry
-        del odict['_mm']
-
-        return odict
-
-    def __setstate__(self, dict):
-        # reopen mmap
-        filehandle = dict['_filehandle'].unwrap()
-        data_len = dict['_data_len']
-
-        mm = None
-        if platform.system() == "Windows":
-            mm = mmap.mmap(filehandle.fileno(), data_len, None, mmap.ACCESS_READ)
-        else:
-            mm = mmap.mmap(filehandle.fileno(), data_len, mmap.MAP_PRIVATE, mmap.PROT_READ)
-
-        # set the seek pointer
-        offset = dict['_offset']
-        mm.seek(offset)
-
-        # update attributes
-        self.__dict__.update(dict)
-
-        # restore the mmap
-        self._mm = mm  
-
-################################################################################
 
 def xml_unescape(e):
     '''unescape < amd >'''
@@ -589,46 +459,16 @@ def cmd_dump(args):
         print(msg)
     mlog.rewind()
 
-def cmd_magfit_child_task(mlog, timestamp_in_range):
-    '''child task for cmd_magfit'''
-
-    from MAVProxy.modules.lib import magfit    
-
-    # unwrap
-    mlog.filehandle = mlog.filehandle.unwrap()
-    mlog.data_map = mlog.data_map.unwrap()
-
-    mfit = magfit.MagFitUI(mlog, timestamp_in_range)
-    mfit.show()
+mfit_tool = None
 
 def cmd_magfit(args):
     '''fit magnetic field'''
 
-    # TODO: should lock access to mestate.mlog at this point as we
-    # are temporarily modifying the types of filehandle and data_map
-    # in the parent process
-
-    # capture parent state before modifying
-    filehandle = mestate.mlog.filehandle
-    data_map = mestate.mlog.data_map
-    data_len = mestate.mlog.data_len
-
-    try:
-        # wrap for pickling
-        mestate.mlog.filehandle = WrapFileHandle(filehandle)
-        mestate.mlog.data_map = WrapMMap(data_map,
-                                         filehandle,
-                                         data_len)
-        
-        child = multiproc.Process(target=cmd_magfit_child_task,
-                                  args=(mestate.mlog, timestamp_in_range))
-        child.start()
-
-    finally:
-        # restore
-        mestate.mlog.filehandle = filehandle
-        mestate.mlog.data_map = data_map
-
+    from MAVProxy.modules.lib import magfit    
+    global mfit_tool
+    mfit_tool = magfit.MagFit(title="MagFit",
+                              mlog=mestate.mlog,
+                              timestamp_in_range=timestamp_in_range)
 
 def save_graph(graphdef):
     '''save a graph as XML'''

--- a/MAVProxy/tools/MAVExplorer.py
+++ b/MAVProxy/tools/MAVExplorer.py
@@ -459,10 +459,9 @@ def cmd_dump(args):
         print(msg)
     mlog.rewind()
 
-def cmd_magfit_child_task(filename, timestamp_in_range):
+def cmd_magfit_child_task(mlog, timestamp_in_range):
     '''child task for cmd_magfit on macOS'''
     from MAVProxy.modules.lib import magfit    
-    mlog = mavutil.mavlink_connection(filename, notimestamps=False, zero_time_base=False)
     mfit = magfit.MagFitUI(mlog, timestamp_in_range)
     mfit.show()
 
@@ -471,7 +470,7 @@ def cmd_magfit(args):
     # On macOS multiprocess uses `spawn` and arguments to Process must be pickleable
     if platform.system() == 'Darwin' and sys.version_info >= (3, 8):
         child = multiproc.Process(target=cmd_magfit_child_task,
-                                  args=(mestate.filename, timestamp_in_range))
+                                  args=(mestate.mlog, timestamp_in_range))
         child.start()
     else:
         from MAVProxy.modules.lib import magfit

--- a/MAVProxy/tools/MAVExplorer.py
+++ b/MAVProxy/tools/MAVExplorer.py
@@ -29,8 +29,11 @@ from MAVProxy.modules.lib.graphdefinition import GraphDefinition
 from lxml import objectify
 import pkg_resources
 from builtins import input
+import copyreg
 import datetime
 import matplotlib
+import mmap
+import struct
 
 grui = []
 last_xlim = None
@@ -40,6 +43,133 @@ flightmodes = None
 
 # Global var to hold the GUI menu element
 TopMenu = None
+
+################################################################################
+# Custom pickling for multiprocessing
+
+def pickle_struct(s):
+    '''Custom pickle function for struct.Struct'''
+
+    return struct.Struct, (s.format, )
+
+copyreg.pickle(struct.Struct, pickle_struct)
+
+class WrapFileHandle(object):
+    '''Wrap a filehandle object for pickling'''
+    
+    def __init__(self, filehandle):
+        # the filehandle is not pickled
+        self._filehandle = filehandle
+
+        # state for pickling - populated in __getstate__
+        self._name = None
+        self._mode = None
+        self._encoding = None
+        self._errors = None
+        self._newlines = None
+        self._offset = None
+
+        # TODO: these are additional args to open() but it is less 
+        # clear where to acquire their state when persisting
+        # self._buffering = None
+        # self._closefd = None
+        # self._opener = None
+
+    def unwrap(self):
+        '''Returns the encapsulated object'''
+
+        return self._filehandle
+
+    def __getstate__(self):
+        # capture the filehandle state
+        self._name = self._filehandle.name
+        self._mode = self._filehandle.mode
+        self._encoding = self._filehandle.encoding
+        self._errors = self._filehandle.errors
+        self._newlines = self._filehandle.newlines
+        self._offset = self._filehandle.tell()
+        
+        # copy the dict since we change it
+        odict = self.__dict__.copy()
+
+        # remove the _filehandle entry
+        del odict['_filehandle']
+
+        return odict
+
+    def __setstate__(self, dict):
+        # reopen file
+        name = dict['_name']
+        mode = dict['_mode']
+        encoding = dict['_encoding']
+        errors = dict['_errors']
+        newlines = dict['_newlines']
+        filehandle = open(name, mode=mode, encoding=encoding, errors=errors, newline=newlines)
+        
+        # set the seek pointer
+        offset = dict['_offset']
+        filehandle.seek(offset)
+
+        # update attributes
+        self.__dict__.update(dict)
+
+        # restore the filehandle
+        self._filehandle = filehandle  
+
+class WrapMMap(object):
+    '''Wrap a memory map object for pickling'''
+
+    # mmap does not retain the filehandle and data_len as attributes
+    # when it is constructed, so it is necessary to pass them as args
+    # to the wrapper 
+    def __init__(self, mm, filehandle, data_len):
+        # the mmap is not pickled
+        self._mm = mm
+
+        # state for pickling - populated in __getstate__
+        self._filehandle = WrapFileHandle(filehandle)
+        self._data_len = data_len
+        self._offset = None
+
+    def unwrap(self):
+        '''Returns the encapsulated object'''
+
+        return self._mm
+
+    def __getstate__(self):
+        # capture the mmap state
+        self._offset = self._mm.tell()
+        
+        # copy the dict since we change it
+        odict = self.__dict__.copy()
+
+        # remove the _mm entry
+        del odict['_mm']
+
+        return odict
+
+    def __setstate__(self, dict):
+        # reopen mmap
+        filehandle = dict['_filehandle'].unwrap()
+        data_len = dict['_data_len']
+
+        mm = None
+        if platform.system() == "Windows":
+            mm = mmap.mmap(filehandle.fileno(), data_len, None, mmap.ACCESS_READ)
+        else:
+            mm = mmap.mmap(filehandle.fileno(), data_len, mmap.MAP_PRIVATE, mmap.PROT_READ)
+
+        # set the seek pointer
+        offset = dict['_offset']
+        mm.seek(offset)
+
+        # update attributes
+        self.__dict__.update(dict)
+
+        # restore the mmap
+        self._mm = mm  
+
+################################################################################
 
 def xml_unescape(e):
     '''unescape < amd >'''
@@ -460,24 +590,46 @@ def cmd_dump(args):
     mlog.rewind()
 
 def cmd_magfit_child_task(mlog, timestamp_in_range):
-    '''child task for cmd_magfit on macOS'''
+    '''child task for cmd_magfit'''
+
     from MAVProxy.modules.lib import magfit    
+
+    # unwrap
+    mlog.filehandle = mlog.filehandle.unwrap()
+    mlog.data_map = mlog.data_map.unwrap()
+
     mfit = magfit.MagFitUI(mlog, timestamp_in_range)
     mfit.show()
 
 def cmd_magfit(args):
-    '''fit magnetic field'''    
-    # On macOS multiprocess uses `spawn` and arguments to Process must be pickleable
-    if platform.system() == 'Darwin' and sys.version_info >= (3, 8):
+    '''fit magnetic field'''
+
+    # TODO: should lock access to mestate.mlog at this point as we
+    # are temporarily modifying the types of filehandle and data_map
+    # in the parent process
+
+    # capture parent state before modifying
+    filehandle = mestate.mlog.filehandle
+    data_map = mestate.mlog.data_map
+    data_len = mestate.mlog.data_len
+
+    try:
+        # wrap for pickling
+        mestate.mlog.filehandle = WrapFileHandle(filehandle)
+        mestate.mlog.data_map = WrapMMap(data_map,
+                                         filehandle,
+                                         data_len)
+        
         child = multiproc.Process(target=cmd_magfit_child_task,
                                   args=(mestate.mlog, timestamp_in_range))
         child.start()
-    else:
-        from MAVProxy.modules.lib import magfit
-        mfit = magfit.MagFitUI(mestate.mlog, timestamp_in_range)
-        child = multiproc.Process(target=mfit.show)
-        child.start()
-    
+
+    finally:
+        # restore
+        mestate.mlog.filehandle = filehandle
+        mestate.mlog.data_map = data_map
+
+
 def save_graph(graphdef):
     '''save a graph as XML'''
     if graphdef.filename is None:


### PR DESCRIPTION
This change enables the MagFitUI to display on macOS. It is contingent on pickle support for DFReader https://github.com/ArduPilot/pymavlink/pull/480.

An additional function is provided for the UI child process when the platform is macOS which requires DFReader to be pickled. The alternative would be to retain the existing function and provide additional pickle support for the MagFitUI class.   

