### PR TITLE
Add support for new terrain data sources

### DIFF
--- a/MAVProxy/modules/mavproxy_adsb.py
+++ b/MAVProxy/modules/mavproxy_adsb.py
@@ -219,7 +219,7 @@ class ADSBModule(mp_module.MPModule):
                 self.threat_vehicles[id].update(m.to_dict(), self.get_time())
                 for mp in self.module_matching('map*'):
                     # update the map
-                    ground_alt = mp.ElevationMap.GetElevation(m.lat*1e-7, m.lon*1e-7)
+                    ground_alt = self.module('terrain').ElevationModel.GetElevation(m.lat*1e-7, m.lon*1e-7)
                     alt_amsl = m.altitude * 0.001
                     if alt_amsl > 0:
                         alt = int(alt_amsl - ground_alt)

--- a/MAVProxy/modules/mavproxy_cameraview.py
+++ b/MAVProxy/modules/mavproxy_cameraview.py
@@ -7,7 +7,6 @@ Feb 2014
 
 import math
 from MAVProxy.modules.mavproxy_map import mp_slipmap
-from MAVProxy.modules.mavproxy_map import mp_elevation
 from MAVProxy.modules.lib import mp_util
 from MAVProxy.modules.lib import mp_settings
 from cuav.lib import cuav_util
@@ -35,7 +34,6 @@ class CameraViewModule(mp_module.MPModule):
         self.lon = 0
         self.home_height = 0
         self.hdg = 0
-        self.elevation_model = mp_elevation.ElevationModel()
         self.camera_params = CameraParams() # TODO how to get actual camera params
         self.view_settings = mp_settings.MPSettings(
             [ ('r', float, 0.5),
@@ -88,7 +86,7 @@ class CameraViewModule(mp_module.MPModule):
         if mtype == 'GLOBAL_POSITION_INT':
             state.lat, state.lon = m.lat*scale_latlon, m.lon*scale_latlon
             state.hdg = m.hdg*scale_hdg
-            agl = state.elevation_model.GetElevation(state.lat, state.lon)
+            agl = self.module('terrain').ElevationModel.GetElevation(state.lat, state.lon)
             if agl is not None:
                 state.height = m.relative_alt*scale_relative_alt + state.home_height - agl
         elif mtype == 'ATTITUDE':
@@ -99,7 +97,7 @@ class CameraViewModule(mp_module.MPModule):
             else:
                 home = [self.master.field('HOME', c)*scale_latlon for c in ['lat', 'lon']]
             old = state.home_height # TODO TMP
-            agl = state.elevation_model.GetElevation(*home)
+            agl = self.module('terrain').ElevationModel.GetElevation(*home)
             if agl is None:
                 return
             state.home_height = agl

--- a/MAVProxy/modules/mavproxy_link.py
+++ b/MAVProxy/modules/mavproxy_link.py
@@ -511,10 +511,10 @@ class LinkModule(mp_module.MPModule):
     def report_altitude(self, altitude):
         '''possibly report a new altitude'''
         master = self.master
-        if getattr(self.console, 'ElevationMap', None) is not None and self.mpstate.settings.basealt != 0:
+        if len(self.module_matching('terrain')) > 0 and self.mpstate.settings.basealt != 0:
             lat = master.field('GLOBAL_POSITION_INT', 'lat', 0)*1.0e-7
             lon = master.field('GLOBAL_POSITION_INT', 'lon', 0)*1.0e-7
-            alt1 = self.console.ElevationMap.GetElevation(lat, lon)
+            alt1 = self.module('terrain').ElevationModel.GetElevation(lat, lon)
             if alt1 is not None:
                 alt2 = self.mpstate.settings.basealt
                 altitude += alt2 - alt1

--- a/MAVProxy/modules/mavproxy_map/mp_elevation.py
+++ b/MAVProxy/modules/mavproxy_map/mp_elevation.py
@@ -13,29 +13,38 @@ import numpy
 
 from MAVProxy.modules.mavproxy_map import srtm
 
+# SRTM1 = 1 arc-second resolution data (~30m)
+# SRTM3 = 3 arc-second resolution data (~90m)
+TERRAIN_SERVICES = {
+    "SRTM1"      : ("terrain.ardupilot.org", "SRTM1"),
+    "SRTM3"      : ("terrain.ardupilot.org", "SRTM3")
+}
+
 class ElevationModel():
     '''Elevation Model. Only SRTM for now'''
 
-    def __init__(self, database='srtm', offline=0, debug=False):
+    def __init__(self, database='SRTM3', offline=0, debug=False):
         '''Use offline=1 to disable any downloading of tiles, regardless of whether the
         tile exists'''
         self.database = database
-        if self.database == 'srtm':
-            self.downloader = srtm.SRTMDownloader(offline=offline, debug=debug)
+        if self.database in ['SRTM1', 'SRTM3']:
+            self.downloader = srtm.SRTMDownloader(offline=offline, debug=debug, directory=self.database)
             self.downloader.loadFileList()
             self.tileDict = dict()
-
-        '''Use the Geoscience Australia database instead - watch for the correct database path'''
-        if self.database == 'geoscience':
+        elif self.database == 'geoscience':
+            '''Use the Geoscience Australia database instead - watch for the correct database path'''
             from MAVProxy.modules.mavproxy_map import GAreader
             self.mappy = GAreader.ERMap()
             self.mappy.read_ermapper(os.path.join(os.environ['HOME'], './Documents/Elevation/Canberra/GSNSW_P756demg'))
+        else:
+            print("Error: Bad terrain source " + database)
+            self.database = None
 
     def GetElevation(self, latitude, longitude, timeout=0):
         '''Returns the altitude (m ASL) of a given lat/long pair, or None if unknown'''
         if latitude is None or longitude is None:
             return None
-        if self.database == 'srtm':
+        if self.database in ['SRTM1', 'SRTM3']:
             TileID = (numpy.floor(latitude), numpy.floor(longitude))
             if TileID in self.tileDict:
                 alt = self.tileDict[TileID].getAltitudeFromLatLon(latitude, longitude)
@@ -52,26 +61,28 @@ class ElevationModel():
                     return None
                 self.tileDict[TileID] = tile
                 alt = tile.getAltitudeFromLatLon(latitude, longitude)
-        if self.database == 'geoscience':
+        elif self.database == 'geoscience':
              alt = self.mappy.getAltitudeAtPoint(latitude, longitude)
+        else:
+            return None
         return alt
 
 
 if __name__ == "__main__":
 
-    from optparse import OptionParser
-    parser = OptionParser("mp_elevation.py [options]")
-    parser.add_option("--lat", type='float', default=-35.052544, help="start latitude")
-    parser.add_option("--lon", type='float', default=149.509165, help="start longitude")
-    parser.add_option("--database", type='string', default='srtm', help="elevation database")
-    parser.add_option("--debug", action='store_true', help="enabled debugging")
+    from argparse import ArgumentParser
+    parser = ArgumentParser("mp_elevation.py [options]")
+    parser.add_argument("--lat", type=float, default=-35.052544, help="start latitude")
+    parser.add_argument("--lon", type=float, default=149.509165, help="start longitude")
+    parser.add_argument("--database", type=str, default='SRTM3', help="elevation database", choices=["SRTM1", "SRTM3"])
+    parser.add_argument("--debug", action='store_true', help="enabled debugging")
 
-    (opts, args) = parser.parse_args()
+    args = parser.parse_args()
 
-    EleModel = ElevationModel(opts.database, debug=opts.debug)
+    EleModel = ElevationModel(args.database, debug=args.debug)
 
-    lat = opts.lat
-    lon = opts.lon
+    lat = args.lat
+    lon = args.lon
 
     '''Do a few lat/long pairs to demonstrate the caching
     Note the +0.000001 to the time. On faster PCs, the two time periods
@@ -84,15 +95,15 @@ if __name__ == "__main__":
     t1 = time.time()+.000001
     print("Altitude at (%.6f, %.6f) is %u m. Pulled at %.1f FPS" % (lat, lon, alt, 1/(t1-t0)))
 
-    lat = opts.lat+0.001
-    lon = opts.lon+0.001
+    lat = args.lat+0.001
+    lon = args.lon+0.001
     t0 = time.time()
     alt = EleModel.GetElevation(lat, lon, timeout=10)
     t1 = time.time()+.000001
     print("Altitude at (%.6f, %.6f) is %u m. Pulled at %.1f FPS" % (lat, lon, alt, 1/(t1-t0)))
 
-    lat = opts.lat-0.001
-    lon = opts.lon-0.001
+    lat = args.lat-0.001
+    lon = args.lon-0.001
     t0 = time.time()
     alt = EleModel.GetElevation(lat, lon, timeout=10)
     t1 = time.time()+.000001

--- a/MAVProxy/modules/mavproxy_map/mp_slipmap_util.py
+++ b/MAVProxy/modules/mavproxy_map/mp_slipmap_util.py
@@ -14,7 +14,6 @@ import cv2
 import numpy as np
 import warnings
 
-from MAVProxy.modules.mavproxy_map import mp_elevation
 from MAVProxy.modules.mavproxy_map import mp_tile
 from MAVProxy.modules.lib import mp_util
 

--- a/MAVProxy/modules/mavproxy_misseditor/__init__.py
+++ b/MAVProxy/modules/mavproxy_misseditor/__init__.py
@@ -16,7 +16,7 @@ class MissionEditorModule(mp_module.MPModule):
 
         # to work around an issue on MacOS this module is a thin wrapper around a separate MissionEditorMain object
         from MAVProxy.modules.mavproxy_misseditor import mission_editor
-        self.me_main = mission_editor.MissionEditorMain(mpstate)
+        self.me_main = mission_editor.MissionEditorMain(mpstate, self.module('terrain').ElevationModel.database)
 
     def unload(self):
         '''unload module'''

--- a/MAVProxy/modules/mavproxy_misseditor/missionEditorFrame.py
+++ b/MAVProxy/modules/mavproxy_misseditor/missionEditorFrame.py
@@ -39,7 +39,7 @@ ME_DIST_COL = 12
 ME_ANGLE_COL = 13
 
 class MissionEditorFrame(wx.Frame):
-    def __init__(self, state, *args, **kwds):
+    def __init__(self, state, elemodel='SRTM1', *args, **kwds):
         # begin wxGlade: MissionEditorFrame.__init__
         self.state = state
         kwds["style"] = wx.DEFAULT_FRAME_STYLE
@@ -71,7 +71,7 @@ class MissionEditorFrame(wx.Frame):
         self.__set_properties()
         self.__do_layout()
 
-        self.ElevationModel = mp_elevation.ElevationModel()
+        self.ElevationModel = mp_elevation.ElevationModel(database=elemodel)
 
 
         self.Bind(wx.EVT_TEXT_ENTER, self.on_wp_radius_enter, self.text_ctrl_wp_radius)

--- a/MAVProxy/modules/mavproxy_misseditor/mission_editor.py
+++ b/MAVProxy/modules/mavproxy_misseditor/mission_editor.py
@@ -181,7 +181,7 @@ class MissionEditorEventThread(threading.Thread):
             time.sleep(0.2)
 
 class MissionEditorMain(object):
-    def __init__(self, mpstate):
+    def __init__(self, mpstate, elemodel):
         self.num_wps_expected = 0 #helps me to know if all my waypoints I'm expecting have arrived
         self.wps_received = {}
 
@@ -195,7 +195,7 @@ class MissionEditorMain(object):
         self.close_window = multiproc.Semaphore()
         self.close_window.acquire()
 
-        self.child = multiproc.Process(target=self.child_task,args=(self.event_queue,self.event_queue_lock,self.gui_event_queue,self.gui_event_queue_lock,self.close_window))
+        self.child = multiproc.Process(target=self.child_task,args=(self.event_queue,self.event_queue_lock,self.gui_event_queue,self.gui_event_queue_lock,self.close_window, elemodel))
         self.child.start()
 
         self.event_thread = MissionEditorEventThread(self, self.event_queue, self.event_queue_lock)
@@ -317,7 +317,7 @@ class MissionEditorMain(object):
 
                     self.wps_received[m.seq] = True
 
-    def child_task(self, q, l, gq, gl, cw_sem):
+    def child_task(self, q, l, gq, gl, cw_sem, elemodel):
         '''child process - this holds GUI elements'''
         mp_util.child_close_fds()
 
@@ -326,7 +326,7 @@ class MissionEditorMain(object):
         from MAVProxy.modules.mavproxy_misseditor import missionEditorFrame
 
         self.app = wx.App(False)
-        self.app.frame = missionEditorFrame.MissionEditorFrame(self,parent=None,id=wx.ID_ANY)
+        self.app.frame = missionEditorFrame.MissionEditorFrame(self,parent=None,id=wx.ID_ANY, elemodel=elemodel)
 
         self.app.frame.set_event_queue(q)
         self.app.frame.set_event_queue_lock(l)

--- a/MAVProxy/modules/mavproxy_wp.py
+++ b/MAVProxy/modules/mavproxy_wp.py
@@ -381,11 +381,11 @@ class WPModule(mp_module.MPModule):
         self.undo_type = "move"
 
         (lat, lon) = latlon
-        if (getattr(self.console, 'ElevationMap', None) is not None and
+        if (len(self.module_matching('terrain')) > 0 and
             wp.frame == mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT and
             self.settings.wpterrainadjust):
-            alt1 = self.console.ElevationMap.GetElevation(lat, lon)
-            alt2 = self.console.ElevationMap.GetElevation(wp.x, wp.y)
+            alt1 = self.module('terrain').ElevationModel.GetElevation(lat, lon)
+            alt2 = self.module('terrain').ElevationModel.GetElevation(wp.x, wp.y)
             if alt1 is not None and alt2 is not None:
                 wp.z += alt1 - alt2
         wp.x = lat
@@ -454,11 +454,11 @@ class WPModule(mp_module.MPModule):
                 b2 = mp_util.gps_bearing(lat, lon, newlat, newlon)
                 (newlat, newlon) = mp_util.gps_newpos(lat, lon, b2+rotation, d2)
 
-            if (getattr(self.console, 'ElevationMap', None) is not None and
+            if (len(self.module_matching('terrain')) > 0 and
                 wp.frame != mavutil.mavlink.MAV_FRAME_GLOBAL_TERRAIN_ALT and
                 self.settings.wpterrainadjust):
-                alt1 = self.console.ElevationMap.GetElevation(newlat, newlon)
-                alt2 = self.console.ElevationMap.GetElevation(wp.x, wp.y)
+                alt1 = self.module('terrain').ElevationModel.GetElevation(newlat, newlon)
+                alt2 = self.module('terrain').ElevationModel.GetElevation(wp.x, wp.y)
                 if alt1 is not None and alt2 is not None:
                     wp.z += alt1 - alt2
             wp.x = newlat

--- a/MAVProxy/tools/mavflightview.py
+++ b/MAVProxy/tools/mavflightview.py
@@ -532,7 +532,7 @@ def mavflightview_show(path, wp, fen, used_flightmodes, mav_type, options, insta
         else:
             map = mp_slipmap.MPSlipMap(title=title,
                                        service=options.service,
-                                       elevation=True,
+                                       elevation="SRTM3",
                                        width=600,
                                        height=600,
                                        ground_width=ground_width,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-pymavlink>=2.2.8
+pymavlink>=2.4.14
 pyserial>=3.0
+numpy

--- a/setup.py
+++ b/setup.py
@@ -27,14 +27,14 @@ package_data.extend(package_files('MAVProxy/modules/mavproxy_cesium/app'))
 # use the system versions of these dependencies, so it tries to download and install
 # large numbers of modules like numpy etc which may be already installed
 requirements=['pymavlink>=2.4.14',
-              'pyserial>=3.0']
+              'pyserial>=3.0',
+              'numpy']
 
 if platform.system() == "Darwin":
     # on MacOS we can have a more complete requirements list
     requirements.extend(['billiard>=3.5.0',
                          'gnureadline',
                          'matplotlib',
-                         'numpy',
                          'opencv-python',
                          'lxml',
                          'future',


### PR DESCRIPTION
This PR started as adding support for the SRTM1 dataset (https://terrain.ardupilot.org/SRTM1/) and allowing the user to select between the SRTM1 and SRTM3 datasets.

Along the way, I've made the ``terrain`` module the central place for all ground elevation requests where practical to do so. Previously, each module tended to have its own instance of the ``mp_elevation`` object.

The terrain data source can be switched at any time using ``terrain set source [SRTM1, SRTM3]`` or using the main menu on the map window.

The only outstanding issue is the ``misseditor`` GUI needs to be restarted if the terrain data source is changed. I've not quite worked out how to send updates to that GUI.

ping @auturgy 