### PR TITLE
MAVExplorer: Add custom labels to xml graphs

### DIFF
--- a/MAVProxy/modules/lib/graphdefinition.py
+++ b/MAVProxy/modules/lib/graphdefinition.py
@@ -4,9 +4,10 @@ GraphDefinition class
 
 class GraphDefinition(object):
     '''a pre-defined graph'''
-    def __init__(self, name, expression, description, expressions, filename):
+    def __init__(self, name, expression, description, expressions, filename, label_or=None):
         self.name = name
         self.expression = expression
         self.description = description
         self.expressions = expressions
         self.filename = filename
+        self.label_override = label_or

--- a/MAVProxy/tools/MAVExplorer.py
+++ b/MAVProxy/tools/MAVExplorer.py
@@ -306,7 +306,11 @@ def load_graph_xml(xml, filename, load_all=False):
                     description = g.description.text
                 else:
                     description = ''
-                ret.append(GraphDefinition(name, e, description, expressions, filename))
+                # add a legend label overide if the xml feild has been populated
+                label_overide = None
+                if hasattr(g,'label'):
+                    label_overide = g.label.text
+                ret.append(GraphDefinition(name, e, description, expressions, filename, label_overide))
                 break
     return ret
 
@@ -379,6 +383,17 @@ def cmd_graph(args):
         # write desciption to console
         if g.description:
             mestate.console.write("%s\n" % g.description, fg='blue')
+        # check for label overides. These were defined using <label> in the .xml files.
+        label = []
+        if g.label_override is not None:
+            label = g.label_override.split()
+            # only add the label override if the number of labels matches the number of expressions
+            if len(label) == len(args):
+                # amend the expression to add the label overide syntax
+                amended = ''
+                for j,e in enumerate(args):
+                    amended = '%s %s<%s>' % (amended,e,label[j])
+                g.expression = amended
         mestate.rl.add_history("graph %s" % ' '.join(expression.split()))
         mestate.last_graph = g
     else:

--- a/MAVProxy/tools/MAVExplorer.py
+++ b/MAVProxy/tools/MAVExplorer.py
@@ -370,11 +370,13 @@ def cmd_graph(args):
         print(usage)
         return
     if args[0][0] == ':':
+        # then this is a predefined graph from an xml file
         i = int(args[0][1:])
         g = mestate.graphs[i]
         expression = g.expression
         args = expression.split()
         mestate.console.write("Added graph: %s\n" % g.name)
+        # write desciption to console
         if g.description:
             mestate.console.write("%s\n" % g.description, fg='blue')
         mestate.rl.add_history("graph %s" % ' '.join(expression.split()))

--- a/MAVProxy/tools/graphs/mavgraphs2.xml
+++ b/MAVProxy/tools/graphs/mavgraphs2.xml
@@ -390,4 +390,21 @@
   <expression>PIDS.P PIDS.I PIDS.D</expression>
  </graph>
 
+ <graph name='Servos/X8 Mean Motor Yaw CCW-CW'>
+  <description>Average motor contibution to yaw</description>
+  <expression>(RCOU.C5+RCOU.C7+RCOU.C1+RCOU.C3)/4 (RCOU.C6+RCOU.C8+RCOU.C4+RCOU.C2)/4</expression>
+  <label>CCW(C1,C3,C5,C7) CW(C2,C4,C6,C8)</label>
+ </graph>
+
+  <graph name='Servos/X8 Mean Roll P-SB'>
+  <description>Average motor contibution to Roll</description>
+  <expression>(RCOU.C2+RCOU.C5+RCOU.C3+RCOU.C8)/4 (RCOU.C1+RCOU.C6+RCOU.C4+RCOU.C7)/4</expression>
+  <label>Port(C2,C3,C5,C8) Starboard(C1,C4,C6,C7)</label>
+ </graph>
+
+  <graph name='Servos/X8 Mean Pitch Rear-Fwd'>
+  <description>Average motor contibution to Pitch</description>
+  <expression>(RCOU.C3+RCOU.C8+RCOU.C4+RCOU.C7)/4 (RCOU.C2+RCOU.C5+RCOU.C1+RCOU.C6)/4</expression>
+  <label>Rear(C3,C4,C7,C8) Forward(C1,C2,C5,C6)</label>
+ </graph>
 </graphs>


### PR DESCRIPTION
This PR adds the custom legend label override functionality to the XML graphs.

Sometimes I prefer a 'prettier' label over the sometimes long expressions in the ledged label.  So this adds the ability to the predfined xml graphs.  There a few examples added as well.  E.g:

![image](https://user-images.githubusercontent.com/34512430/134578527-e5f172ed-85e7-4643-b773-cec49f5270ef.png)

comes from:

![image](https://user-images.githubusercontent.com/34512430/134578610-0b0ed7a9-5270-4ff3-ae68-c85fbcbcb7ac.png)

I also snuck a few extra comments in there as a seperate commit :-)