### PR TITLE
Use mavlink DO_MOUNT_CONTROL in place of old MOUNT_CONTROL message

### DIFF
--- a/MAVProxy/modules/mavproxy_gimbal.py
+++ b/MAVProxy/modules/mavproxy_gimbal.py
@@ -90,14 +90,20 @@ class GimbalModule(mp_module.MPModule):
             print("No map click position available and no parameters set")
             return
         elif latlon is None:
-            print("usage: gimbal roi [LAT LON ALT]")
+            print("usage: gimbal roi [LAT LON RELHOMEALT]")
             return
-        self.master.mav.mount_control_send(self.target_system,
-                                           self.target_component,
-                                           int(latlon[0]*1e7),
-                                           int(latlon[1]*1e7),
-                                           int(alt),
-                                           0)
+        self.master.mav.command_long_send(
+            self.settings.target_system,
+            self.settings.target_component,
+            mavutil.mavlink.MAV_CMD_DO_MOUNT_CONTROL,
+            0, # confirmation
+            0, # param1
+            0, # param2
+            0, # param3
+            alt, # param4 - alt (exception to the usual rule about where this goes)
+            int(latlon[0]*1e7), # lat
+            int(latlon[1]*1e7), # lon
+            mavutil.mavlink.MAV_MOUNT_MODE_GPS_POINT) # param7
 
     def cmd_gimbal_roi_vel(self, args):
         '''control roi position and velocity'''

--- a/MAVProxy/modules/mavproxy_gimbal.py
+++ b/MAVProxy/modules/mavproxy_gimbal.py
@@ -156,12 +156,18 @@ class GimbalModule(mp_module.MPModule):
             print("usage: gimbal point ROLL PITCH YAW")
             return
         (roll, pitch, yaw) = (float(args[0]), float(args[1]), float(args[2]))
-        self.master.mav.mount_control_send(self.target_system,
-                                           self.target_component,
-                                           int(pitch*100),
-                                           int(roll*100),
-                                           int(yaw*100),
-                                           0)
+        self.master.mav.command_long_send(
+            self.settings.target_system,
+            self.settings.target_component,
+            mavutil.mavlink.MAV_CMD_DO_MOUNT_CONTROL,
+            0, # confirmation
+            pitch, # param1
+            roll, # param2
+            yaw, # param3
+            0, # param4
+            0, # lat
+            0, # lon
+            mavutil.mavlink.MAV_MOUNT_MODE_MAVLINK_TARGETING) # param7
 
     def cmd_gimbal_status(self, args):
         '''show gimbal status'''


### PR DESCRIPTION
ArduPIlot has started to send deprecation warnings for the old mount messages and they will be removed at some point.

This work sponsored by Harris Aerial
