### PR TITLE
mavproxy_wp: correct re-requesting of waypoints

### DIFF
--- a/MAVProxy/modules/mavproxy_wp.py
+++ b/MAVProxy/modules/mavproxy_wp.py
@@ -31,7 +31,6 @@ class WPModule(mp_module.MPModule):
         self.undo_type = None
         self.undo_wp_idx = -1
         self.upload_start = None
-        self.wploader.expected_count = 0
         self.last_get_home = time.time()
         self.add_command('wp', self.cmd_wp,       'waypoint management',
                          ["<list|clear|move|remove|loop|set|undo|movemulti|moverelhome|changealt|param|status|slope|ftp|add_takeoff|add_landing|add_dls|add_rtl>",
@@ -79,6 +78,7 @@ class WPModule(mp_module.MPModule):
         '''per-sysid wploader'''
         if self.target_system not in self.wploader_by_sysid:
             self.wploader_by_sysid[self.target_system] = mavwp.MAVWPLoader()
+            self.wploader_by_sysid[self.target_system].expected_count = 0
         return self.wploader_by_sysid[self.target_system]
 
     def missing_wps_to_request(self):


### PR DESCRIPTION
this was attempting to transfer new waypoints automatically and utterly failing.

So just warn the user that their mission is stale based on what the autopilot is announcing.

Alternative to @magicrub 's https://github.com/ArduPilot/MAVProxy/pull/1152
