### PR TITLE
Option to block auto parameters upload. Params preload in console.

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -314,6 +314,7 @@ class MPState(object):
         self.functions = MAVFunctions()
         self.select_extra = {}
         self.continue_mode = False
+        self.params_from_file = False
         self.aliases = {}
         import platform
         self.system = platform.system()
@@ -1236,6 +1237,7 @@ if __name__ == '__main__':
     parser.add_option("--mavversion", type='choice', choices=['1.0', '2.0'] , help="Force MAVLink Version (1.0, 2.0). Otherwise autodetect version")
     parser.add_option("--nowait", action='store_true', default=False, help="don't wait for HEARTBEAT on startup")
     parser.add_option("-c", "--continue", dest='continue_mode', action='store_true', default=False, help="continue logs")
+    parser.add_option("--no_params_upload", dest='params_auto_upload', action='store_false', default=True, help="No params auto upload")
     parser.add_option("--dialect",  default="ardupilotmega", help="MAVLink dialect")
     parser.add_option("--rtscts",  action='store_true', help="enable hardware RTS/CTS flow control")
     parser.add_option("--moddebug",  type=int, help="module debug level", default=0)
@@ -1282,6 +1284,7 @@ if __name__ == '__main__':
     mpstate.status.exit = False
     mpstate.command_map = command_map
     mpstate.continue_mode = opts.continue_mode
+    mpstate.params_auto_upload = opts.params_auto_upload
     # queues for logging
     mpstate.logqueue = Queue.Queue()
     mpstate.logqueue_raw = Queue.Queue()

--- a/MAVProxy/modules/mavproxy_param.py
+++ b/MAVProxy/modules/mavproxy_param.py
@@ -114,7 +114,7 @@ class ParamState:
                 if self.logdir is not None:
                     self.mav_param.save(os.path.join(self.logdir, self.parm_file), '*', verbose=True)
                 self.fetch_set = None
-            if self.fetch_set is not None and len(self.fetch_set) == 0:
+            if self.fetch_set is not None and len(self.fetch_set) == 0 and self.mpstate.params_auto_upload:
                 self.fetch_check(master, force=True)
         elif m.get_type() == 'HEARTBEAT':
             if m.get_srcComponent() == 1:
@@ -126,7 +126,7 @@ class ParamState:
         if self.param_period.trigger() or force:
             if master is None:
                 return
-            if len(self.mav_param_set) == 0 and not self.ftp_started:
+            if len(self.mav_param_set) == 0 and not self.ftp_started and self.mpstate.params_auto_upload:
                 if not self.use_ftp():
                     master.param_fetch_all()
                 else:
@@ -573,6 +573,10 @@ class ParamModule(mp_module.MPModule):
                                                     handler=MPMenuCallFileDialog(flags=('open',),
                                                                                  title='Param Load',
                                                                                  wildcard='ParmFiles(*.parm,*.param)|*.parm;*.param')),
+                                         MPMenuItem('Preload', 'Preload', '# param preload ',
+                                                    handler=MPMenuCallFileDialog(flags=('open',),
+                                                                                 title='Param Preload',
+                                                                                 wildcard='ParmFiles(*.parm,*.param)|*.parm;*.param')),
                                          MPMenuItem('Save', 'Save', '# param save ',
                                                     handler=MPMenuCallFileDialog(flags=('save', 'overwrite_prompt'),
                                                                                  title='Param Save',
@@ -601,7 +605,7 @@ class ParamModule(mp_module.MPModule):
         if self.continue_mode and self.logdir is not None:
             parmfile = os.path.join(self.logdir, fname)
             if os.path.exists(parmfile):
-                mpstate.mav_param.load(parmfile)
+                self.mpstate.mav_param.load(parmfile)
                 self.pstate[sysid].mav_param_set = set(self.mav_param.keys())
         self.pstate[sysid].param_help.xml_filepath = self.xml_filepath
 


### PR DESCRIPTION
Command option --no_params_upload added to prevent parameters upload.
Added console option for preload.  

Target is for use in bandwidth limited systems where parameter loading takes 5min+.
Existing console load does not work since there are no parameters to load against.

Should this be/also be a setting?  Is a per-vehicle setting required?