### PR TITLE
Handle the case where msg.text is a bytes

### DIFF
--- a/MAVProxy/modules/mavproxy_link.py
+++ b/MAVProxy/modules/mavproxy_link.py
@@ -661,7 +661,10 @@ class LinkModule(mp_module.MPModule):
                         if chunk_seq != next_expected_chunk:
                             out += " ... "
                             next_expected_chunk = chunk_seq
-                        out += self.chunks[chunk_seq]
+                        if isinstance(self.chunks[chunk_seq], str):
+                            out += self.chunks[chunk_seq]
+                        else:
+                            out += self.chunks[chunk_seq].decode(errors="ignore")
                         next_expected_chunk += 1
 
                     return out


### PR DESCRIPTION
This is the case in the type annotation PR (<https://github.com/ArduPilot/pymavlink/pull/666>) in pymavlink.