### PR TITLE
grapher: nuke marker is redundantly defined

### DIFF
--- a/MAVProxy/modules/lib/grapher.py
+++ b/MAVProxy/modules/lib/grapher.py
@@ -360,7 +360,7 @@ class MavGraph(object):
                                 alpha=0.6,
                                 verticalalignment='center')
                 else:
-                    ax.plot_date(x[i], y[i], color=color, label=fields[i],
+                    ax.plot_date(x[i], y[i], fmt=color, label=fields[i],
                                  linestyle=linestyle, marker=marker, tz=None)
 
             empty = False


### PR DESCRIPTION
This removes this warning that is annoying whenever you graph a new plot. 
See [here](https://stackoverflow.com/questions/69188540/userwarning-marker-is-redundantly-defined-by-the-marker-keyword-argument-when)


![image](https://user-images.githubusercontent.com/69225461/159138231-1e488f95-8feb-4024-b311-fa69f8d4b77d.png)


Closes: https://github.com/ArduPilot/MAVProxy/issues/986