### PR TITLE
Option --no_param_auto_fetch to only fetch params on request. Preload added to menu.

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -1236,6 +1236,7 @@ if __name__ == '__main__':
     parser.add_option("--mavversion", type='choice', choices=['1.0', '2.0'] , help="Force MAVLink Version (1.0, 2.0). Otherwise autodetect version")
     parser.add_option("--nowait", action='store_true', default=False, help="don't wait for HEARTBEAT on startup")
     parser.add_option("-c", "--continue", dest='continue_mode', action='store_true', default=False, help="continue logs")
+    parser.add_option("--no_auto_fetch", dest='params_auto_fetch', action='store_false', default=True, help="Do not auto fetch parameters on vehicle detect")
     parser.add_option("--dialect",  default="ardupilotmega", help="MAVLink dialect")
     parser.add_option("--rtscts",  action='store_true', help="enable hardware RTS/CTS flow control")
     parser.add_option("--moddebug",  type=int, help="module debug level", default=0)
@@ -1282,6 +1283,7 @@ if __name__ == '__main__':
     mpstate.status.exit = False
     mpstate.command_map = command_map
     mpstate.continue_mode = opts.continue_mode
+    mpstate.params_auto_fetch = opts.params_auto_fetch
     # queues for logging
     mpstate.logqueue = Queue.Queue()
     mpstate.logqueue_raw = Queue.Queue()


### PR DESCRIPTION
Command option --no_param_auto_fetch added to prevent parameters upload.
Added console menu option for preload.  This was necessary for testing.

Adding some state tracking to enable parameter fetch when requested while using this option.

Target is for use in bandwidth limited systems where parameter loading takes 5min+.

