### PR TITLE
MavExplorer: Stats for macOS / Windows

### DIFF
--- a/MAVProxy/modules/lib/magfit.py
+++ b/MAVProxy/modules/lib/magfit.py
@@ -434,15 +434,15 @@ class MagFit(MPDataLogChildTask):
             The title of the application
         mlog : DFReader
             A dataflash or telemetry log
-        timestamp_in_range: func
-            A function with one arg that returns True if a time stamp is in range
+        xlimits: MAVExplorer.XLimits
+            An object capturing timestamp limits
         '''
 
         super(MagFit, self).__init__(*args, **kwargs)
 
         # all attributes are implicitly passed to the child process 
         self.title = kwargs['title']
-        self.timestamp_in_range = kwargs['timestamp_in_range']
+        self.xlimits = kwargs['xlimits']
 
     # @override
     def child_task(self):
@@ -456,7 +456,7 @@ class MagFit(MPDataLogChildTask):
         app.frame = MagFitUI(title=self.title,
                              close_event=self.close_event,
                              mlog=self.mlog,
-                             timestamp_in_range=self.timestamp_in_range)
+                             timestamp_in_range=self.xlimits.timestamp_in_range)
 
         app.frame.SetDoubleBuffered(True)
         app.frame.Show()

--- a/MAVProxy/modules/lib/mav_fft.py
+++ b/MAVProxy/modules/lib/mav_fft.py
@@ -22,23 +22,23 @@ class MavFFT(MPDataLogChildTask):
         ----------
         mlog : DFReader
             A dataflash or telemetry log
-        timestamp_in_range: func
-            A function with one arg that returns True if a time stamp is in range
+        xlimits: MAVExplorer.XLimits
+            An object capturing timestamp limits
         '''
 
         super(MavFFT, self).__init__(*args, **kwargs)
 
         # all attributes are implicitly passed to the child process 
-        self.timestamp_in_range = kwargs['timestamp_in_range']
+        self.xlimits = kwargs['xlimits']
 
     # @override
     def child_task(self):
         '''Launch `mavfft_display`'''
 
         # run the fft tool
-        mavfft_display(self.mlog, self.timestamp_in_range)
+        mavfft_display(self.mlog, self.xlimits.timestamp_in_range)
 
-def mavfft_display(mlog,timestamp_in_range):
+def mavfft_display(mlog, timestamp_in_range):
     '''display fft for raw ACC data in logfile'''
 
     '''object to store data about a single FFT plot'''

--- a/MAVProxy/tools/MAVExplorer.py
+++ b/MAVProxy/tools/MAVExplorer.py
@@ -432,11 +432,15 @@ def cmd_fft(args):
                               mlog=mestate.mlog,
                               timestamp_in_range=timestamp_in_range)
 
+msgstats_tool = None
+
 def cmd_stats(args):
     '''show status on log'''
+
     from MAVProxy.modules.lib import msgstats
-    child = multiproc.Process(target=msgstats.show_stats, args=[mestate.mlog])
-    child.start()
+    global msgstats_tool
+    msgstats_tool = msgstats.MavMsgStats(title="Stats",
+                                         mlog=mestate.mlog)
 
 def cmd_dump(args):
     '''dump messages from log'''

--- a/MAVProxy/tools/MAVExplorer.py
+++ b/MAVProxy/tools/MAVExplorer.py
@@ -428,9 +428,9 @@ def cmd_fft(args):
     else:
         condition = None
     global fft_tool
-    fft_tool = mav_fft.MavFFT(title="MavFFT",
-                              mlog=mestate.mlog,
+    fft_tool = mav_fft.MavFFT(mlog=mestate.mlog,
                               timestamp_in_range=timestamp_in_range)
+    fft_tool.start()
 
 msgstats_tool = None
 
@@ -439,8 +439,8 @@ def cmd_stats(args):
 
     from MAVProxy.modules.lib import msgstats
     global msgstats_tool
-    msgstats_tool = msgstats.MavMsgStats(title="Stats",
-                                         mlog=mestate.mlog)
+    msgstats_tool = msgstats.MPMsgStats(mlog=mestate.mlog)
+    msgstats_tool.start()
 
 def cmd_dump(args):
     '''dump messages from log'''
@@ -478,6 +478,7 @@ def cmd_magfit(args):
     mfit_tool = magfit.MagFit(title="MagFit",
                               mlog=mestate.mlog,
                               timestamp_in_range=timestamp_in_range)
+    mfit_tool.start()
 
 def save_graph(graphdef):
     '''save a graph as XML'''


### PR DESCRIPTION
This PR updates enables MAVExplorer > Tools > Stats on macOS / Windows

It also factors out the common code to support child tasks into a small class hierarchy: 

MPChildTask <- MPDataLogChildTask

This reduces much of the duplication in the earlier versions.

Tested on:
- macOS / Python 3.9
- Windows10 / Python 3.9 (VM)