### PR TITLE
ntrip: support ntrip casters with non ascii header responses

### DIFF
--- a/MAVProxy/modules/lib/ntrip.py
+++ b/MAVProxy/modules/lib/ntrip.py
@@ -146,7 +146,8 @@ class NtripClient(object):
                 self.socket = None
                 casterResponse = ''
             if sys.version_info.major >= 3:
-                casterResponse = str(casterResponse, 'ascii')
+                # Ignore non ascii characters in HTTP response
+                casterResponse = str(casterResponse, 'ascii', 'ignore')
             header_lines = casterResponse.split("\r\n")
             for line in header_lines:
                 if line == "":


### PR DESCRIPTION
Some ntrip casters return non ascii header payload.  Pull request ignores such characters as they are not needed to validate response status

Example, see byte `\xf0`:
`b'ICY 200 OK\r\nServer: GNSS Spider 7.7.0.9065/1.0\r\nDate: tre\xf0d., 11 aug. 2021 07:49:46 GMT\r\n\r\n'`