### PR TITLE
MAVExplorer.py: add verbose-dumping of mavlink messages

### DIFF
--- a/MAVProxy/tools/MAVExplorer.py
+++ b/MAVProxy/tools/MAVExplorer.py
@@ -477,6 +477,13 @@ def cmd_stats(args):
 def cmd_dump(args):
     '''dump messages from log'''
     global xlimits
+
+    # understand --verbose to give as much information about message as possible
+    verbose = False
+    if "--verbose" in args:
+        verbose = True
+        args = list(filter(lambda x : x != "--verbose", args))
+
     if len(args) > 0:
         wildcard = args[0]
     else:
@@ -498,7 +505,10 @@ def cmd_dump(args):
             continue
         if in_range > 0:
             continue
-        print("%s %s" % (timestring(msg), msg))
+        if verbose and "pymavlink.dialects" in str(type(msg)):
+            mavutil.dump_message_verbose(sys.stdout, msg)
+        else:
+            print("%s %s" % (timestring(msg), msg))
     mlog.rewind()
 
 mfit_tool = None


### PR DESCRIPTION
based on MAVProxy's support ofthe same sort of dumping.

I've thought on several occasions I'd already done this...

```
pbarker@fx:~/rc/MAVProxy(pr/mavexplorer-gets-verbose-dumping)$ MAVExplorer.py $TLOG
/home/pbarker/.mavproxy/Blimp.xml Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration.
/home/pbarker/.mavproxy/Rover.xml Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration.
MAV> dump --verbose HEARTBEAT
MAV> 2017-10-29 12:44:09.76: HEARTBEAT (id=0) (link=None) (signed=False) (seq=0) (src=255/0)
    type: 6 (MAV_TYPE_GCS)
    autopilot: 8 (MAV_AUTOPILOT_INVALID)
    base_mode: 0
      ! MAV_MODE_FLAG_CUSTOM_MODE_ENABLED
      ! MAV_MODE_FLAG_TEST_ENABLED
      ! MAV_MODE_FLAG_AUTO_ENABLED
      ! MAV_MODE_FLAG_GUIDED_ENABLED
      ! MAV_MODE_FLAG_STABILIZE_ENABLED
      ! MAV_MODE_FLAG_HIL_ENABLED
      ! MAV_MODE_FLAG_MANUAL_INPUT_ENABLED
      ! MAV_MODE_FLAG_SAFETY_ARMED
    custom_mode: 0
    system_status: 0 (MAV_STATE_UNINIT)
    mavlink_version: 3
2017-10-29 12:44:46.95: HEARTBEAT (id=0) (link=None) (signed=False) (seq=0) (src=1/1)
    type: 1 (MAV_TYPE_FIXED_WING)
    autopilot: 3 (MAV_AUTOPILOT_ARDUPILOTMEGA)
    base_mode: 17
        MAV_MODE_FLAG_CUSTOM_MODE_ENABLED
      ! MAV_MODE_FLAG_TEST_ENABLED
      ! MAV_MODE_FLAG_AUTO_ENABLED
      ! MAV_MODE_FLAG_GUIDED_ENABLED
        MAV_MODE_FLAG_STABILIZE_ENABLED
      ! MAV_MODE_FLAG_HIL_ENABLED
      ! MAV_MODE_FLAG_MANUAL_INPUT_ENABLED
      ! MAV_MODE_FLAG_SAFETY_ARMED
    custom_mode: 16
    system_status: 2 (MAV_STATE_CALIBRATING)
    mavlink_version: 3
2017-10-29 12:44:47.00: HEARTBEAT (id=0) (link=None) (signed=False) (seq=2) (src=255/0)
    type: 6 (MAV_TYPE_GCS)
    autopilot: 8 (MAV_AUTOPILOT_INVALID)
    base_mode: 0
      ! MAV_MODE_FLAG_CUSTOM_MODE_ENABLED
      ! MAV_MODE_FLAG_TEST_ENABLED
      ! MAV_MODE_FLAG_AUTO_ENABLED
      ! MAV_MODE_FLAG_GUIDED_ENABLED
      ! MAV_MODE_FLAG_STABILIZE_ENABLED
      ! MAV_MODE_FLAG_HIL_ENABLED
      ! MAV_MODE_FLAG_MANUAL_INPUT_ENABLED
      ! MAV_MODE_FLAG_SAFETY_ARMED
    custom_mode: 0
    system_status: 0 (MAV_STATE_UNINIT)
    mavlink_version: 3
.
.
.
MAV> dump HEARTBEAT
MAV> 2017-10-29 12:44:09.767 HEARTBEAT {type : 6, autopilot : 8, base_mode : 0, custom_mode : 0, system_status : 0, mavlink_version : 3}
2017-10-29 12:44:46.951 HEARTBEAT {type : 1, autopilot : 3, base_mode : 17, custom_mode : 16, system_status : 2, mavlink_version : 3}
2017-10-29 12:44:47.004 HEARTBEAT {type : 6, autopilot : 8, base_mode : 0, custom_mode : 0, system_status : 0, mavlink_version : 3}
2017-10-29 12:44:48.013 HEARTBEAT {type : 6, autopilot : 8, base_mode : 0, custom_mode : 0, system_status : 0, mavlink_version : 3}
2017-10-29 12:44:48.095 HEARTBEAT {type : 1, autopilot : 3, base_mode : 17, custom_mode : 16, system_status : 2, mavlink_version : 3}
2017-10-29 12:44:49.004 HEARTBEAT {type : 1, autopilot : 3, base_mode : 17, custom_mode : 16, system_status : 2, mavlink_version : 3}
2017-10-29 12:44:49.015 HEARTBEAT {type : 6, autopilot : 8, base_mode : 0, custom_mode : 0, system_status : 0, mavlink_version : 3}
2017-10-29 12:44:50.017 HEARTBEAT {type : 6, autopilot : 8, base_mode : 0, custom_mode : 0, system_status : 0, mavlink_version : 3}
```
