### PR TITLE
Added parameter help in MAVExplorer

### DIFF
--- a/MAVProxy/modules/lib/param_help.py
+++ b/MAVProxy/modules/lib/param_help.py
@@ -111,9 +111,6 @@ class ParamHelp:
                 except Exception as e:
                     pass
                 try:
-                    # The entry "values" has been blatted by a cython
-                    # function at this point, so we instead get the
-                    # "values" by offset rather than name.
                     values = self.get_Values_from_help(help)
                     if len(values):
                         print("\nValues: ")

--- a/MAVProxy/modules/lib/param_help.py
+++ b/MAVProxy/modules/lib/param_help.py
@@ -1,0 +1,167 @@
+import time, os
+from pymavlink import mavutil, mavparm
+from MAVProxy.modules.lib import mp_util
+from MAVProxy.modules.lib import multiproc
+
+class ParamHelp:
+    def __init__(self):
+        self.xml_filepath = None
+        self.vehicle_name = None
+
+    def param_help_download(self):
+        '''download XML files for parameters'''
+        files = []
+        for vehicle in ['Rover', 'ArduCopter', 'ArduPlane', 'ArduSub', 'AntennaTracker']:
+            url = 'http://autotest.ardupilot.org/Parameters/%s/apm.pdef.xml.gz' % vehicle
+            path = mp_util.dot_mavproxy("%s.xml" % vehicle)
+            files.append((url, path))
+            url = 'http://autotest.ardupilot.org/%s-defaults.parm' % vehicle
+            if vehicle != 'AntennaTracker':
+                # defaults not generated for AntennaTracker ATM
+                path = mp_util.dot_mavproxy("%s-defaults.parm" % vehicle)
+                files.append((url, path))
+        try:
+            child = multiproc.Process(target=mp_util.download_files, args=(files,))
+            child.start()
+        except Exception as e:
+            print(e)
+
+    def param_use_xml_filepath(self, filepath):
+        self.xml_filepath = filepath
+
+    def param_help_tree(self):
+        '''return a "help tree", a map between a parameter and its metadata.  May return None if help is not available'''
+        if self.xml_filepath is not None:
+            print("param: using xml_filepath=%s" % self.xml_filepath)
+            path = self.xml_filepath
+        else:
+            if self.vehicle_name is None:
+                print("Unknown vehicle type")
+                return None
+            path = mp_util.dot_mavproxy("%s.xml" % self.vehicle_name)
+            if not os.path.exists(path):
+                print("Please run 'param download' first (vehicle_name=%s)" % self.vehicle_name)
+                return None
+        if not os.path.exists(path):
+            print("Param XML (%s) does not exist" % path)
+            return None
+        xml = open(path,'rb').read()
+        from lxml import objectify
+        objectify.enable_recursive_str()
+        tree = objectify.fromstring(xml)
+        htree = {}
+        for p in tree.vehicles.parameters.param:
+            n = p.get('name').split(':')[1]
+            htree[n] = p
+        for lib in tree.libraries.parameters:
+            for p in lib.param:
+                n = p.get('name')
+                htree[n] = p
+        return htree
+
+    def param_set_xml_filepath(self, args):
+        self.xml_filepath = args[0]
+
+    def param_apropos(self, args):
+        '''search parameter help for a keyword, list those parameters'''
+        if len(args) == 0:
+            print("Usage: param apropos keyword")
+            return
+
+        htree = self.param_help_tree()
+        if htree is None:
+            return
+
+        contains = {}
+        for keyword in args:
+            keyword = keyword.lower()
+            for param in htree.keys():
+                if str(htree[param]).lower().find(keyword) != -1:
+                    contains[param] = True
+        for param in contains.keys():
+            print("%s" % (param,))
+
+    def get_Values_from_help(self, help):
+        children = help.getchildren()
+        if len(children) == 0:
+            return []
+        vchild = children[0]
+        return vchild.getchildren()
+            
+    def param_help(self, args):
+        '''show help on a parameter'''
+        if len(args) == 0:
+            print("Usage: param help PARAMETER_NAME")
+            return
+
+        htree = self.param_help_tree()
+        if htree is None:
+            return
+
+        for h in args:
+            h = h.upper()
+            if h in htree:
+                help = htree[h]
+                print("%s: %s\n" % (h, help.get('humanName')))
+                print(help.get('documentation'))
+                try:
+                    print("\n")
+                    for f in help.field:
+                        print("%s : %s" % (f.get('name'), str(f)))
+                except Exception as e:
+                    pass
+                try:
+                    # The entry "values" has been blatted by a cython
+                    # function at this point, so we instead get the
+                    # "values" by offset rather than name.
+                    values = self.get_Values_from_help(help)
+                    if len(values):
+                        print("\nValues: ")
+                        for v in values:
+                            print("\t%s : %s" % (v.get('code'), str(v)))
+                except Exception as e:
+                    print("Caught exception %s" % repr(e))
+                    pass
+            else:
+                print("Parameter '%s' not found in documentation" % h)
+            
+    def param_check(self, params, args):
+        '''Check through parameters for obvious misconfigurations'''
+        problems_found = False
+        htree = self.param_help_tree()
+        if htree is None:
+            return
+        for param in params.keys():
+            if param.startswith("SIM_"):
+                # no documentation for these ATM
+                continue
+            value = params[param]
+#            print("%s: %s" % (param, str(value)))
+            try:
+                help = htree[param]
+            except KeyError:
+                print("%s: not found in documentation" % (param,))
+                problems_found = True
+                continue
+
+            # we'll ignore the Values field if there's a bitmask field
+            # involved as they're usually just examples.
+            has_bitmask = False
+            for f in getattr(help, "field", []):
+                if f.get('name') == "Bitmask":
+                    has_bitmask = True
+                    break
+            if not has_bitmask:
+                values = self.get_Values_from_help(help)
+                if len(values) == 0:
+                    # no prescribed values list
+                    continue
+                value_values = [float(x.get("code")) for x in values]
+                if value not in value_values:
+                    print("%s: value %f not in Values (%s)" %
+                          (param, value, str(value_values)))
+                    problems_found = True
+
+        if problems_found:
+            print("Remember to `param download` before trusting the checking!  Also, remember that parameter documentation is for *master*!")
+

--- a/MAVProxy/modules/mavproxy_param.py
+++ b/MAVProxy/modules/mavproxy_param.py
@@ -436,15 +436,32 @@ class ParamState:
         elif args[0] == "set_xml_filepath":
             self.param_set_xml_filepath(args[1:])
         elif args[0] == "show":
+            verbose = False
             if len(args) > 1:
                 pattern = args[1]
+                if len(args) > 2 and args[2] == '-v':
+                    verbose = True
             else:
                 pattern = "*"
-            self.mav_param.show(pattern)
+            self.param_show(pattern, verbose)
         elif args[0] == "status":
             print("Have %u/%u params" % (len(self.mav_param_set), self.mav_param_count))
         else:
             print(usage)
+
+    def param_show(self, pattern, verbose):
+        '''show parameters'''
+        k = sorted(self.mav_param.keys())
+        for p in k:
+            name = str(p).upper()
+            if fnmatch.fnmatch(name, pattern.upper()):
+                value = self.mav_param.get(name)
+                s = "%-16.16s %s" % (name, value)
+                if verbose:
+                    info = self.param_help.param_info(name, value)
+                    if info is not None:
+                        s = "%-28.28s # %s" % (s, info)
+                print(s)
 
     def ftp_upload_callback(self, dlen):
         '''callback on ftp put completion'''

--- a/MAVProxy/tools/MAVExplorer.py
+++ b/MAVProxy/tools/MAVExplorer.py
@@ -777,6 +777,7 @@ def set_vehicle_name():
 
 def cmd_param(args):
     '''show parameters'''
+    verbose = False
     if len(args) > 0:
         if args[0] == 'help':
             set_vehicle_name()
@@ -790,12 +791,20 @@ def cmd_param(args):
             mestate.param_help.param_check(mestate.mlog.params, args[1:])
             return
         wildcard = args[0]
+        if len(args) > 1 and args[1] == "-v":
+            set_vehicle_name()
+            verbose = True
     else:
         wildcard = '*'
     k = sorted(mestate.mlog.params.keys())
     for p in k:
         if fnmatch.fnmatch(str(p).upper(), wildcard.upper()):
-            print("%-16.16s %f" % (str(p), mestate.mlog.params[p]))
+            s = "%-16.16s %f" % (str(p), mestate.mlog.params[p])
+            if verbose:
+                info = mestate.param_help.param_info(p, mestate.mlog.params[p])
+                if info is not None:
+                    s += " # %s" % info
+            print(s)
 
 def cmd_paramchange(args):
     '''show param changes'''


### PR DESCRIPTION
This makes parameter help available in MAVExplorer.

Examples:
 param help ARMING_CHECK
 param ARMING* -v
 param SERV*ION -v

it displays values and bitmasks with -v, for example:
```
Q_TAILSIT_MOTMX  15.000000 # Motor 1|Motor 2|Motor 3|Motor 4
SERVO1_FUNCTION  36.000000 # Motor4
```

verbose show also works in mavproxy:
  param show SER*ION -v
```
SERVO10_FUNCTION 0.0 # Disabled
SERVO11_FUNCTION 0.0 # Disabled
SERVO12_FUNCTION 0.0 # Disabled
SERVO13_FUNCTION 0.0 # Disabled
SERVO14_FUNCTION 0.0 # Disabled
SERVO15_FUNCTION 0.0 # Disabled
SERVO16_FUNCTION 0.0 # Disabled
SERVO1_FUNCTION  4.0 # Aileron
SERVO2_FUNCTION  19.0 # Elevator
SERVO3_FUNCTION  70.0 # Throttle
SERVO4_FUNCTION  21.0 # Rudder
SERVO5_FUNCTION  33.0 # Motor1
SERVO6_FUNCTION  34.0 # Motor2
SERVO7_FUNCTION  35.0 # Motor3
SERVO8_FUNCTION  36.0 # Motor4
SERVO9_FUNCTION  27.0 # Parachute
```
