### PR TITLE
movinghome: Accept position information from other constellations too

### DIFF
--- a/MAVProxy/modules/mavproxy_movinghome.py
+++ b/MAVProxy/modules/mavproxy_movinghome.py
@@ -120,7 +120,7 @@ class movinghome(mp_module.MPModule):
                     print("movinghome: decode error; baudrate issue?")
                     self.last_decode_error_print = now
                 return
-            if (data.startswith("$GPGGA")):
+            if (data.contains("GGA")):
                 msg = pynmea2.parse(data)
                 if int(msg.num_sats) > 5:
                     #convert LAT


### PR DESCRIPTION
Position information can come from other constellations too as discribed
in another ArduPilot related ticket:

https://github.com/ArduPilot/ardupilot/issues/1241

I did not test this with actual hardware. I can test this in the next days if necessary.