### PR TITLE
Added the ability to set an empty value for modules by default 

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -1409,7 +1409,8 @@ if __name__ == '__main__':
         # some core functionality is in modules
         standard_modules = opts.default_modules.split(',')
         for m in standard_modules:
-            load_module(m, quiet=True)
+            if m:
+                load_module(m, quiet=True)
 
     if platform.system() != 'Windows':
         if opts.console:


### PR DESCRIPTION
Without this changes:
```shell
$ mavproxy.py --default-modules="" --master=/dev/ttyACM2 --baudrate=115200
Connect /dev/ttyACM2 source_system=255
Traceback (most recent call last):
  File "/usr/local/bin/mavproxy.py", line 4, in <module>
    __import__('pkg_resources').run_script('MAVProxy==1.8.46', 'mavproxy.py')
  File "/home/gs/.local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 666, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/home/gs/.local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1469, in run_script
    exec(script_code, namespace, namespace)
  File "/usr/local/lib/python2.7/dist-packages/MAVProxy-1.8.46-py2.7.egg/EGG-INFO/scripts/mavproxy.py", line 1412, in <module>
    
  File "/usr/local/lib/python2.7/dist-packages/MAVProxy-1.8.46-py2.7.egg/EGG-INFO/scripts/mavproxy.py", line 511, in load_module
    
  File "/usr/local/lib/python2.7/dist-packages/MAVProxy-1.8.46-py2.7.egg/EGG-INFO/scripts/mavproxy.py", line 664, in import_package
    
ValueError: Empty module name
```