### PR TITLE
map: use command_int when sending ROI

### DIFF
--- a/MAVProxy/modules/mavproxy_map/__init__.py
+++ b/MAVProxy/modules/mavproxy_map/__init__.py
@@ -632,16 +632,18 @@ class MapModule(mp_module.MPModule):
         (lat, lon) = (self.mpstate.click_location[0], self.mpstate.click_location[1])
         alt = self.module('terrain').ElevationModel.GetElevation(lat, lon)
         print("Setting ROI to: ", lat, lon, alt)
-        self.master.mav.command_long_send(
+        self.master.mav.command_int_send(
             self.settings.target_system, self.settings.target_component,
+            mavutil.mavlink.MAV_FRAME_GLOBAL,
             mavutil.mavlink.MAV_CMD_DO_SET_ROI_LOCATION,
-            0, # confirmation
+            0, # current
+            0, # autocontinue
             0, # param1
             0, # param2
             0, # param3
             0, # param4
-            lat, # lat
-            lon, # lon
+            int(lat*1e7), # lat
+            int(lon*1e7), # lon
             alt) # param7
         
     def cmd_set_origin(self, args):


### PR DESCRIPTION
ArduPilot interprets the command_long frame as relative-alt - we are sending through an AMSL alt of the terrain for the lat/lon.

Using command_int means we remove this problem by actually specifying our frame.

This work sponsored by Harris Aerial
