### PR TITLE
Modules: Do not list ADSB system as a vehicle

### DIFF
--- a/MAVProxy/modules/mavproxy_console.py
+++ b/MAVProxy/modules/mavproxy_console.py
@@ -199,6 +199,8 @@ class ConsoleModule(mp_module.MPModule):
             return "Tracker"
         if hb.type == mavutil.mavlink.MAV_TYPE_AIRSHIP:
             return "Blimp"
+        elif hb.type == mavutil.mavlink.MAV_TYPE_ADSB:
+            return "ADSB"
         return "UNKNOWN(%u)" % hb.type
 
     def component_type_string(self, hb):
@@ -209,6 +211,8 @@ class ConsoleModule(mp_module.MPModule):
             return "Gimbal"
         elif hb.type == mavutil.mavlink.MAV_TYPE_ONBOARD_CONTROLLER:
             return "CC"
+        elif hb.type == mavutil.mavlink.MAV_TYPE_ADSB:
+            return "ADSB"
         elif hb.type == mavutil.mavlink.MAV_TYPE_GENERIC:
             return "Generic"
         return self.vehicle_type_string(hb)


### PR DESCRIPTION
In flight controllers with mavlink-based ADSB receivers (such as the ADSB Cube carrier board), the receiver will show up as a separate vehicle in MAVProxy (so 2 separate vehicles in the MAVProxy console's "Vehicle" menu), leading to some confusion as to which is the correct vehicle.

This is extra confusing if the flight controller has a different SYSID to the ADSB receiver.