### PR TITLE
Graph: Catch exception in Windows

### DIFF
--- a/MAVProxy/modules/lib/graph_ui.py
+++ b/MAVProxy/modules/lib/graph_ui.py
@@ -52,11 +52,11 @@ class Graph_UI(object):
         if self.xlim_pipe is None:
             return None
         xlim = None
-        while self.xlim_pipe[0].poll():
-            try:
+        try:
+            while self.xlim_pipe[0].poll():
                 xlim = self.xlim_pipe[0].recv()
-            except EOFError:
-                return None
+        except (EOFError, BrokenPipeError):
+            return None
         if xlim != self.xlim:
             return xlim
         return None


### PR DESCRIPTION
This patch fixes an ``BrokenPipeError`` exception when running under Windows.
