### PR TITLE
Fix for MAV_CMD_DO_SET_ROI_LOCATION issue

### DIFF
--- a/MAVProxy/modules/mavproxy_map/__init__.py
+++ b/MAVProxy/modules/mavproxy_map/__init__.py
@@ -628,21 +628,24 @@ class MapModule(mp_module.MPModule):
             0) # no height change
 
     def cmd_set_roi(self, args):
-        '''called when user selects "Set ROI" on map'''
-        (lat, lon) = (self.mpstate.click_location[0], self.mpstate.click_location[1])
-        alt = self.module('terrain').ElevationModel.GetElevation(lat, lon)
-        print("Setting ROI to: ", lat, lon, alt)
-        self.master.mav.command_long_send(
-            self.settings.target_system, self.settings.target_component,
-            mavutil.mavlink.MAV_CMD_DO_SET_ROI_LOCATION,
-            0, # confirmation
-            0, # param1
-            0, # param2
-            0, # param3
-            0, # param4
-            lat, # lat
-            lon, # lon
-            alt) # param7
+    '''called when user selects "Set ROI" on map'''
+    (lat, lon) = (self.mpstate.click_location[0], self.mpstate.click_location[1])
+    alt = self.module('terrain').ElevationModel.GetElevation(lat, lon)
+    print("Setting ROI to: ", lat, lon, alt)
+    # this is the updated line in the code below
+    lat = int(lat * 1e7)
+    lon = int(lon * 1e7)
+    self.master.mav.command_long_send(
+        self.settings.target_system, self.settings.target_component,
+        mavutil.mavlink.MAV_CMD_DO_SET_ROI_LOCATION,
+        0, # confirmation
+        0, # param1
+        0, # param2
+        0, # param3
+        0, # param4
+        lat, # lat
+        lon, # lon
+        alt) # param7
         
     def cmd_set_origin(self, args):
         '''called when user selects "Set Origin (with height)" on map'''


### PR DESCRIPTION
@rmackay9, This pull request resolves the issue with the MAV_CMD_DO_SET_ROI_LOCATION command in the simulated vehicle SITL instance.

According to the MAVLink docs, the latitude and longitude fields should be in 1e7 form, however, the firmware and also MAVProxy implemented this feature with float numbers, causing the simulated vehicle SITL instance to immediately stop working.

This pull request changes the code so that the lat, lon, and alt fields are correctly specified in 1e7 form, ensuring that the simulated vehicle SITL instance will function correctly.

**Changes Made**
The cmd_set_roi function was updated to convert the lat, lon fields to int and multiply them by 1e7 before sending the **MAV_CMD_DO_SET_ROI_LOCATION** command.

**Types of changes**
Bug fix