### PR TITLE
Fix CI build errors

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -23,16 +23,16 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install -U wheel
+          python -m pip install -U wheel setuptools pip
           python -m pip install -U pywin32 lxml pymavlink numpy matplotlib==3.2.2 pyserial opencv-python==4.5.3.56 PyYAML Pygame Pillow wxpython prompt-toolkit scipy
-          python -m pip install -U pyinstaller==4.3 setuptools packaging 
+          python -m pip install -U pyinstaller packaging 
       - name: Download Inno Setup installer
         run: curl -L -o installer.exe http://files.jrsoftware.org/is/6/innosetup-6.2.0.exe
       - name: Install Inno Setup
         run: ./installer.exe /verysilent /allusers /dir=inst
       - name: Build MAVProxy
         run: |
-          python setup.py build install
+          python -m pip install . --user
           python -m pip list
       - name: Prepare installer
         run: |

--- a/windows/MAVProxyWinBuild.bat
+++ b/windows/MAVProxyWinBuild.bat
@@ -32,7 +32,7 @@ if exist "..\..\pymavlink" (
 
 rem -----Build MAVProxy-----
 cd ..\
-python.exe setup.py clean build install --user
+python.exe -m pip install . --user
 cd .\MAVProxy
 copy ..\windows\mavproxy.spec
 pyinstaller -y --clean mavproxy.spec


### PR DESCRIPTION
This PR fixes the current Windows build errors in Github Actions.

The issue turned out to be a few package versions not playing nicely together (pip and pyinstaller), so the CI script now ensures it's using the latest pip and pyinstaller.

In addition, pip now recommends using ``python -m pip install .`` in place of ``python setup.py build install`` for building local packages. What I did not realise was that this "recommendation" is in fact _mandatory_ when using the latest version of pyinstaller. :shrug: 