### PR TITLE
Checklist: Close GUI on module unload

### DIFF
--- a/MAVProxy/modules/mavproxy_checklist.py
+++ b/MAVProxy/modules/mavproxy_checklist.py
@@ -107,7 +107,10 @@ class ChecklistModule(mp_module.MPModule):
             else:
                 self.checklist.set_check("IMU Check", 0)
 
-
+    def unload(self):
+        '''unload module'''
+        self.checklist.close()
+        
 def init(mpstate):
     '''initialise module'''
     return ChecklistModule(mpstate)


### PR DESCRIPTION
For #1056 - this ensures the checklist module GUI cleanly closes on module unload

@AndKe - can you confirm this works for you?