### PR TITLE
Vicon: Fix coordinate frame conventions, add object_name option

### DIFF
--- a/MAVProxy/modules/mavproxy_vicon.py
+++ b/MAVProxy/modules/mavproxy_vicon.py
@@ -10,15 +10,15 @@ from MAVProxy.modules.lib import mp_module
 from MAVProxy.modules.lib import mp_settings
 from MAVProxy.modules.lib import LowPassFilter2p
 from pymavlink.rotmat import Vector3
+from pymavlink.quaternion import Quaternion
 from pymavlink import mavutil
 from pymavlink import mavextra
 
 from pyvicon import pyvicon
-from pymavlink.quaternion import Quaternion
 
 
 def get_gps_time(tnow):
-    '''return gps_week and gps_week_ms for current time'''
+    """return gps_week and gps_week_ms for current time"""
     leapseconds = 18
     SEC_PER_WEEK = 7 * 86400
 
@@ -45,7 +45,8 @@ class ViconModule(mp_module.MPModule):
              ('vel_filter_hz', float, 30.0),
              ('gps_rate', int, 5),
              ('gps_nsats', float, 16),
-             ('yaw_offset', float, 0.0)])
+             ('object_name', str, None)
+             ])
         self.add_command('vicon', self.cmd_vicon, 'VICON control',
                          ["<start>",
                           "<stop>",
@@ -64,33 +65,64 @@ class ViconModule(mp_module.MPModule):
         self.vel_filter = LowPassFilter2p.LowPassFilter2p(200.0, 30.0)
         self.actual_frame_rate = 0.0
 
+    def detect_vicon_object(self):
+        self.vicon.get_frame()
+        object_name = self.vicon_settings.object_name
+        if object_name is None:
+            # We haven't specified which object we are looking for, so just find the first one
+            object_name = self.vicon.get_subject_name(0)
+        if object_name is None:
+            # No objects found
+            return None, None
+        segment_name = self.vicon.get_subject_root_segment_name(object_name)
+        if segment_name is None:
+            # Object we're looking for can't be found
+            return None, None
+        print("Connected to subject '%s' segment '%s'" % (object_name, segment_name))
+        return object_name, segment_name
+
+    def get_vicon_pose(self, object_name, segment_name):
+
+        # get position in mm. Coordinates are in NED
+        vicon_pos = self.vicon.get_segment_global_translation(object_name, segment_name)
+
+        if vicon_pos is None:
+            # Object is not in view
+            return None, None, None, None
+
+        vicon_quat = Quaternion(self.vicon.get_segment_global_quaternion(object_name, segment_name))
+
+        pos_ned = Vector3(vicon_pos * 0.001)
+        euler = vicon_quat.euler
+        roll, pitch, yaw = euler[0], euler[1], euler[2]
+        yaw = math.radians(mavextra.wrap_360(math.degrees(yaw)))
+
+        return pos_ned, roll, pitch, yaw
+
     def thread_loop(self):
-        '''background processing'''
-        name = None
+        """background processing"""
+        object_name = None
+        segment_name = None
         last_pos = None
         last_frame_num = None
+        frame_count = 0
 
         while True:
-            vicon = self.vicon
-            if vicon is None:
+            if self.vicon is None:
                 time.sleep(0.1)
+                object_name = None
                 continue
 
-            if not name:
-                vicon.get_frame()
-                name = vicon.get_subject_name(0)
-                if name is None:
+            if not object_name:
+                object_name, segment_name = self.detect_vicon_object()
+                if object_name is None:
                     continue
-                segname = vicon.get_subject_root_segment_name(name)
-                print("Connected to subject '%s' segment '%s'" % (name, segname))
                 last_msg_time = time.time()
-                last_gps_pos = None
                 now = time.time()
                 last_origin_send = now
                 now_ms = int(now * 1000)
                 last_gps_send_ms = now_ms
-                last_gps_send = now
-                frame_rate = vicon.get_frame_rate()
+                frame_rate = self.vicon.get_frame_rate()
                 frame_dt = 1.0/frame_rate
                 last_rate = time.time()
                 frame_count = 0
@@ -99,11 +131,11 @@ class ViconModule(mp_module.MPModule):
             if self.vicon_settings.gps_rate > 0:
                 gps_period_ms = 1000 // self.vicon_settings.gps_rate
             time.sleep(0.01)
-            vicon.get_frame()
+            self.vicon.get_frame()
             mav = self.master
             now = time.time()
             now_ms = int(now * 1000)
-            frame_num = vicon.get_frame_number()
+            frame_num = self.vicon.get_frame_number()
 
             frame_count += 1
             if now - last_rate > 0.1:
@@ -113,13 +145,11 @@ class ViconModule(mp_module.MPModule):
                 frame_count = 0
                 self.vel_filter.set_cutoff_frequency(self.actual_frame_rate, self.vicon_settings.vel_filter_hz)
 
-            # get position in mm
-            pos_enu = vicon.get_segment_global_translation(name, segname)
-            if pos_enu is None:
+            pos_ned, roll, pitch, yaw = self.get_vicon_pose(object_name, segment_name)
+            if pos_ned is None:
                 continue
-
-            # convert to NED meters
-            pos_ned = Vector3(pos_enu[1]*0.001, pos_enu[0]*0.001, -pos_enu[2]*0.001)
+            
+            # print(f"XYZ: {pos_ned.x}, {pos_ned.y}, {pos_ned.z}, ")
 
             if last_frame_num is None or frame_num - last_frame_num > 100 or frame_num <= last_frame_num:
                 last_frame_num = frame_num
@@ -140,22 +170,9 @@ class ViconModule(mp_module.MPModule):
 
             last_msg_time = now
 
-            # get orientation in euler, converting to ArduPilot conventions
-            quat = vicon.get_segment_global_quaternion(name, segname)
-            q = Quaternion([quat[3], quat[0], quat[1], quat[2]])
-            euler = q.euler
-            roll, pitch, yaw = euler[2], euler[1], euler[0]
-            yaw += math.radians(self.vicon_settings.yaw_offset)
-            yaw = math.radians(mavextra.wrap_360(math.degrees(yaw)))
-
             self.pos = pos_ned
             self.att = [math.degrees(roll), math.degrees(pitch), math.degrees(yaw)]
             self.frame_count += 1
-
-            yaw_cd = int(mavextra.wrap_360(math.degrees(yaw)) * 100)
-            if yaw_cd == 0:
-                # the yaw extension to GPS_INPUT uses 0 as no yaw support
-                yaw_cd = 36000
 
             time_us = int(now * 1.0e6)
 
@@ -173,32 +190,8 @@ class ViconModule(mp_module.MPModule):
 
             if self.vicon_settings.gps_rate > 0 and now_ms - last_gps_send_ms > gps_period_ms:
                 '''send GPS data at the specified rate, trying to align on the given period'''
-                if last_gps_pos is None:
-                    last_gps_pos = pos_ned
-                gps_lat, gps_lon = mavextra.gps_offset(self.vicon_settings.origin_lat,
-                                                       self.vicon_settings.origin_lon,
-                                                       pos_ned.y, pos_ned.x)
-                gps_alt = self.vicon_settings.origin_alt - pos_ned.z
-
-                gps_dt = now - last_gps_send
-                gps_vel = filtered_vel
-                last_gps_pos = pos_ned
-
-                gps_week, gps_week_ms = get_gps_time(now)
-
-                if self.vicon_settings.gps_nsats >= 6:
-                    fix_type = 3
-                else:
-                    fix_type = 1
-                mav.mav.gps_input_send(time_us, 0, 0, gps_week_ms, gps_week, fix_type,
-                                       int(gps_lat*1.0e7), int(gps_lon*1.0e7), gps_alt,
-                                       1.0, 1.0,
-                                       gps_vel.x, gps_vel.y, gps_vel.z,
-                                       0.2, 1.0, 1.0,
-                                       self.vicon_settings.gps_nsats,
-                                       yaw_cd)
+                self.gps_input_send(now, pos_ned, yaw, filtered_vel)
                 last_gps_send_ms = (now_ms//gps_period_ms) * gps_period_ms
-                last_gps_send = now
                 self.gps_count += 1
 
             if self.vicon_settings.vision_rate > 0:
@@ -210,8 +203,32 @@ class ViconModule(mp_module.MPModule):
                                                              roll, pitch, yaw, force_mavlink1=True)
                 self.vision_count += 1
 
+    def gps_input_send(self, time, pos_ned, yaw, gps_vel):
+        time_us = int(time * 1.0e6)
+
+        gps_lat, gps_lon = mavextra.gps_offset(self.vicon_settings.origin_lat,
+                                               self.vicon_settings.origin_lon,
+                                               pos_ned.y, pos_ned.x)
+        gps_alt = self.vicon_settings.origin_alt - pos_ned.z
+        gps_week, gps_week_ms = get_gps_time(time)
+        if self.vicon_settings.gps_nsats >= 6:
+            fix_type = 3
+        else:
+            fix_type = 1
+        yaw_cd = int(mavextra.wrap_360(math.degrees(yaw)) * 100)
+        if yaw_cd == 0:
+            # the yaw extension to GPS_INPUT uses 0 as no yaw support
+            yaw_cd = 36000
+        self.master.mav.gps_input_send(time_us, 0, 0, gps_week_ms, gps_week, fix_type,
+                               int(gps_lat * 1.0e7), int(gps_lon * 1.0e7), gps_alt,
+                               1.0, 1.0,
+                               gps_vel.x, gps_vel.y, gps_vel.z,
+                               0.2, 1.0, 1.0,
+                               self.vicon_settings.gps_nsats,
+                               yaw_cd)
+
     def cmd_start(self):
-        '''start vicon'''
+        """start vicon"""
         vicon = pyvicon.PyVicon()
         print("Opening Vicon connection to %s" % self.vicon_settings.host)
         vicon.connect(self.vicon_settings.host)
@@ -221,11 +238,15 @@ class ViconModule(mp_module.MPModule):
         vicon.enable_segment_data()
         vicon.enable_unlabeled_marker_data()
         vicon.enable_device_data()
+
+        # Set the axis mapping to the ardupilot convention (North, East, Down)
+        vicon.set_axis_mapping(pyvicon.Direction.Forward, pyvicon.Direction.Right, pyvicon.Direction.Down)
+        print(vicon.get_axis_mapping())
         print("vicon ready")
         self.vicon = vicon
 
     def cmd_vicon(self, args):
-        '''command processing'''
+        """command processing"""
         if len(args) == 0:
             print("Usage: vicon <set|start|stop>")
             return
@@ -233,21 +254,20 @@ class ViconModule(mp_module.MPModule):
             self.cmd_start()
         if args[0] == "stop":
             self.vicon = None
-            self.vehicle_name = None
         elif args[0] == "set":
             self.vicon_settings.command(args[1:])
 
     def idle_task(self):
-        '''run on idle'''
+        """run on idle"""
         if not self.pos or not self.att or self.frame_count == self.last_frame_count:
             return
         self.last_frame_count = self.frame_count
-        self.console.set_status('VPos', 'VPos %.2f %.2f %.2f' % (self.pos.x, self.pos.y, self.pos.z), row=5)
-        self.console.set_status('VAtt', 'VAtt %.2f %.2f %.2f GPS %u VIS %u RATE %.1f' % (self.att[0], self.att[1], self.att[2],
+        self.console.set_status('VPos', 'Vicon: Pos: %.2fN %.2fE %.2fD' % (self.pos.x, self.pos.y, self.pos.z), row=5)
+        self.console.set_status('VAtt', ' Att R:%.2f P:%.2f Y:%.2f GPS %u VIS %u RATE %.1f' % (self.att[0], self.att[1], self.att[2],
                                                                                          self.gps_count, self.vision_count,
                                                                                          self.actual_frame_rate), row=5)
 
 
 def init(mpstate):
-    '''initialise module'''
+    """initialise module"""
     return ViconModule(mpstate)


### PR DESCRIPTION
This commit adds the object_name option to the vicon module. If there are multiple objects being tracked by the vicon system, then you can select the object that corresponds to the UAV. If no option is selected, it will select the first object found.

I have also fixed the coordinate frame conventions, so that the vicon system reports the coordinates in NED, which is what ardupilot expects. There are also some fixes to how quaternions are handled, so that the roll pitch are yaw are correctly reported. I have removed the yaw_offset parameter since it is no-longer necessary.

There is an accompanying pull request on the ardupilot wiki ArduPilot/ardupilot_wiki#3510 to document the correct setup for the vicon system.