### PR TITLE
paramedit: fixed bug in bitmask editing

### DIFF
--- a/MAVProxy/modules/mavproxy_paramedit/checklisteditor.py
+++ b/MAVProxy/modules/mavproxy_paramedit/checklisteditor.py
@@ -9,7 +9,19 @@ class GridCheckListEditor(gridlib.PyGridCellEditor):
     This is a custom CheckListBox editor for setting of Bitmasks
     """
     def __init__(self, choice, pvalcol, start):
-        self.choices = choice
+        # ensure the choices list has no gaps
+        bvalue = 0
+        self.choices = []
+        for c in choice:
+            bopt = c.split(":")
+            if len(bopt) != 2:
+                continue
+            bval = int(bopt[0])
+            while bvalue < bval:
+                self.choices.append("%u:INVALID" % bvalue)
+                bvalue += 1
+            self.choices.append(c)
+            bvalue += 1
         binary = bin(int(start))[2:]
         self.startValue = [(len(binary)-ones-1) for ones in range(len(binary)) if binary[ones] == '1']
         self.pvalcol = pvalcol

--- a/MAVProxy/modules/mavproxy_paramedit/param_editor_frame.py
+++ b/MAVProxy/modules/mavproxy_paramedit/param_editor_frame.py
@@ -339,8 +339,15 @@ class ParamEditorFrame(wx.Frame):
                     self.display_list.SetCellEditor(row, PE_OPTION, cle.GridCheckListEditor(bits, PE_VALUE, pvalue))
                     val = ""
                     binary = bin(int(pvalue))[2:]
-                    for i in [(len(binary)-ones-1) for ones in range(len(binary)) if binary[ones] == '1']:
-                        val = val + str(bits[i]) + "\n"
+                    for b in bits:
+                        bopt = b.split(":")
+                        if len(bopt) != 2:
+                            continue
+                        bvalue = int(bopt[0])
+                        bstr = bopt[1].strip()
+                        if (int(pvalue) & (1 << bvalue)) != 0:
+                            val = val + "%u: %s\n" % (bvalue, bstr)
+                    val = val.strip()
                     self.display_list.SetCellValue(row, PE_OPTION, str(val))
                     self.set_row_size(row, 25*len(bits))
                     return


### PR DESCRIPTION
if the bitmask has gaps then the wrong value was displayed