### PR TITLE
Better filtering of MAVLink components

### DIFF
--- a/MAVProxy/modules/lib/mp_module.py
+++ b/MAVProxy/modules/lib/mp_module.py
@@ -205,9 +205,11 @@ class MPModule(object):
             label = str(link.linknum+1)
         return label
 
-    def is_primary_vehicle(self, msg):
+    def message_is_from_primary_vehicle(self, msg):
         '''see if a msg is from our primary vehicle'''
         sysid = msg.get_srcSystem()
-        if self.target_system == 0 or self.target_system == sysid:
+        compid = msg.get_srcComponent()
+        if ((self.target_system == 0 or self.target_system == sysid) and
+           (self.target_component == 0 or self.target_component == compid)):
             return True
         return False

--- a/MAVProxy/modules/mavproxy_console.py
+++ b/MAVProxy/modules/mavproxy_console.py
@@ -336,7 +336,7 @@ class ConsoleModule(mp_module.MPModule):
         if type == 'SYS_STATUS':
             self.check_critical_error(msg)
 
-        if not self.is_primary_vehicle(msg):
+        if not self.message_is_from_primary_vehicle(msg):
             # don't process msgs from other than primary vehicle, other than
             # updating vehicle list
             return
@@ -540,13 +540,6 @@ class ConsoleModule(mp_module.MPModule):
             self.console.set_status('PWR', status, fg=fg)
             self.console.set_status('Srv', 'Srv %.2f' % (msg.Vservo*0.001), fg='green')
         elif type in ['HEARTBEAT', 'HIGH_LATENCY2']:
-            if msg.get_srcComponent() in [mavutil.mavlink.MAV_COMP_ID_ADSB,
-                                          mavutil.mavlink.MAV_COMP_ID_ODID_TXRX_1,
-                                          mavutil.mavlink.MAV_COMP_ID_ODID_TXRX_2,
-                                          mavutil.mavlink.MAV_COMP_ID_ODID_TXRX_3]:
-                # ignore these
-                return
-
             fmode = master.flightmode
             if self.settings.vehicle_name:
                 fmode = self.settings.vehicle_name + ':' + fmode

--- a/MAVProxy/modules/mavproxy_fence.py
+++ b/MAVProxy/modules/mavproxy_fence.py
@@ -218,7 +218,7 @@ class FenceModule(mission_item_protocol.MissionItemProtocolModule):
             self.console.set_status('Fence', 'FEN', row=0, fg='red')
 
     def mavlink_packet(self, m):
-        if m.get_type() == 'SYS_STATUS':
+        if m.get_type() == 'SYS_STATUS' and self.message_is_from_primary_vehicle(m):
             self.handle_sys_status(m)
         super(FenceModule, self).mavlink_packet(m)
 

--- a/MAVProxy/modules/mavproxy_map/__init__.py
+++ b/MAVProxy/modules/mavproxy_map/__init__.py
@@ -959,7 +959,7 @@ class MapModule(mp_module.MPModule):
                     else:
                         label = None
                     self.map.set_position('Pos' + vehicle, (lat, lon), rotation=heading, label=label, colour=(255,255,255))
-                    self.map.set_follow_object('Pos' + vehicle, self.is_primary_vehicle(m))
+                    self.map.set_follow_object('Pos' + vehicle, self.message_is_from_primary_vehicle(m))
 
         elif mtype == "HIGH_LATENCY2" and self.map_settings.showahrspos:
             (lat, lon) = (m.latitude*1.0e-7, m.longitude*1.0e-7)
@@ -972,7 +972,7 @@ class MapModule(mp_module.MPModule):
                 else:
                     label = None
                 self.map.set_position('Pos' + vehicle, (lat, lon), rotation=cog, label=label, colour=(255,255,255))
-                self.map.set_follow_object('Pos' + vehicle, self.is_primary_vehicle(m))
+                self.map.set_follow_object('Pos' + vehicle, self.message_is_from_primary_vehicle(m))
 
         elif mtype == 'HOME_POSITION':
             (lat, lon) = (m.latitude*1.0e-7, m.longitude*1.0e-7)
@@ -1016,7 +1016,7 @@ class MapModule(mp_module.MPModule):
             else:
                 self.map.add_object(mp_slipmap.SlipClearLayer(tlayer))
 
-        if not self.is_primary_vehicle(m):
+        if not self.message_is_from_primary_vehicle(m):
             # the rest should only be done for the primary vehicle
             return
 


### PR DESCRIPTION
This adds the appropriate filters so that ``MAV_COMP_ID_PERIPHERAL`` devices can be used without confusing MAVProxy.

EDIT:
This PR now allows any MAVLink accessories (same sysid as flight controller, different component id) to:
a) Not confuse MAVProxy if the accessory is sending a heartbeat
b) Selecting the accessory in the console->vehicle->select menu correctly filters packets from the accessory to non-multi-vehicle-aware modules.