### PR TITLE
Better handling of mutiple vehicles & links

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -304,6 +304,11 @@ class MPState(object):
         self.mav_outputs = []
         self.sysid_outputs = {}
 
+        # Mapping of all detected sysid's to links
+        # Key is link id, value is all detected sysid's/compid's in that link
+        # Dict of self.vehicle_link_map[linknumber] = set([(sysid1,compid1), (sysid2,compid2), ...])
+        self.vehicle_link_map = {}
+
         # SITL output
         self.sitl_output = None
 
@@ -949,9 +954,11 @@ def set_stream_rates():
         else:
             rate = mpstate.settings.streamrate2
         if rate != -1 and mpstate.settings.streamrate != -1:
-            master.mav.request_data_stream_send(mpstate.settings.target_system, mpstate.settings.target_component,
-                                                mavutil.mavlink.MAV_DATA_STREAM_ALL,
-                                                rate, 1)
+            # Send to all detected vehicles in this link
+            for (sysid, compid) in mpstate.vehicle_link_map[master.linknum]:
+                master.mav.request_data_stream_send(sysid, compid,
+                                                    mavutil.mavlink.MAV_DATA_STREAM_ALL,
+                                                    rate, 1)
 
 def check_link_status():
     '''check status of master links'''

--- a/MAVProxy/modules/mavproxy_link.py
+++ b/MAVProxy/modules/mavproxy_link.py
@@ -337,6 +337,7 @@ class LinkModule(mp_module.MPModule):
         self.mpstate.mav_master.append(conn)
         self.status.counters['MasterIn'].append(0)
         self.status.bytecounters['MasterIn'].append(self.status.ByteCounter())
+        self.mpstate.vehicle_link_map[conn.linknum] = set(())
         try:
             mp_util.child_fd_list_add(conn.port.fileno())
         except Exception:
@@ -404,10 +405,15 @@ class LinkModule(mp_module.MPModule):
         self.mpstate.mav_master.pop(i)
         self.status.counters['MasterIn'].pop(i)
         self.status.bytecounters['MasterIn'].pop(i)
+        del self.mpstate.vehicle_link_map[conn.linknum]
         # renumber the links
+        vehicle_link_map_reordered = {}
         for j in range(len(self.mpstate.mav_master)):
             conn = self.mpstate.mav_master[j]
+            map_old = self.mpstate.vehicle_link_map[conn.linknum]
             conn.linknum = j
+            vehicle_link_map_reordered[j] = map_old
+        self.mpstate.vehicle_link_map = vehicle_link_map_reordered
 
     def get_usec(self):
         '''time since 1970 in microseconds'''
@@ -749,19 +755,22 @@ class LinkModule(mp_module.MPModule):
 
     def mavlink_packet(self, msg):
         '''handle an incoming mavlink packet'''
-        type = msg.get_type()
-
-        if type == 'HEARTBEAT' or type == 'HIGH_LATENCY2':
-            sysid = msg.get_srcSystem()
-            if not sysid in self.vehicle_list and msg.type != mavutil.mavlink.MAV_TYPE_GCS:
-                self.vehicle_list.add(sysid)
+        pass
 
     def master_callback(self, m, master):
         '''process mavlink message m on master, sending any messages to recipients'''
-
-        # see if it is handled by a specialised sysid connection
         sysid = m.get_srcSystem()
         mtype = m.get_type()
+
+        if mtype in ['HEARTBEAT', 'HIGH_LATENCY2'] and m.type != mavutil.mavlink.MAV_TYPE_GCS:
+            compid = m.get_srcComponent()
+            if sysid not in self.vehicle_list:
+                self.vehicle_list.add(sysid)
+            if (sysid, compid) not in self.mpstate.vehicle_link_map[master.linknum]:
+                self.mpstate.vehicle_link_map[master.linknum].add((sysid, compid))
+                print("Detected vehicle {0}:{1} on link {2}".format(sysid, compid, master.linknum))
+
+        # see if it is handled by a specialised sysid connection
         if sysid in self.mpstate.sysid_outputs:
             self.mpstate.sysid_outputs[sysid].write(m.get_msgbuf())
             if mtype == "GLOBAL_POSITION_INT":


### PR DESCRIPTION
This PR allows MAVProxy to better handle multiple vehicles on multiple links, for example 5x vehicles on link0 and 2x vehicles on link1.

Previously, MAVProxy would only send the ``request_data_stream_send`` to the active (selected) vehicle. Now MAVProxy will send this message to the relevant (detected) vehicles on each link.

This also exposes a mapping of what vehicles are detected in each link, making it easier for modules to know _which_ links to send a vehicle command on.

@auturgy 