### PR TITLE
mavproxy_link: understand Swift-Flyer USB device string

### DIFF
--- a/MAVProxy/modules/mavproxy_link.py
+++ b/MAVProxy/modules/mavproxy_link.py
@@ -32,7 +32,9 @@ preferred_ports = [
     '*Hex_*',
     '*Holybro_*',
     '*mRo*',
-    '*FMU*']
+    '*FMU*',
+    '*Swift-Flyer*',
+]
 
 class LinkModule(mp_module.MPModule):
 


### PR DESCRIPTION
as used on F4BY