### PR TITLE
wxsettings: fix for #868 on macOS

### DIFF
--- a/MAVProxy/modules/lib/wxsettings_ui.py
+++ b/MAVProxy/modules/lib/wxsettings_ui.py
@@ -1,3 +1,4 @@
+import sys
 from MAVProxy.modules.lib.wx_loader import wx
 
 class TabbedDialog(wx.Dialog):
@@ -70,7 +71,12 @@ class TabbedDialog(wx.Dialog):
             setting = self.setting_map[label]
             ctrl = self.controls[label]
             value = ctrl.GetValue()
-            if isinstance(value, str) or isinstance(value, unicode):
+
+            # Python 2 compatiblility - alternative is:
+            # import six
+            # isinstance(value, six.string_types)
+            if isinstance(value, str) \
+                or isinstance(value, str if sys.version_info[0] >= 3 else unicode):
                 ctrl.SetValue(str(setting.value))
             else:
                 ctrl.SetValue(setting.value)

--- a/MAVProxy/modules/lib/wxsettings_ui.py
+++ b/MAVProxy/modules/lib/wxsettings_ui.py
@@ -29,10 +29,10 @@ class TabbedDialog(wx.Dialog):
         button_box.Add(self.button_save, 0, wx.ALL)
         button_box.Add(self.button_load, 0, wx.ALL)
         self.dialog_sizer.Add(button_box, 0, wx.GROW|wx.ALL, 5)
-        wx.EVT_BUTTON(self, self.button_cancel.GetId(), self.on_cancel)
-        wx.EVT_BUTTON(self, self.button_apply.GetId(), self.on_apply)
-        wx.EVT_BUTTON(self, self.button_save.GetId(), self.on_save)
-        wx.EVT_BUTTON(self, self.button_load.GetId(), self.on_load)
+        self.Bind(wx.EVT_BUTTON, self.on_cancel, self.button_cancel)
+        self.Bind(wx.EVT_BUTTON, self.on_apply, self.button_apply)
+        self.Bind(wx.EVT_BUTTON, self.on_save, self.button_save)
+        self.Bind(wx.EVT_BUTTON, self.on_load, self.button_load)
         self.Centre()
 
     def on_cancel(self, event):

--- a/MAVProxy/modules/lib/wxsettings_ui.py
+++ b/MAVProxy/modules/lib/wxsettings_ui.py
@@ -28,7 +28,7 @@ class TabbedDialog(wx.Dialog):
         button_box.Add(self.button_apply, 0, wx.ALL)
         button_box.Add(self.button_save, 0, wx.ALL)
         button_box.Add(self.button_load, 0, wx.ALL)
-        self.dialog_sizer.Add(button_box, 0, wx.GROW|wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5)
+        self.dialog_sizer.Add(button_box, 0, wx.GROW|wx.ALL, 5)
         wx.EVT_BUTTON(self, self.button_cancel.GetId(), self.on_cancel)
         wx.EVT_BUTTON(self, self.button_apply.GetId(), self.on_apply)
         wx.EVT_BUTTON(self, self.button_save.GetId(), self.on_save)
@@ -97,7 +97,7 @@ class TabbedDialog(wx.Dialog):
         box.Add( ctrl, 1, wx.ALIGN_CENTRE|wx.ALL, 5 )
         if ctrl2 is not None:
             box.Add( ctrl2, 0, wx.ALIGN_CENTRE|wx.ALL, 5 )
-        self.sizer(tab_name).Add(box, 0, wx.GROW|wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5)
+        self.sizer(tab_name).Add(box, 0, wx.GROW|wx.ALL, 5)
         self.controls[label] = ctrl
         if value is not None:
             ctrl.Value = value


### PR DESCRIPTION
This PR is to fix an error in the console settings module (wxsettings) on macOS raised in issue #868.

The main issue was the use of `wx ALIGN_CENTER_VERTICAL` in vertical sizers which raised an exception in wxPython that prevented the window from displaying.

There are two other minor changes to fix issues that surfaced once the window was working: the first is to replace a deprecated event binding call and the second deals with the Python 2 / 3 treatment of unicode. 

These changes tested on:
- macOS Catalina 10.15.7, Python 3.9.1, wxPython 4.1.0
- Ubuntu 18.04, Python 3.6.9, wxPython 4.1.1
- Ubuntu 18.04, Python 2.7.17, wxPython 4.1.1
- Windows 10, Python 3.9.0, wxPython 4.1.1 (successful when run from PowerShell)
  - (would benefit from further testing on Windows as tests are not successful on all command shells (cmd and cygwin are failing probably due to env set up, MAVProxy run in PowerShell is working) 


![image](https://user-images.githubusercontent.com/24916364/109701176-a0e50900-7b8a-11eb-97f9-a1f648834f6c.png)