### PR TITLE
mavproxy_log: prevent division-by-zero on empty logs

### DIFF
--- a/MAVProxy/modules/mavproxy_log.py
+++ b/MAVProxy/modules/mavproxy_log.py
@@ -123,6 +123,9 @@ class LogModule(mp_module.MPModule):
         if m is None:
             size = 0
             pct = 0
+        elif m.size == 0:
+            size = 0
+            pct = 100
         else:
             size = m.size
             pct = (100.0*file_size)/size


### PR DESCRIPTION
`log download 2` where 2 is an empty log creates a div-by-zero error.
