### PR TITLE
Windows: Fix console icons to work under Windows

### DIFF
--- a/MAVProxy/modules/lib/wxconsole.py
+++ b/MAVProxy/modules/lib/wxconsole.py
@@ -16,11 +16,9 @@ class MessageConsole(textconsole.SimpleConsole):
     a message console for MAVProxy
     '''
     def __init__(self,
-                 title='MAVProxy: console',
-                 ico=None):
+                 title='MAVProxy: console'):
         textconsole.SimpleConsole.__init__(self)
         self.title = title
-        self.ico = ico
         self.menu_callback = None
         self.parent_pipe_recv,self.child_pipe_send = multiproc.Pipe(duplex=False)
         self.child_pipe_recv,self.parent_pipe_send = multiproc.Pipe(duplex=False)
@@ -43,7 +41,7 @@ class MessageConsole(textconsole.SimpleConsole):
         from MAVProxy.modules.lib.wx_loader import wx
         from MAVProxy.modules.lib.wxconsole_ui import ConsoleFrame
         app = wx.App(False)
-        app.frame = ConsoleFrame(state=self, title=self.title, ico=self.ico)
+        app.frame = ConsoleFrame(state=self, title=self.title)
         app.frame.SetDoubleBuffered(True)
         app.frame.Show()
         app.MainLoop()

--- a/MAVProxy/modules/lib/wxconsole_ui.py
+++ b/MAVProxy/modules/lib/wxconsole_ui.py
@@ -4,15 +4,19 @@ from MAVProxy.modules.lib import mp_menu
 from MAVProxy.modules.lib.wxconsole_util import Value, Text
 from MAVProxy.modules.lib.wx_loader import wx
 from MAVProxy.modules.lib import win_layout
+from MAVProxy.modules.lib import icon
 
 class ConsoleFrame(wx.Frame):
     """ The main frame of the console"""
 
-    def __init__(self, state, title, ico=None):
+    def __init__(self, state, title):
         self.state = state
         wx.Frame.__init__(self, None, title=title, size=(800,300))
-        if ico is not None:
-            self.SetIcon(ico.get_ico())
+        # different icons for MAVExplorer and MAVProxy
+        if title == "MAVExplorer":
+            self.SetIcon(icon.SimpleIcon("EXPLORER").get_ico())
+        else:
+            self.SetIcon(icon.SimpleIcon("CONSOLE").get_ico())
         self.panel = wx.Panel(self)
         self.panel.SetBackgroundColour('white')
         state.frame = self

--- a/MAVProxy/modules/mavproxy_console.py
+++ b/MAVProxy/modules/mavproxy_console.py
@@ -14,7 +14,6 @@ from MAVProxy.modules.lib import mp_util
 from MAVProxy.modules.lib import mp_module
 from MAVProxy.modules.lib import wxsettings
 from MAVProxy.modules.lib.mp_menu import *
-from MAVProxy.modules.lib import icon
 
 class DisplayItem:
     def __init__(self, fmt, expression, row):
@@ -38,7 +37,7 @@ class ConsoleModule(mp_module.MPModule):
         self.user_added = {}
         self.safety_on = False
         self.add_command('console', self.cmd_console, "console module", ['add','list','remove'])
-        mpstate.console = wxconsole.MessageConsole(title='Console', ico=icon.SimpleIcon("CONSOLE"))
+        mpstate.console = wxconsole.MessageConsole(title='Console')
 
         # setup some default status information
         mpstate.console.set_status('Mode', 'UNKNOWN', row=0, fg='blue')

--- a/MAVProxy/tools/MAVExplorer.py
+++ b/MAVProxy/tools/MAVExplorer.py
@@ -28,7 +28,6 @@ from pymavlink import mavutil
 from MAVProxy.modules.lib.mp_settings import MPSettings, MPSetting
 from MAVProxy.modules.lib import wxsettings
 from MAVProxy.modules.lib.graphdefinition import GraphDefinition
-from MAVProxy.modules.lib import icon
 from lxml import objectify
 import pkg_resources
 from builtins import input
@@ -89,7 +88,7 @@ class MEState(object):
     def __init__(self):
         self.input_queue = multiproc.Queue()
         self.rl = None
-        self.console = wxconsole.MessageConsole(title='MAVExplorer', ico=icon.SimpleIcon("EXPLORER"))
+        self.console = wxconsole.MessageConsole(title='MAVExplorer')
         self.exit = False
         self.status = MEStatus()
         self.settings = MPSettings(


### PR DESCRIPTION
This patches f1eb929ff11aa78ec379423143db0a67417f7c0f to work under Windows.

Tested in Ubuntu too.