### PR TITLE
Resend Position to NTRIP Caster

### DIFF
--- a/MAVProxy/modules/mavproxy_ntrip.py
+++ b/MAVProxy/modules/mavproxy_ntrip.py
@@ -74,6 +74,9 @@ class NtripModule(mp_module.MPModule):
                 self.start_pending = True
                 self.last_restart = now
             return
+        if time.time() - self.ntrip.dt_last_gga_sent > 2:
+            self.ntrip.setPosition(self.pos[0], self.pos[1])
+            self.ntrip.send_gga()
         self.log_rtcm(data)
 
         rtcm_id = self.ntrip.get_ID()


### PR DESCRIPTION
This PR targets #977 . The Fix was slightly more complicated from what I suggested in the issue.
I tested it and it solved the problem of the ntrip restart.

The position in the `NtripClient` is updated every 2 seconds and then sent to the ntrip caster.