### PR TITLE
Ntrip: Handle ssl exception in header

### DIFF
--- a/MAVProxy/modules/lib/ntrip.py
+++ b/MAVProxy/modules/lib/ntrip.py
@@ -143,6 +143,9 @@ class NtripClient(object):
                     mps = bytearray(mps, 'ascii')
                 try:
                     self.socket.sendall(mps)
+                except ssl.SSLWantReadError:
+                    self.sent_header = False
+                    return None
                 except Exception:
                     self.socket = None
                     return None


### PR DESCRIPTION
Fixes a bug where the ntrip module silently fails if there's an ssl exception when getting the header. Now it will re-request the header if there's an exception.

Tested with ssl and non-ssl connection to ``ntrip.data.gnss.ga.gov.au``