### PR TITLE
graph_ui.py: avoid exception under Python2 when closing graph window

### DIFF
--- a/MAVProxy/modules/lib/graph_ui.py
+++ b/MAVProxy/modules/lib/graph_ui.py
@@ -1,6 +1,8 @@
 from MAVProxy.modules.lib import grapher
 from MAVProxy.modules.lib import multiproc
 
+import socket
+
 graph_count = 1
 
 class Graph_UI(object):
@@ -55,8 +57,12 @@ class Graph_UI(object):
         try:
             while self.xlim_pipe[0].poll():
                 xlim = self.xlim_pipe[0].recv()
-        except (EOFError, BrokenPipeError):
+        except EOFError:
             return None
+        except socket.error as e:
+            if e.errno == errno.EPIPE:
+                return None
+            raise e
         if xlim != self.xlim:
             return xlim
         return None


### PR DESCRIPTION
Closing the graph window results in an exception:

```
pbarker@bluebottle:~/rc/ardupilot(pr/sim-gps)$ MAVExplorer.py logs/00000002.BIN MAV> graph GPS[0].NSats GPS[1].NSats[1]
MAV> Exception in thread main_loop:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 754, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/home/pbarker/.local/lib/python2.7/site-packages/MAVProxy-1.8.45-py2.7.egg/EGG-INFO/scripts/MAVExplorer.py", line 972, in main_loop
  File "build/bdist.linux-x86_64/egg/MAVProxy/modules/lib/graph_ui.py", line 58, in check_xlim_change
    except (EOFError, BrokenPipeError):
NameError: global name 'BrokenPipeError' is not defined
```