### PR TITLE
mavproxy_map: fix Python3 keys issue

### DIFF
--- a/MAVProxy/modules/mavproxy_map/mp_slipmap_ui.py
+++ b/MAVProxy/modules/mavproxy_map/mp_slipmap_ui.py
@@ -702,7 +702,7 @@ class MPSlipMapPanel(wx.Panel):
         '''clear all thumbnails from the map'''
         state = self.state
         for l in state.layers:
-            keys = state.layers[l].keys()[:]
+            keys = list(state.layers[l].keys())[:]
             for key in keys:
                 if (isinstance(state.layers[l][key], SlipThumbnail)
                     and not isinstance(state.layers[l][key], SlipIcon)):


### PR DESCRIPTION
this fixes the error you get when typing "c" into the map 

![image](https://user-images.githubusercontent.com/7077857/232185013-fc5ede76-1ae3-439e-80e3-3069addf5e2d.png)

