### PR TITLE
MAVExplorer FFT support

### DIFF
--- a/MAVProxy/modules/lib/mav_fft.py
+++ b/MAVProxy/modules/lib/mav_fft.py
@@ -11,6 +11,58 @@ import sys
 import time
 
 from pymavlink import mavutil
+from MAVProxy.modules.lib import multiproc
+from MAVProxy.modules.lib.multiproc_util import WrapFileHandle, WrapMMap
+
+class MavFFT(object):
+    '''MavFFT tool
+    
+    Launch the mavfft_display function in another process and manage
+    marshalling the log from the parent to child process. 
+    '''
+
+    def __init__(self, title, mlog, timestamp_in_range):
+        self.title = title
+        self.close_event = multiproc.Event()
+        self.child = None
+
+        # capture mlog state before modifying
+        filehandle = mlog.filehandle
+        data_map = mlog.data_map
+        data_len = mlog.data_len
+
+        try:
+            # wrap filehandle and mmap in mlog for pickling
+            mlog.filehandle = WrapFileHandle(filehandle)
+            mlog.data_map = WrapMMap(data_map, filehandle, data_len)
+
+            # spawn the child process
+            self.child = multiproc.Process(target=self.child_task,
+                                           args=(mlog, timestamp_in_range))
+            self.child.start()
+        finally:
+            # restore the state of mlog
+            mlog.filehandle = filehandle
+            mlog.data_map = data_map
+
+    def child_task(self, mlog, timestamp_in_range):
+        # unwrap
+        mlog.filehandle = mlog.filehandle.unwrap()
+        mlog.data_map = mlog.data_map.unwrap()
+
+        # run the fft tool
+        mavfft_display(mlog, timestamp_in_range)
+
+        # trigger close event when the tool exits 
+        self.close_event.set()
+
+    def close(self):
+        self.close_event.set()
+        if self.is_alive():
+            self.child.join(2)
+
+    def is_alive(self):
+        return self.child.is_alive()
 
 def mavfft_display(mlog,timestamp_in_range):
     '''display fft for raw ACC data in logfile'''

--- a/MAVProxy/tools/MAVExplorer.py
+++ b/MAVProxy/tools/MAVExplorer.py
@@ -417,15 +417,20 @@ def cmd_reload(args):
     setup_menus()
     mestate.console.write("Loaded %u graphs\n" % len(mestate.graphs))
 
+fft_tool = None
+
 def cmd_fft(args):
     '''display fft from log'''
+
     from MAVProxy.modules.lib import mav_fft
     if len(args) > 0:
         condition = args[0]
     else:
         condition = None
-    child = multiproc.Process(target=mav_fft.mavfft_display, args=[mestate.mlog,timestamp_in_range])
-    child.start()
+    global fft_tool
+    fft_tool = mav_fft.MavFFT(title="MavFFT",
+                              mlog=mestate.mlog,
+                              timestamp_in_range=timestamp_in_range)
 
 def cmd_stats(args):
     '''show status on log'''


### PR DESCRIPTION
This PR updates the MAVExplorer `cmd_fft` function to use a new class `MavFFT` which manages the serialisation of the data log between the parent and child processes.

Tested on:
- macOS / Python 3.9
- Windows10 / Python 3.9 (VM)
