### PR TITLE
Create --udp-timeout option

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -1253,6 +1253,7 @@ if __name__ == '__main__':
     parser.add_option("--state-basedir", default=None, help="base directory for logs and aircraft directories")
     parser.add_option("--version", action='store_true', help="version information")
     parser.add_option("--default-modules", default="log,signing,wp,rally,fence,ftp,param,relay,tuneopt,arm,mode,calibration,rc,auxopt,misc,cmdlong,battery,terrain,output,adsb,layout", help='default module list')
+    parser.add_option("--udp-timeout",dest="udp_timeout", default=0.0, type='float', help="Timeout for udp clients in seconds")
 
     (opts, args) = parser.parse_args()
     if len(args) != 0:
@@ -1366,7 +1367,7 @@ if __name__ == '__main__':
 
     # open any mavlink output ports
     for port in opts.output:
-        mpstate.mav_outputs.append(mavutil.mavlink_connection(port, baud=int(opts.baudrate), input=False))
+        mpstate.mav_outputs.append(mavutil.mavlink_connection(port, baud=int(opts.baudrate), input=False, udp_timeout=opts.udp_timeout))
 
     if opts.sitl:
         mpstate.sitl_output = mavutil.mavudp(opts.sitl, input=False)


### PR DESCRIPTION
This allows connecting multiple clients to an udp server.
If there is more than one client connected, clients with no communication after `udp-timeout` seconds get removed.

Depends on https://github.com/ArduPilot/pymavlink/pull/574

With timeout=0 (the default), the communication is kept even if the GCS is silent (`set heartbeat 0`)
![Screenshot from 2021-10-11 19-30-08](https://user-images.githubusercontent.com/4013804/136864152-61409ddb-371e-4b9a-9cb4-66c68dacaf1b.png)


With timeout higher than zero, the clients that stop talking get removed:
![Screenshot from 2021-10-11 19-36-09](https://user-images.githubusercontent.com/4013804/136863740-aaf82bba-ecdf-4294-b2a6-d5c1b15638f7.png)

I'm guessing the "Heartbeat OK" is some background task of MAVProxy restoring the communication by sending something (apparently mavproxy sending REQUEST_DATA_STREAM)

