### PR TITLE
link: add option to watch messages verbosely

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -101,6 +101,7 @@ class MPStatus(object):
         self.lost_gps_lock = False
         self.last_gps_lock = 0
         self.watch = None
+        self.watch_verbose = False
         self.last_streamrate1 = -1
         self.last_streamrate2 = -1
         self.last_seq = 0
@@ -475,7 +476,14 @@ def cmd_watch(args):
     '''watch a mavlink packet pattern'''
     if len(args) == 0:
         mpstate.status.watch = None
+        mpstate.status.watch_verbose = False
         return
+    if "--verbose" in args:
+        mpstate.status.watch_verbose = True
+        args.remove('--verbose')
+    else:
+        mpstate.status.watch_verbose = False
+
     mpstate.status.watch = args
     print("Watching %s" % mpstate.status.watch)
 


### PR DESCRIPTION
 - factors the watch stuff into a method
 - allows --verbose to show details about the messages going back and forth:

Note the additional useful information below if which system we are getting the ACK from:

```
LOITER> watch --verbose COMMAND_ACK
LOITER> Watching ['COMMAND_ACK']

LOITER> 
LOITER> 
LOITER> arm throttle
LOITER> Got COMMAND_ACK: COMPONENT_ARM_DISARM: ACCEPTED
< 2023-03-02 11:32:00.25: COMMAND_ACK (id=77) (link=None) (signed=False) (seq=184) (src=1/1)
    command: 400 (MAV_CMD_COMPONENT_ARM_DISARM)
    result: 0 (MAV_RESULT_ACCEPTED)
    progress: 0
    result_param2: 0
    target_system: 145
    target_component: 230

Got COMMAND_ACK: COMPONENT_ARM_DISARM: DENIED
< 2023-03-02 11:32:00.26: COMMAND_ACK (id=77) (link=None) (signed=False) (seq=16) (src=1/154)
    command: 400 (MAV_CMD_COMPONENT_ARM_DISARM)
    result: 2 (MAV_RESULT_DENIED)
    progress: 0
    result_param2: 0
    target_system: 145
    target_component: 230

watch COMMAND_ACK
LOITER> Watching ['COMMAND_ACK']

LOITER> 
LOITER> arm throttle
LOITER> Got COMMAND_ACK: COMPONENT_ARM_DISARM: ACCEPTED
< COMMAND_ACK {command : 400, result : 0, progress : 0, result_param2 : 0, target_system : 145, target_component : 230}
Got COMMAND_ACK: COMPONENT_ARM_DISARM: DENIED
< COMMAND_ACK {command : 400, result : 2, progress : 0, result_param2 : 0, target_system : 145, target_component : 230}
watch
LOITER> arm throttle
LOITER> Got COMMAND_ACK: COMPONENT_ARM_DISARM: ACCEPTED
Got COMMAND_ACK: COMPONENT_ARM_DISARM: DENIED
```

This work sponsored by Harris Aerial
