### PR TITLE
graph: prevent interference between graphs in MAVExplorer

### DIFF
--- a/MAVProxy/modules/lib/graph_ui.py
+++ b/MAVProxy/modules/lib/graph_ui.py
@@ -3,6 +3,7 @@ from MAVProxy.modules.lib import multiproc
 
 import errno
 import socket
+import copy
 
 graph_count = 1
 
@@ -36,7 +37,7 @@ class Graph_UI(object):
         self.mg.set_linestyle(self.mestate.settings.linestyle)
         self.mg.set_show_flightmode(self.mestate.settings.show_flightmode)
         self.mg.set_legend(self.mestate.settings.legend)
-        self.mg.add_mav(self.mestate.mlog)
+        self.mg.add_mav(copy.copy(self.mestate.mlog))
         for f in graphdef.expression.split():
             self.mg.add_field(f)
         self.mg.process(self.mestate.flightmode_selections, self.mestate.mlog._flightmodes)


### PR DESCRIPTION
use a shallow copy to make graphs independent, avoiding a parsing issue if you start a new graph before the previous graph has displayed