### PR TITLE
mavflightview: Add options to not show lines when displaying missions 

### DIFF
--- a/MAVProxy/modules/mavproxy_map/mp_slipmap_util.py
+++ b/MAVProxy/modules/mavproxy_map/mp_slipmap_util.py
@@ -195,7 +195,7 @@ class SlipCircle(SlipObject):
 
 class SlipPolygon(SlipObject):
     '''a polygon to display on the map'''
-    def __init__(self, key, points, layer, colour, linewidth, arrow = False, popup_menu=None):
+    def __init__(self, key, points, layer, colour, linewidth, arrow = False, popup_menu=None, showlines=True):
         SlipObject.__init__(self, key, layer, popup_menu=popup_menu)
         self.points = points
         self.colour = colour
@@ -205,6 +205,7 @@ class SlipPolygon(SlipObject):
         self._pix_points = []
         self._selected_vertex = None
         self._has_timestamps = False
+        self._showlines = showlines
 
     def bounds(self):
         '''return bounding box'''
@@ -225,7 +226,8 @@ class SlipPolygon(SlipObject):
                 self._pix_points.append(None)
             self._pix_points.append(None)
             return
-        cv2.line(img, pix1, pix2, colour, linewidth)
+        if self._showlines:
+            cv2.line(img, pix1, pix2, colour, linewidth)
         cv2.circle(img, pix2, linewidth*2, colour)
         if len(self._pix_points) == 0:
             self._pix_points.append(pix1)

--- a/MAVProxy/tools/mavflightview.py
+++ b/MAVProxy/tools/mavflightview.py
@@ -499,8 +499,13 @@ def mavflightview_show(path, wp, fen, used_flightmodes, mav_type, options, insta
     path_objs = []
     for i in range(len(path)):
         if len(path[i]) != 0:
-            path_objs.append(mp_slipmap.SlipPolygon('FlightPath[%u]-%s' % (i,title), path[i], layer='FlightPath',
-                                                    linewidth=2, colour=(255,0,180)))
+            path_objs.append(mp_slipmap.SlipPolygon(
+                'FlightPath[%u]-%s' % (i,title),
+                path[i],
+                layer='FlightPath',
+                linewidth=2,
+                showlines=(not getattr(options, "no_show_lines", False)),
+                colour=(255,0,180)))
     plist = []
     if options.show_waypoints:
         plist = wp.polygon_list()
@@ -665,6 +670,7 @@ if __name__ == "__main__":
     parser.add_option("--no-flightmode-legend", action="store_false", default=True, dest="show_flightmode_legend", help="hide legend for colour used for flight modes")
     parser.add_option("--kml", default=None, help="add kml overlay")
     parser.add_option("--hide-waypoints", dest='show_waypoints', action='store_false', help="do not show waypoints", default=True)
+    parser.add_option("--no-show-lines", action="store_true", default=False)
 
     (opts, args) = parser.parse_args()
 

--- a/MAVProxy/tools/mavflightview.py
+++ b/MAVProxy/tools/mavflightview.py
@@ -168,9 +168,10 @@ def display_waypoints(wploader, map):
 colour_expression_exceptions = dict()
 colour_source_min = 255
 colour_source_max = 0
+colour_over_255 = 0
 
 def colour_for_point(mlog, point, instance, options):
-    global colour_expression_exceptions, colour_source_max, colour_source_min
+    global colour_expression_exceptions, colour_source_max, colour_source_min, colour_over_255
     '''indicate a colour to be used to plot point'''
     source = getattr(options, "colour_source", "flightmode")
     if source == "flightmode":
@@ -209,6 +210,7 @@ def colour_for_point(mlog, point, instance, options):
     elif v > 255:
         print("colour expression returned %d (> 255)" % v)
         v = 255
+        colour_over_255 += 1
 
     if v < colour_source_min:
         colour_source_min = v
@@ -571,7 +573,7 @@ def mavflightview_show(path, wp, fen, used_flightmodes, mav_type, options, insta
             tuples = [ (t, map_colours[instances[t]]) for t in instances.keys() ]
             map.add_object(mp_slipmap.SlipFlightModeLegend("legend", tuples))
         else:
-            print("colour-source: min=%f max=%f" % (colour_source_min, colour_source_max))
+            print("colour-source: min=%f max=%f over-255=%u" % (colour_source_min, colour_source_max, colour_over_255))
 
 
 def load_kml(kml):


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/7077857/171814088-82d649ae-b6c6-4250-84a8-a9ccd9b9ea2d.png)

After:
![image](https://user-images.githubusercontent.com/7077857/171814143-a4f91266-c0b8-4e54-a618-f4f738f018fa.png)

This can be useful when trying to simplify things, particularly Rover missions.

Also sneaks in a little bit of diagnostics for `--colour-source`