### PR TITLE
mavproxy_map: avoid division by zero in map zooming

### DIFF
--- a/MAVProxy/modules/mavproxy_map/mp_slipmap_util.py
+++ b/MAVProxy/modules/mavproxy_map/mp_slipmap_util.py
@@ -309,9 +309,9 @@ class SlipGrid(SlipObject):
             dist = mp_util.gps_distance(lat2,lon,lat2,lon2)
             count = int(dist / spacing)
             if count < 2:
-                spacing /= 10
+                spacing /= 10.0
             elif count > 50:
-                spacing *= 10
+                spacing *= 10.0
             else:
                 break
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "build/bdist.linux-x86_64/egg/MAVProxy/modules/mavproxy_map/mp_slipmap_ui.py", line 569, in on_redraw_timer
  File "build/bdist.linux-x86_64/egg/MAVProxy/modules/mavproxy_map/mp_slipmap_ui.py", line 543, in redraw_map
  File "build/bdist.linux-x86_64/egg/MAVProxy/modules/mavproxy_map/mp_slipmap_util.py", line 306, in draw
  File "build/bdist.linux-x86_64/egg/MAVProxy/modules/lib/mp_util.py", line 240, in latlon_round
ZeroDivisionError: float divmod()
```
