### PR TITLE
fakegps: avoid None-doesn't-have-attribute error

### DIFF
--- a/MAVProxy/modules/mavproxy_fakegps.py
+++ b/MAVProxy/modules/mavproxy_fakegps.py
@@ -71,6 +71,8 @@ class FakeGPSModule(mp_module.MPModule):
 
     def idle_task(self):
         '''called on idle'''
+        if self.master is None:
+            return
         now = time.time()
         if now - self.last_send < 1.0 / self.FakeGPS_settings.rate:
             return


### PR DESCRIPTION
```
'NoneType' object has no attribute 'mav'
Traceback (most recent call last):
  File "/home/pbarker/.local/lib/python3.6/site-packages/MAVProxy-1.8.48-py3.6.egg/EGG-INFO/scripts/mavproxy.py", line 1023, in periodic_tasks
  File "/home/pbarker/.local/lib/python3.6/site-packages/MAVProxy-1.8.48-py3.6.egg/MAVProxy/modules/mavproxy_fakegps.py", line 92, in idle_task
    self.master.mav.gps_input_send(time_us, 0, 0, gps_week_ms, gps_week, fix_type,
AttributeError: 'NoneType' object has no attribute 'mav'
```
