### PR TITLE
Fix map bugs with --tracker used in ArduPilot

### DIFF
--- a/MAVProxy/modules/mavproxy_map/__init__.py
+++ b/MAVProxy/modules/mavproxy_map/__init__.py
@@ -753,18 +753,19 @@ class MapModule(mp_module.MPModule):
                 self.create_vehicle_icon('GPS2' + vehicle, 'green')
                 self.map.set_position('GPS2' + vehicle, (lat, lon), rotation=m.cog*0.01)
 
-        elif mtype == 'GLOBAL_POSITION_INT' and self.map_settings.showahrspos:
+        elif mtype == 'GLOBAL_POSITION_INT':
             (lat, lon, heading) = (m.lat*1.0e-7, m.lon*1.0e-7, m.hdg*0.01)
             self.lat_lon_heading[m.get_srcSystem()] = (lat,lon,heading)
-            if abs(lat) > 1.0e-3 or abs(lon) > 1.0e-3:
-                self.have_global_position = True
-                self.create_vehicle_icon('Pos' + vehicle, 'red', follow=True)
-                if len(self.vehicle_type_by_sysid) > 1:
-                    label = str(sysid)
-                else:
-                    label = None
-                self.map.set_position('Pos' + vehicle, (lat, lon), rotation=heading, label=label, colour=(255,255,255))
-                self.map.set_follow_object('Pos' + vehicle, self.is_primary_vehicle(m))
+            if self.map_settings.showahrspos:
+                if abs(lat) > 1.0e-3 or abs(lon) > 1.0e-3:
+                    self.have_global_position = True
+                    self.create_vehicle_icon('Pos' + vehicle, 'red', follow=True)
+                    if len(self.vehicle_type_by_sysid) > 1:
+                        label = str(sysid)
+                    else:
+                        label = None
+                    self.map.set_position('Pos' + vehicle, (lat, lon), rotation=heading, label=label, colour=(255,255,255))
+                    self.map.set_follow_object('Pos' + vehicle, self.is_primary_vehicle(m))
 
         elif mtype == "HIGH_LATENCY2" and self.map_settings.showahrspos:
             (lat, lon) = (m.latitude*1.0e-7, m.longitude*1.0e-7)

--- a/MAVProxy/modules/mavproxy_map/__init__.py
+++ b/MAVProxy/modules/mavproxy_map/__init__.py
@@ -740,7 +740,7 @@ class MapModule(mp_module.MPModule):
         elif mtype == "GPS_RAW_INT" and self.map_settings.showgpspos:
             (lat, lon) = (m.lat*1.0e-7, m.lon*1.0e-7)
             if lat != 0 or lon != 0:
-                if m.vel > 300 or 'ATTITUDE' not in self.master.messages:
+                if m.vel > 300 or m.get_srcSystem() not in self.lat_lon_heading:
                     heading = m.cog*0.01
                 else:
                     (_,_,heading) = self.lat_lon_heading[m.get_srcSystem()]


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/pbarker/.local/lib/python3.6/site-packages/MAVProxy-1.8.46-py3.6.egg/MAVProxy/modules/mavproxy_link.py", line 895, in master_callback
    mod.mavlink_packet(m)
  File "/home/pbarker/.local/lib/python3.6/site-packages/MAVProxy-1.8.46-py3.6.egg/MAVProxy/modules/mavproxy_map/__init__.py", line 746, in mavlink_packet
    (_,_,heading) = self.lat_lon_heading[m.get_srcSystem()]
KeyError: 1
```

... and an unrelated issue where you wouldn't get a heading if you weren't showing ahrspos
