### PR TITLE
MAVProxy: default to using the 'all' dialect

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -1359,7 +1359,7 @@ if __name__ == '__main__':
     parser.add_option("--mavversion", type='choice', choices=['1.0', '2.0'] , help="Force MAVLink Version (1.0, 2.0). Otherwise autodetect version")  # noqa:E501
     parser.add_option("--nowait", action='store_true', default=False, help="don't wait for HEARTBEAT on startup")
     parser.add_option("-c", "--continue", dest='continue_mode', action='store_true', default=False, help="continue logs")
-    parser.add_option("--dialect", default="ardupilotmega", help="MAVLink dialect")
+    parser.add_option("--dialect", default="all", help="MAVLink dialect")
     parser.add_option("--rtscts", action='store_true', help="enable hardware RTS/CTS flow control")
     parser.add_option("--moddebug", type=int, help="module debug level", default=0)
     parser.add_option("--mission", dest="mission", help="mission name", default=None)

--- a/MAVProxy/modules/lib/grapher.py
+++ b/MAVProxy/modules/lib/grapher.py
@@ -708,7 +708,7 @@ if __name__ == "__main__":
     parser.add_argument("--zero-time-base", action='store_true', help="use Z time base for DF logs")
     parser.add_argument("--show-flightmode", default=True,
                         help="Add background colour to plot corresponding to current flight mode.  Cannot be specified with --xaxis.")
-    parser.add_argument("--dialect", default="ardupilotmega", help="MAVLink dialect")
+    parser.add_argument("--dialect", default="all", help="MAVLink dialect")
     parser.add_argument("--output", default=None, help="provide an output format")
     parser.add_argument("--timeshift", type=float, default=0, help="shift time on first graph in seconds")
     parser.add_argument("--grid", action='store_true', help="show a grid")


### PR DESCRIPTION
This would allow MAVProxy to see messages in other inclusions in `all.xml` - so including the ones in `storm32.xml` for example.

I've run this for a while locally and it seems to run just fine.
