### PR TITLE
live_graph: fix for #867 on macOS

### DIFF
--- a/MAVProxy/modules/lib/MacOS/backend_wxagg.py
+++ b/MAVProxy/modules/lib/MacOS/backend_wxagg.py
@@ -4,8 +4,7 @@ from matplotlib.figure import Figure
 
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.backends import backend_wx    # already uses wxversion.ensureMinimal('2.8')
-from matplotlib.backends.backend_wx import DEBUG_MSG, \
-    error_msg_wx, NavigationToolbar2Wx
+from matplotlib.backends.backend_wx import error_msg_wx, NavigationToolbar2Wx
 from matplotlib.backends.backend_wxagg import FigureManager, FigureCanvasWxAgg, \
     FigureFrameWx, draw_if_interactive, show, backend_version
 import wx
@@ -35,7 +34,6 @@ def new_figure_manager(num, *args, **kwargs):
     """
     # in order to expose the Figure constructor to the pylab
     # interface we need to create the figure here
-    DEBUG_MSG("new_figure_manager()", 3, None)
     backend_wx._create_wx_app()
 
     FigureClass = kwargs.pop('FigureClass', Figure)

--- a/MAVProxy/modules/lib/MacOS/backend_wxagg.py
+++ b/MAVProxy/modules/lib/MacOS/backend_wxagg.py
@@ -2,13 +2,13 @@ from __future__ import division, print_function
 import matplotlib
 from matplotlib.figure import Figure
 
-from backend_agg import FigureCanvasAgg
-import backend_wx    # already uses wxversion.ensureMinimal('2.8')
-from backend_wx import FigureManager, FigureManagerWx, FigureCanvasWx, \
-    FigureFrameWx, DEBUG_MSG, NavigationToolbar2Wx, error_msg_wx, \
-    draw_if_interactive, show, Toolbar, backend_version
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib.backends import backend_wx    # already uses wxversion.ensureMinimal('2.8')
+from matplotlib.backends.backend_wx import DEBUG_MSG, \
+    error_msg_wx, NavigationToolbar2Wx
+from matplotlib.backends.backend_wxagg import FigureManager, FigureCanvasWxAgg, \
+    FigureFrameWx, draw_if_interactive, show, backend_version
 import wx
-
 
 class FigureFrameWxAgg(FigureFrameWx):
     def get_canvas(self, fig):
@@ -16,80 +16,13 @@ class FigureFrameWxAgg(FigureFrameWx):
 
     def _get_toolbar(self, statbar):
         if matplotlib.rcParams['toolbar']=='classic':
-            toolbar = NavigationToolbarWx(self.canvas, True)
+            toolbar = NavigationToolbar2Wx(self.canvas, True)
         elif matplotlib.rcParams['toolbar']=='toolbar2':
             toolbar = NavigationToolbar2WxAgg(self.canvas)
             toolbar.set_status_bar(statbar)
         else:
             toolbar = None
         return toolbar
-
-
-class FigureCanvasWxAgg(FigureCanvasAgg, FigureCanvasWx):
-    """
-    The FigureCanvas contains the figure and does event handling.
-
-    In the wxPython backend, it is derived from wxPanel, and (usually)
-    lives inside a frame instantiated by a FigureManagerWx. The parent
-    window probably implements a wxSizer to control the displayed
-    control size - but we give a hint as to our preferred minimum
-    size.
-    """
-
-    def draw(self, drawDC=None):
-        """
-        Render the figure using agg.
-        """
-        DEBUG_MSG("draw()", 1, self)
-        FigureCanvasAgg.draw(self)
-
-        self.bitmap = _convert_agg_to_wx_bitmap(self.get_renderer(), None)
-        self._isDrawn = True
-        self.gui_repaint(drawDC=drawDC)
-
-    def blit(self, bbox=None):
-        """
-        Transfer the region of the agg buffer defined by bbox to the display.
-        If bbox is None, the entire buffer is transferred.
-        """
-        if bbox is None:
-            self.bitmap = _convert_agg_to_wx_bitmap(self.get_renderer(), None)
-            self.gui_repaint()
-            return
-
-        l, b, w, h = bbox.bounds
-        r = l + w
-        t = b + h
-        x = int(l)
-        y = int(self.bitmap.GetHeight() - t)
-
-        srcBmp = _convert_agg_to_wx_bitmap(self.get_renderer(), None)
-        srcDC = wx.MemoryDC()
-        srcDC.SelectObject(srcBmp)
-
-        destDC = wx.MemoryDC()
-        destDC.SelectObject(self.bitmap)
-
-        destDC.BeginDrawing()
-        destDC.Blit(x, y, int(w), int(h), srcDC, x, y)
-        destDC.EndDrawing()
-
-        destDC.SelectObject(wx.NullBitmap)
-        srcDC.SelectObject(wx.NullBitmap)
-        self.gui_repaint()
-
-    filetypes = FigureCanvasAgg.filetypes
-
-    def print_figure(self, filename, *args, **kwargs):
-        # Use pure Agg renderer to draw
-        FigureCanvasAgg.print_figure(self, filename, *args, **kwargs)
-        # Restore the current view; this is needed because the
-        # artist contains methods rely on particular attributes
-        # of the rendered figure for determining things like
-        # bounding boxes.
-        if self._isDrawn:
-            self.draw()
-
 
 class NavigationToolbar2WxAgg(NavigationToolbar2Wx):
     def get_canvas(self, frame, fig):


### PR DESCRIPTION
This PR is to fix an error in the graph module on macOS raised in issue #867

The change is macOS specific and affects `lib/MacOS/backend_wxagg.py`. It updates import directives to account for interface changes in the `matplotlib.backends` module.

These changes tested on macOS Catalina 10.15.7, Python 3.9.1, matplotlib 3.3.3.

![macos_live_graph_example](https://user-images.githubusercontent.com/24916364/109663603-3620d700-7b64-11eb-9ed2-f7d3bea7b708.png)

My main concern would be support for earlier versions of matplotlib, but we could make it clear in the documentation that a later version is expected and perhaps add matplotlib to `requirements.txt`.
