### PR TITLE
mavlink_link: correct iteration over statustext message ids

### DIFF
--- a/MAVProxy/modules/mavproxy_link.py
+++ b/MAVProxy/modules/mavproxy_link.py
@@ -89,7 +89,7 @@ class LinkModule(mp_module.MPModule):
             m.mav.srcComponent = self.settings.source_component
         # don't let pending statustext wait forever for last chunk:
         for src in self.status.statustexts_by_sysidcompid:
-            msgids = self.status.statustexts_by_sysidcompid[src].keys()
+            msgids = list(self.status.statustexts_by_sysidcompid[src].keys())
             for msgid in msgids:
                 pending = self.status.statustexts_by_sysidcompid[src][msgid]
                 if time.time() - pending.last_chunk_time > 1:


### PR DESCRIPTION
can get a dictionary-changed error without this.  It's in the idle task
(for where we don't have a complete message), so doesn't happen often.