### PR TITLE
CI: Publish Windows Installer to Github Releases

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -13,12 +13,12 @@ jobs:
         python-version: [3.8]
         
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -61,8 +61,24 @@ jobs:
           ISCC.exe /dMyAppVersion=$env:VERSION mavproxy.iss
           ls Output
       - name: Archive build
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
            name: MAVProxyInstaller
            path: windows/Output
            retention-days: 7
+      - name: Pre Release
+        uses: "marvinpinto/action-automatic-releases@latest"
+        if: github.ref == 'refs/heads/master'
+        with:
+          automatic_release_tag: "latest"
+          prerelease: true
+          title: "Development Build"
+          files: windows/Output/*.*
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Release
+        uses: "marvinpinto/action-automatic-releases@latest"
+        if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          prerelease: false
+          files: windows/Output/*.*
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This PR allows for auto-upload of the Windows Installer to the "Github Releases" tab.

There are 2 sections to this:
- The latest master will be uploaded as a pre-release
- Any tagged "v``x.y.z``" commits (semantic versioning) will be published as individual releases. So whenever a new MAVProxy version is released, the relevant commit will need to be tagged.

![Screenshot from 2022-10-24 09-38-29](https://user-images.githubusercontent.com/1731976/197421614-07b504b9-20f0-4b00-aa3e-3eb9412b1eef.png)
