### PR TITLE
Module-messagestats - Shows statistics on intervals between received messages

### DIFF
--- a/MAVProxy/modules/mavproxy_messagestats.py
+++ b/MAVProxy/modules/mavproxy_messagestats.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 '''
-Message Rate viewer
-Peter Barker, December 2018
+Message Statistics
+Matthew Coleman, December 2021
 
-Simply display message rates
+Simply display message statistics
 '''
 
 import time

--- a/MAVProxy/modules/mavproxy_messagestats.py
+++ b/MAVProxy/modules/mavproxy_messagestats.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+'''
+Message Rate viewer
+Peter Barker, December 2018
+
+Simply display message rates
+'''
+
+import time
+
+from MAVProxy.modules.lib import mp_module
+import statistics
+import struct
+import numpy as np
+
+class messagestats(mp_module.MPModule):
+    def __init__(self, mpstate):
+        """Initialise module"""
+        super(messagestats, self).__init__(mpstate, "messagestats", "")
+        
+        self.max_timestamps = 20
+        self.msg_stats_timeout = 60.0
+        self.msg_timestamps = {}
+        self.msg_type_lengths = {}
+
+        self.last_calc = time.time()
+        self.add_command('messagestats',
+                         self.cmd_messagestats,
+                         "messagestats module",
+                         ['show', 'reset', 'len'])
+
+    def usage(self):
+        '''show help on command line options'''
+        return "Usage: messagestats <show|reset|len (length)|timeout>"
+
+    def cmd_messagestats(self, args):
+        '''control behaviour of the module'''
+        if len(args) == 0:
+            print(self.usage())
+        elif args[0] == "show":
+            print(self.stats())
+        elif args[0] == "reset":
+            self.reset()
+        elif args[0] == "len":
+            if len(args) == 2:
+                self.max_timestamps = int(args(1))
+            print("messagestats: maximum message timestamps = %d" % self.max_timestamps)
+        elif args[0] == "timeout":
+            if len(args) == 2:
+                self.msg_stats_timeout = float(args[1])
+            print("messagerate stats: message timeout = %d" % self.stats_age_timeout)
+        else:
+            print(self.usage())
+
+    def reset(self):
+        '''reset message timestamps'''
+        self.msg_timestamps = {}
+
+
+    def stats(self):
+        ret = "\n\n"
+        ret += "Message stats - Max timestamps:%u   Msg timeout:%fs\n" % (self.max_timestamps, self.msg_stats_timeout)
+        mtypes = sorted(self.msg_timestamps.keys())
+        total_datarate = 0
+        now = time.time()
+        for mtype in mtypes:
+            timestamps = np.array(self.msg_timestamps[mtype])
+            timestamp_ages = now - timestamps 
+            timestamp_not_old = timestamp_ages < self.msg_stats_timeout
+            filtered_timestamps = timestamps[timestamp_not_old]
+            tstamps_count = len(filtered_timestamps)
+            if tstamps_count >= 2:
+                periods = filtered_timestamps[1:] - filtered_timestamps[0:-1]  
+
+                period_mean = statistics.mean(periods)
+                mean_rate = 1.0 / period_mean
+                size = self.msg_type_lengths[mtype]
+                mean_bitrate = mean_rate * size
+                period_min = min(periods)
+                period_max = max(periods)
+                age = now - timestamps[-1]
+                total_datarate += mean_rate * size
+                period_stdev = 0.0
+                period_stdev_norm = 0
+                if tstamps_count > 8:
+                    period_stdev = statistics.stdev(periods)
+                    period_stdev_norm = period_stdev / period_mean
+                  
+                ret += "%25s: %3uB  age:%6.1fs  %5uBps  Period(ms)(%5.0f:mean %5.0u:max  %5.0u:min %5.2f:stddev_norm)    PERIODS:" % (mtype, size, age, mean_bitrate, period_mean*1000.0, period_max*1000, period_min*1000, period_stdev_norm)
+                for period in periods:
+                    ret += "  %5.0fms" % (period*1000)
+                ret += "\n"
+        if total_datarate < 1000.0:
+            ret += "\n%25s: %0.2fBps\n" %("Total mean", total_datarate)
+        else:
+            ret += "\n%25s: %0.2fkBps\n" %("Total mean", total_datarate*0.001)
+        return ret
+
+#     def idle_task(self):
+#         '''called rapidly by mavproxy'''
+
+
+    def mavlink_packet(self, m):
+        '''handle mavlink packets'''
+        mtype = m.get_type()
+        
+        if mtype not in self.msg_timestamps.keys():
+            self.msg_timestamps[mtype] = []
+            try:
+                length = struct.calcsize(m.format) + 9
+            except:
+                length = 9
+            self.msg_type_lengths[mtype] = length
+            
+        self.msg_timestamps[mtype].append(time.time())
+        self.msg_timestamps[mtype] = self.msg_timestamps[mtype][-self.max_timestamps:]
+
+
+def init(mpstate):
+    '''initialise module'''
+    return messagestats(mpstate)


### PR DESCRIPTION
For every message it displays:
  min, max, average, normalized standard deviation 
  message size, average data rate, age of last message
  Last N message intervals
  Total data rate

Messages older than timeout are not included.
Maximum message timestamps to measure over can be set.

Example output of "messagestats show".  View this on a wider screen editor for better clarity

Message stats - Max timestamps:100   Msg timeout:60.000000s
                          AHRS:  37B  age:   0.9s     21Bps  Intervals(ms) ( 1751:mean  4002:max    989:min  0.59:stddev_norm) :   1998ms   2014ms    989ms   4002ms    999ms    999ms   1996ms   1010ms
                         AHRS2:  33B  age:   0.9s     18Bps  Intervals(ms) ( 1751:mean  4002:max    989:min  0.59:stddev_norm) :   1998ms   2014ms    989ms   4002ms    999ms    999ms   1996ms   1010ms
                       AOA_SSA:  25B  age:   0.9s     14Bps  Intervals(ms) ( 1751:mean  4001:max    989:min  0.59:stddev_norm) :   1999ms   2012ms    989ms   4002ms    999ms   1000ms   1995ms   1011ms
                      ATTITUDE:  37B  age:   0.9s     21Bps  Intervals(ms) ( 1750:mean  4000:max    999:min  0.59:stddev_norm) :   2000ms   2000ms   1001ms   4001ms    999ms   1001ms   2001ms   1001ms
                BATTERY_STATUS:  58B  age:   0.9s     33Bps  Intervals(ms) ( 1751:mean  4002:max    989:min  0.59:stddev_norm) :   1999ms   2013ms    989ms   4002ms    999ms   1000ms   1995ms   1011ms
             EKF_STATUS_REPORT:  35B  age:   0.9s     19Bps  Intervals(ms) ( 1751:mean  4002:max    989:min  0.59:stddev_norm) :   1999ms   2013ms    989ms   4002ms    999ms   1000ms   1995ms   1011ms
        FILE_TRANSFER_PROTOCOL: 263B  age:  19.2s  20191Bps  Intervals(ms) (   13:mean  1109:max      0:min  8.55:stddev_norm) :      1ms      1ms      1ms      1ms      1ms      1ms      1ms      1ms     12ms      1ms
           GLOBAL_POSITION_INT:  37B  age:   0.6s     30Bps  Intervals(ms) ( 1215:mean  4001:max    499:min  0.77:stddev_norm) :   1499ms   1000ms    502ms    500ms    500ms   1000ms    499ms   1502ms   1499ms   2001ms
             GPS_GLOBAL_ORIGIN:  29B  age:   0.6s      2Bps  Intervals(ms) (12002:mean 12001:max  12001:min  0.00:stddev_norm) :  12002ms
                   GPS_RAW_INT:  61B  age:   0.9s     34Bps  Intervals(ms) ( 1751:mean  4001:max    990:min  0.59:stddev_norm) :   1999ms   2013ms    990ms   4001ms   1000ms    998ms   1997ms   1009ms
                     HEARTBEAT:  18B  age:   0.9s      8Bps  Intervals(ms) ( 2000:mean  4001:max    999:min  0.58:stddev_norm) :   2002ms   3999ms   2000ms   2000ms   1000ms   4002ms   1000ms   1000ms   1999ms   1001ms
                 HOME_POSITION:  69B  age:   0.6s      5Bps  Intervals(ms) (12001:mean 12001:max  12001:min  0.00:stddev_norm) :  12001ms
                      HWSTATUS:  12B  age:   0.9s      6Bps  Intervals(ms) ( 1751:mean  4002:max    989:min  0.59:stddev_norm) :   1999ms   2014ms    989ms   4002ms    999ms   1000ms   1995ms   1011ms
            LOCAL_POSITION_NED:  37B  age:   0.6s     32Bps  Intervals(ms) ( 1133:mean  2996:max    494:min  0.66:stddev_norm) :   1497ms   1000ms    502ms    501ms    499ms   1000ms    499ms   1502ms    494ms   2000ms
                       MEMINFO:  17B  age:   0.9s      9Bps  Intervals(ms) ( 1750:mean  4000:max    998:min  0.59:stddev_norm) :   1999ms   2000ms   1003ms   4000ms    998ms   1001ms   1998ms   1004ms
               MISSION_CURRENT:  11B  age:   0.9s      6Bps  Intervals(ms) ( 1751:mean  4000:max    999:min  0.59:stddev_norm) :   1998ms   1999ms   1004ms   4001ms    999ms    999ms   1998ms   1007ms
         NAV_CONTROLLER_OUTPUT:  35B  age:   0.9s     19Bps  Intervals(ms) ( 1751:mean  4000:max    999:min  0.59:stddev_norm) :   1999ms   2000ms   1004ms   4000ms    999ms   1000ms   1998ms   1005ms
                   PARAM_VALUE:  34B  age:   0.6s      5Bps  Intervals(ms) ( 6002:mean 10002:max   2001:min  0.00:stddev_norm) :   2001ms  10002ms
    POSITION_TARGET_GLOBAL_INT:  60B  age:   0.9s     34Bps  Intervals(ms) ( 1751:mean  4002:max    989:min  0.59:stddev_norm) :   1999ms   2013ms    989ms   4002ms    999ms   1000ms   1995ms   1011ms
                  POWER_STATUS:  15B  age:   0.9s      8Bps  Intervals(ms) ( 1750:mean  4000:max    998:min  0.59:stddev_norm) :   2000ms   2000ms   1002ms   4000ms    998ms   1001ms   1999ms   1003ms
                       RAW_IMU:  38B  age:   0.6s     29Bps  Intervals(ms) ( 1308:mean  4504:max    499:min  0.90:stddev_norm) :   1499ms    999ms    502ms    500ms    500ms   1001ms    499ms   1502ms   4505ms   2996ms
                   RC_CHANNELS:  51B  age:   0.6s     44Bps  Intervals(ms) ( 1134:mean  2995:max    499:min  0.61:stddev_norm) :   1499ms    999ms    502ms    500ms    500ms   1001ms    499ms   1502ms   1499ms   2001ms
                   SCALED_IMU2:  33B  age:   0.6s     29Bps  Intervals(ms) ( 1134:mean  2996:max    493:min  0.66:stddev_norm) :   1499ms    999ms    502ms    500ms    500ms   1001ms    499ms   1502ms    494ms   2000ms
               SCALED_PRESSURE:  25B  age:   0.6s     22Bps  Intervals(ms) ( 1133:mean  2996:max    494:min  0.66:stddev_norm) :   1498ms   1000ms    502ms    500ms    499ms   1000ms    499ms   1502ms    494ms   2000ms
              SERVO_OUTPUT_RAW:  46B  age:   0.6s     40Bps  Intervals(ms) ( 1134:mean  2994:max    499:min  0.61:stddev_norm) :   1499ms    999ms    502ms    500ms    500ms   1001ms    499ms   1502ms   1499ms   2001ms
                    STATUSTEXT:  63B  age:  20.6s  76552Bps  Intervals(ms) (    1:mean     1:max      0:min  0.00:stddev_norm) :      1ms      1ms      1ms      1ms
                   SYSTEM_TIME:  21B  age:   0.9s     11Bps  Intervals(ms) ( 1751:mean  4002:max    989:min  0.59:stddev_norm) :   1998ms   2014ms    989ms   4002ms    999ms    999ms   1996ms   1009ms
                    SYS_STATUS:  40B  age:   0.9s     22Bps  Intervals(ms) ( 1750:mean  4000:max    998:min  0.59:stddev_norm) :   2000ms   2000ms   1002ms   4000ms    999ms   1001ms   2000ms   1002ms
                TERRAIN_REPORT:  31B  age:   0.9s     17Bps  Intervals(ms) ( 1751:mean  4002:max    989:min  0.59:stddev_norm) :   1999ms   2013ms    989ms   4002ms    999ms   1000ms   1995ms   1011ms
                       VFR_HUD:  29B  age:   0.9s     16Bps  Intervals(ms) ( 1751:mean  4001:max    998:min  0.59:stddev_norm) :   1998ms   1999ms   1004ms   4002ms    999ms    998ms   1997ms   1007ms
                     VIBRATION:  41B  age:   0.9s     23Bps  Intervals(ms) ( 1751:mean  4002:max    989:min  0.59:stddev_norm) :   1999ms   2013ms    989ms   4002ms    999ms   1000ms   1995ms   1011ms
                          WIND:  21B  age:   0.9s     11Bps  Intervals(ms) ( 1751:mean  4002:max    989:min  0.59:stddev_norm) :   1999ms   2013ms    989ms   4002ms    999ms   1000ms   1995ms   1011ms

               Total mean: 97.35kBps
