### PR TITLE
mavproxy_ftp.py: fix exception in idle task

### DIFF
--- a/MAVProxy/modules/mavproxy_ftp.py
+++ b/MAVProxy/modules/mavproxy_ftp.py
@@ -115,7 +115,7 @@ class FTPModule(mp_module.MPModule):
         self.total_size = 0
         self.read_gaps = []
         self.read_gap_times = {}
-        self.last_gap_send = None
+        self.last_gap_send = 0
         self.read_retries = 0
         self.duplicates = 0
         self.last_read = None


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/pbarker/.local/lib/python2.7/site-packages/MAVProxy-1.8.34-py2.7.egg/EGG-INFO/scripts/mavproxy.py", line 1003, in periodic_tasks
  File "build/bdist.linux-x86_64/egg/MAVProxy/modules/mavproxy_ftp.py", line 753, in idle_task
    self.check_read_send()
  File "build/bdist.linux-x86_64/egg/MAVProxy/modules/mavproxy_ftp.py", line 711, in check_read_send
    if now - self.last_gap_send < 0.05:
TypeError: unsupported operand type(s) for -: 'float' and 'NoneType'
```

I haven't attempted to understand the flow of control in this module to determine if this should always be being set before being checked.

After this patch is applied master ArduPilot produces this:

```
('Read failed with 1 gaps', 'OP seq:5 sess:1 opcode:129 req_opcode:5 size:2 bc:0 ofs:0 plen=2 [2]')
```
