### PR TITLE
CI: Pin OpenCV

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U wheel
-          python -m pip install -U pywin32 lxml pymavlink numpy matplotlib==3.2.2 pyserial opencv-python PyYAML Pygame Pillow wxpython prompt-toolkit scipy
+          python -m pip install -U pywin32 lxml pymavlink numpy matplotlib==3.2.2 pyserial opencv-python==4.5.3.56 PyYAML Pygame Pillow wxpython prompt-toolkit scipy
           python -m pip install -U pyinstaller==4.3 setuptools packaging 
       - name: Build MAVProxy
         run: |


### PR DESCRIPTION
From https://discuss.ardupilot.org/t/help-compiling-mavproxy-installer-on-windows/77479/5, there are issues with the latest OpenCV on the compiled Windows intstaller. So need to pin the previous good version.