### PR TITLE
map: remove reference to OviHybrid tile service

### DIFF
--- a/MAVProxy/modules/mavproxy_map/mp_tile.py
+++ b/MAVProxy/modules/mavproxy_map/mp_tile.py
@@ -619,7 +619,7 @@ if __name__ == "__main__":
     parser.add_option("--lat", type='float', default=-35.362938, help="start latitude")
     parser.add_option("--lon", type='float', default=149.165085, help="start longitude")
     parser.add_option("--width", type='float', default=1000.0, help="width in meters")
-    parser.add_option("--service", default="OviHybrid", help="tile service")
+    parser.add_option("--service", default="MicrosoftSat", help="tile service")
     parser.add_option("--zoom", default=None, type='int', help="zoom level")
     parser.add_option("--max-zoom", type='int', default=19, help="maximum tile zoom")
     parser.add_option("--delay", type='float', default=1.0, help="tile download delay")


### PR DESCRIPTION
Change the default value of the `--service` argument from OviHybrid to MicrosoftSat. OviHybrid was removed a few years ago, so attempting to run `mp_tile.py` as a script with no arguments results in the following error:

```
Traceback (most recent call last):
  File "/nix/store/zs9s8ncp22dpyvnhn858rpvpsch921g3-MAVProxy-1.8.53/bin/.mp_tile.py-wrapped", line 644, in <module>
    mt = MPTile(debug=opts.debug, service=opts.service,
  File "/nix/store/zs9s8ncp22dpyvnhn858rpvpsch921g3-MAVProxy-1.8.53/bin/.mp_tile.py-wrapped", line 208, in __init__
    raise TileException('unknown tile service %s' % service)
__main__.TileException: unknown tile service OviHybrid
```

MicrosoftSat was chosen as the default to match the default parameters of `MPTile`