### PR TITLE
ftp: adjust default read/write sizes

### DIFF
--- a/MAVProxy/modules/mavproxy_ftp.py
+++ b/MAVProxy/modules/mavproxy_ftp.py
@@ -106,8 +106,8 @@ class FTPModule(mp_module.MPModule):
              ('pkt_loss_tx', int, 0),
              ('pkt_loss_rx', int, 0),
              ('max_backlog', int, 5),
-             ('burst_read_size', int, 110),
-             ('write_size', int, 110),
+             ('burst_read_size', int, 80),
+             ('write_size', int, 80),
              ('write_qsize', int, 5),
              ('retry_time', float, 0.5)])
         self.add_completion_function('(FTPSETTING)',


### PR DESCRIPTION
the RFD900x with multipoint firmware does extremely badly at ftp with the normal packet sizes, making param ftp impossible. Using smaller sizes works well and has very little effect on SiK and USB