### PR TITLE
Corrected major/minor/patch decoding of flight_sw_version in AUTOPILOT_STATUS

### DIFF
--- a/MAVProxy/modules/lib/mp_util.py
+++ b/MAVProxy/modules/lib/mp_util.py
@@ -490,3 +490,24 @@ def decode_devid(devid, pname):
         bustypes.get(bus_type,"UNKNOWN"), bus_type,
         bus, address, address, devtype, devtype, decoded_devname,
         devid))
+
+
+def decode_flight_sw_version(flight_sw_version):
+    '''decode 32 bit flight_sw_version mavlink parameter - corresponds to encoding in ardupilot GCS_MAVLINK::send_autopilot_version'''
+    fw_type_id = (flight_sw_version >>  0) % 256
+    patch      = (flight_sw_version >>  8) % 256
+    minor      = (flight_sw_version >> 16) % 256
+    major      = (flight_sw_version >> 24) % 256
+    if (fw_type_id==0):
+        fw_type="dev"
+    elif (fw_type_id==64):
+        fw_type="alpha"
+    elif (fw_type_id==128):
+        fw_type="beta"
+    elif (fw_type_id==192):
+        fw_type="rc"
+    elif (fw_type_id==255):
+        fw_type="official"
+    else:
+        fw_type="undefined"
+    return major,minor,patch,fw_type

--- a/MAVProxy/modules/mavproxy_useralerts.py
+++ b/MAVProxy/modules/mavproxy_useralerts.py
@@ -21,6 +21,7 @@ else:
 
 from MAVProxy.modules.lib import mp_module
 from MAVProxy.modules.lib import mp_settings
+from MAVProxy.modules.lib.mp_util import decode_flight_sw_version
 
 class UserAlertsModule(mp_module.MPModule):
     def __init__(self, mpstate):
@@ -67,9 +68,7 @@ class UserAlertsModule(mp_module.MPModule):
             # board_version : 0, flight_custom_version : [54, 49, 51, 100, 50, 99, 50, 101],
             # middleware_custom_version : [0, 0, 0, 0, 0, 0, 0, 0], os_custom_version : [51, 51, 49, 102, 101, 55, 53, 100],
             # vendor_id : 0, product_id : 0, uid : 0, uid2 : [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}
-            vMajor = hex(m.flight_sw_version)[2]
-            vMinor = hex(m.flight_sw_version)[3]
-            vPatch = hex(m.flight_sw_version)[4]
+            vMajor,vMinor,vPatch,vFwType = decode_flight_sw_version(m.flight_sw_version)
             self.version = "{0}.{1}.{2}".format(vMajor, vMinor, vPatch)
 
         if self.board and self.version:


### PR DESCRIPTION
The useralerts module retrieves the major/minor/patch version (to compare with the alerts) from the AUTOPILOT_STATUS message's flight_sw_version field. But the decoding of this 32bit integer is incorrectly done with the python hex function which array index iterates through octets not bytes of the flight_sw_version field whereas the encoding in the ardupilot is using encoding as below /1/. The decoding function has been separated out as this might be useful in other places, e.g. the version command in mavproxy doesn't produce any output today (the triggered AUTOPILOT_STATUS message just goes into the log), but that will be for another PR.

/1/
    flight_sw_version = version.major << (8 * 3) | \
                        version.minor << (8 * 2) | \
                        version.patch << (8 * 1) | \
                        (uint32_t)(version.fw_type) << (8 * 0);