### PR TITLE
MAVExplorer.py: correct printing of exceptions, catch shlex exception

### DIFF
--- a/MAVProxy/tools/MAVExplorer.py
+++ b/MAVProxy/tools/MAVExplorer.py
@@ -961,6 +961,16 @@ def loadfile(args):
 
     setup_menus()
 
+def print_caught_exception(e):
+    if sys.version_info[0] >= 3:
+        ret = "%s\n" % e
+        ret += ''.join(traceback.format_exception(type(e),
+                                                  value=e,
+                                                  tb=e.__traceback__))
+        print(ret)
+    else:
+        print(traceback.format_exc(e))
+
 def process_stdin(line):
     '''handle commands from user'''
     if line is None:
@@ -970,7 +980,12 @@ def process_stdin(line):
     if not line:
         return
 
-    args = shlex.split(line)
+    try:
+        args = shlex.split(line)
+    except ValueError as e:
+        print_caught_exception(e)
+        return
+
     cmd = args[0]
     if cmd == 'help':
         k = command_map.keys()
@@ -991,14 +1006,7 @@ def process_stdin(line):
     except Exception as e:
         print("ERROR in command %s: %s" % (args[1:], str(e)))
         if mestate.settings.debug > 0:
-            if sys.version_info[0] >= 3:
-                ret = "%s\n" % e
-                ret += ''.join(traceback.format_exception(etype=type(e),
-                                                        value=e,
-                                                        tb=e.__traceback__))
-                print(ret)
-            else:
-                print(traceback.format_exc(e))
+            print_caught_exception(e)
 
 def input_loop():
     '''wait for user input'''


### PR DESCRIPTION
the exception fixes are similar to those already made in mavproxy.py - change to the way we invoke format_exception

shlex raises an exception on bad input, and not catching it makes the MAVExplorer session no-longer-responsive.

param LOG_BACKEND_TYPE\
MAV> No escaped character
Traceback (most recent call last):
  File "/home/pbarker/.local/lib/python3.10/site-packages/MAVProxy-1.8.50-py3.10.egg/EGG-INFO/scripts/MAVExplorer.py", line 984, in process_stdin
  File "/usr/lib/python3.10/shlex.py", line 315, in split
    return list(lex)
  File "/usr/lib/python3.10/shlex.py", line 300, in __next__
    token = self.get_token()
  File "/usr/lib/python3.10/shlex.py", line 109, in get_token
    raw = self.read_token()
  File "/usr/lib/python3.10/shlex.py", line 210, in read_token
    raise ValueError("No escaped character")
ValueError: No escaped character