### PR TITLE
Add icons for console, graph and mavexplorer

### DIFF
--- a/MAVProxy/modules/lib/icon.py
+++ b/MAVProxy/modules/lib/icon.py
@@ -1,0 +1,81 @@
+"""
+  MAVProxy icons generator
+"""
+import numpy as np
+from io import BytesIO
+from matplotlib.figure import Figure
+from matplotlib.gridspec import GridSpec
+import matplotlib.path as mpath
+import matplotlib.patches as mpatches
+from MAVProxy.modules.lib.wx_loader import wx
+
+
+class SimpleIcon():
+    """
+    Generate icons with Matplotlib.
+    """
+    def __init__(self, text=None):
+        LIGHT_BLUE_BACKGROUND = "#afceff"
+        VIOLET_FONT = "#4800f0"
+        t1 = np.arange(0.0, 5.0, 0.1)
+        t2 = np.arange(0.0, 5.0, 0.02)
+
+        def f(t):
+            return np.exp(-t) * np.cos(2*np.pi*t)
+
+        fig = Figure(figsize=(1.28, 1.28), facecolor=LIGHT_BLUE_BACKGROUND)
+        spec = GridSpec(nrows=2, ncols=1, wspace=0, hspace=0.0, height_ratios=[1, 2])
+        ax = fig.add_subplot(spec[0])
+        ax.text(0, 0.8, 'MAV', style='italic', fontsize=20, weight='bold', color=VIOLET_FONT)
+        if text is None:
+            text = "GRAPH"
+        ax.text(0, 0.1, text.upper(), style='italic', fontsize=14, weight='bold', color=VIOLET_FONT)
+        ax.axis('off')
+
+        ax = fig.add_subplot(spec[1], facecolor=LIGHT_BLUE_BACKGROUND)
+        if text == "GRAPH" or text == "EXPLORER":
+            ax.plot(t1, f(t1), color='tab:green', marker='o')
+            ax.plot(t2, f(t2), color='red')
+            ax.set_xticks(t1, minor=True)
+            ax.grid(True, which='both', linestyle="--")
+        if text == "CONSOLE":
+            ax.plot([0, 2.5], [2.5, 1.25], color='red', linewidth=4)
+            ax.plot([0, 2.5], [0, 1.25], color='red', linewidth=4)
+            ax.plot([3, 5], [0, 0], color='red', linewidth=4)
+            ax.axis('off')
+        if text == "MAP":
+            path_data = [
+                (mpath.Path.MOVETO, [2.5, 0]),
+                (mpath.Path.LINETO, [1.25, 2.5]),
+                (mpath.Path.CURVE3, [2.5, 5]),
+                (mpath.Path.CURVE3, [3.75, 2.5]),
+                (mpath.Path.LINETO, [3.75, 2.5]),
+                (mpath.Path.CLOSEPOLY, [2.5, 0])]
+            codes, verts = zip(*path_data)
+            path = mpath.Path(verts, codes)
+
+            patch = mpatches.PathPatch(path, facecolor='red', lw=2)
+            ax.add_patch(patch)
+            circle_neg = mpatches.Circle((2.5, 2.5), 0.5, color='white')
+            ax.add_patch(circle_neg)
+
+            ax.plot([0, 5/3.0, 10/3.0, 5], [5, 4, 5, 4], color='black', linewidth=2)
+            ax.plot([0, 5/3.0, 10/3.0, 5], [-1, -2, -1, -2], color='black', linewidth=2)
+            ax.plot([0, 0], [-1, 5], color='black', linewidth=2)
+            ax.plot([5/3.0, 5/3.0], [-2, 4], color='black', linewidth=2)
+            ax.plot([10/3.0, 10/3.0], [-1, 5], color='black', linewidth=2)
+            ax.plot([5, 5], [-2, 4], color='black', linewidth=2)
+            ax.set_xlim(-0.5, 5.5)
+            ax.set_ylim(-2.5, 5.5)
+            ax.axis('off')
+
+        buf = BytesIO()
+        fig.savefig(buf, format='png')
+        buf.seek(0)
+        svgimg = wx.Image(buf, wx.BITMAP_TYPE_PNG)
+        self.img = svgimg
+
+    def get_ico(self):
+        """Get the ico from the image bitmap.
+        need to be call after the wx.app is created."""
+        return wx.Icon(wx.Bitmap(self.img))

--- a/MAVProxy/modules/lib/live_graph_ui.py
+++ b/MAVProxy/modules/lib/live_graph_ui.py
@@ -1,4 +1,5 @@
 from MAVProxy.modules.lib.wx_loader import wx
+from MAVProxy.modules.lib import icon
 import time
 import numpy, pylab
 
@@ -8,6 +9,7 @@ class GraphFrame(wx.Frame):
 
     def __init__(self, state):
         wx.Frame.__init__(self, None, -1, state.title)
+        self.SetIcon(icon.SimpleIcon().get_ico())
         self.state = state
         self.data = []
         for i in range(len(state.fields)):

--- a/MAVProxy/modules/lib/wxconsole.py
+++ b/MAVProxy/modules/lib/wxconsole.py
@@ -16,9 +16,11 @@ class MessageConsole(textconsole.SimpleConsole):
     a message console for MAVProxy
     '''
     def __init__(self,
-                 title='MAVProxy: console'):
+                 title='MAVProxy: console',
+                 ico=None):
         textconsole.SimpleConsole.__init__(self)
-        self.title  = title
+        self.title = title
+        self.ico = ico
         self.menu_callback = None
         self.parent_pipe_recv,self.child_pipe_send = multiproc.Pipe(duplex=False)
         self.child_pipe_recv,self.parent_pipe_send = multiproc.Pipe(duplex=False)
@@ -41,7 +43,7 @@ class MessageConsole(textconsole.SimpleConsole):
         from MAVProxy.modules.lib.wx_loader import wx
         from MAVProxy.modules.lib.wxconsole_ui import ConsoleFrame
         app = wx.App(False)
-        app.frame = ConsoleFrame(state=self, title=self.title)
+        app.frame = ConsoleFrame(state=self, title=self.title, ico=self.ico)
         app.frame.SetDoubleBuffered(True)
         app.frame.Show()
         app.MainLoop()

--- a/MAVProxy/modules/lib/wxconsole_ui.py
+++ b/MAVProxy/modules/lib/wxconsole_ui.py
@@ -8,9 +8,11 @@ from MAVProxy.modules.lib import win_layout
 class ConsoleFrame(wx.Frame):
     """ The main frame of the console"""
 
-    def __init__(self, state, title):
+    def __init__(self, state, title, ico=None):
         self.state = state
         wx.Frame.__init__(self, None, title=title, size=(800,300))
+        if ico is not None:
+            self.SetIcon(ico.get_ico())
         self.panel = wx.Panel(self)
         self.panel.SetBackgroundColour('white')
         state.frame = self

--- a/MAVProxy/modules/mavproxy_console.py
+++ b/MAVProxy/modules/mavproxy_console.py
@@ -14,6 +14,7 @@ from MAVProxy.modules.lib import mp_util
 from MAVProxy.modules.lib import mp_module
 from MAVProxy.modules.lib import wxsettings
 from MAVProxy.modules.lib.mp_menu import *
+from MAVProxy.modules.lib import icon
 
 class DisplayItem:
     def __init__(self, fmt, expression, row):
@@ -37,7 +38,7 @@ class ConsoleModule(mp_module.MPModule):
         self.user_added = {}
         self.safety_on = False
         self.add_command('console', self.cmd_console, "console module", ['add','list','remove'])
-        mpstate.console = wxconsole.MessageConsole(title='Console')
+        mpstate.console = wxconsole.MessageConsole(title='Console', ico=icon.SimpleIcon("CONSOLE"))
 
         # setup some default status information
         mpstate.console.set_status('Mode', 'UNKNOWN', row=0, fg='blue')

--- a/MAVProxy/modules/mavproxy_map/mp_slipmap_ui.py
+++ b/MAVProxy/modules/mavproxy_map/mp_slipmap_ui.py
@@ -30,6 +30,7 @@ from MAVProxy.modules.mavproxy_map.mp_slipmap_util import SlipFollowObject
 
 from MAVProxy.modules.lib import mp_util
 from MAVProxy.modules.lib import win_layout
+from MAVProxy.modules.lib import icon
 
 from MAVProxy.modules.lib.mp_menu import MPMenuCheckbox
 from MAVProxy.modules.lib.mp_menu import MPMenuItem
@@ -44,6 +45,7 @@ class MPSlipMapFrame(wx.Frame):
     """
     def __init__(self, state):
         wx.Frame.__init__(self, None, wx.ID_ANY, state.title)
+        self.SetIcon(icon.SimpleIcon("MAP").get_ico())
         self.state = state
         state.frame = self
         state.grid = True

--- a/MAVProxy/tools/MAVExplorer.py
+++ b/MAVProxy/tools/MAVExplorer.py
@@ -26,6 +26,7 @@ from pymavlink import mavutil
 from MAVProxy.modules.lib.mp_settings import MPSettings, MPSetting
 from MAVProxy.modules.lib import wxsettings
 from MAVProxy.modules.lib.graphdefinition import GraphDefinition
+from MAVProxy.modules.lib import icon
 from lxml import objectify
 import pkg_resources
 from builtins import input
@@ -86,7 +87,7 @@ class MEState(object):
     def __init__(self):
         self.input_queue = multiproc.Queue()
         self.rl = None
-        self.console = wxconsole.MessageConsole(title='MAVExplorer')
+        self.console = wxconsole.MessageConsole(title='MAVExplorer', ico=icon.SimpleIcon("EXPLORER"))
         self.exit = False
         self.status = MEStatus()
         self.settings = MPSettings(


### PR DESCRIPTION
This add a simple icon.py script that allow to generate icons for mavproxy with the help of Matplotlib.
There is a two steps loading as we cannot use the wx function before the application is created.
It doesn't bring more dependencies.

Rendering on Ubuntu with xorg. (tried on wayland, but icon aren't displayed, another wayland weirdness)
![Capture d’écran de 2021-08-31 16-13-59](https://user-images.githubusercontent.com/705341/131519772-dcbac6f9-7404-4b51-b756-dab435817588.png)
![Capture d’écran de 2021-08-31 16-13-28](https://user-images.githubusercontent.com/705341/131519794-eca89c68-6480-49a9-858e-14d227b2b19c.png)
