### PR TITLE
Vtol: add vtol mav type

### DIFF
--- a/MAVProxy/modules/mavproxy_console.py
+++ b/MAVProxy/modules/mavproxy_console.py
@@ -179,7 +179,10 @@ class ConsoleModule(mp_module.MPModule):
 
     def vehicle_type_string(self, hb):
         '''return vehicle type string from a heartbeat'''
-        if hb.type == mavutil.mavlink.MAV_TYPE_FIXED_WING:
+        if hb.type in [mavutil.mavlink.MAV_TYPE_FIXED_WING,
+                            mavutil.mavlink.MAV_TYPE_VTOL_DUOROTOR,
+                            mavutil.mavlink.MAV_TYPE_VTOL_QUADROTOR,
+                            mavutil.mavlink.MAV_TYPE_VTOL_TILTROTOR]:
             return 'Plane'
         if hb.type == mavutil.mavlink.MAV_TYPE_GROUND_ROVER:
             return 'Rover'

--- a/MAVProxy/modules/mavproxy_link.py
+++ b/MAVProxy/modules/mavproxy_link.py
@@ -671,7 +671,10 @@ class LinkModule(mp_module.MPModule):
                     self.status.last_mode_announced = master.flightmode
                     self.say("Mode " + self.status.flightmode)
 
-            if m.type == mavutil.mavlink.MAV_TYPE_FIXED_WING:
+            if m.type in [mavutil.mavlink.MAV_TYPE_FIXED_WING,
+                            mavutil.mavlink.MAV_TYPE_VTOL_DUOROTOR,
+                            mavutil.mavlink.MAV_TYPE_VTOL_QUADROTOR,
+                            mavutil.mavlink.MAV_TYPE_VTOL_TILTROTOR]:
                 self.mpstate.vehicle_type = 'plane'
                 self.mpstate.vehicle_name = 'ArduPlane'
             elif m.type in [mavutil.mavlink.MAV_TYPE_GROUND_ROVER,

--- a/MAVProxy/modules/mavproxy_map/__init__.py
+++ b/MAVProxy/modules/mavproxy_map/__init__.py
@@ -720,7 +720,10 @@ class MapModule(mp_module.MPModule):
         if mtype == "HEARTBEAT" or mtype == "HIGH_LATENCY2":
             vname = None
             vtype = self.vehicle_type_override.get(sysid, m.type)
-            if vtype in [mavutil.mavlink.MAV_TYPE_FIXED_WING]:
+            if vtype in [mavutil.mavlink.MAV_TYPE_FIXED_WING,
+                            mavutil.mavlink.MAV_TYPE_VTOL_DUOROTOR,
+                            mavutil.mavlink.MAV_TYPE_VTOL_QUADROTOR,
+                            mavutil.mavlink.MAV_TYPE_VTOL_TILTROTOR]:
                 vname = 'plane'
             elif vtype in [mavutil.mavlink.MAV_TYPE_GROUND_ROVER]:
                 vname = 'rover'

--- a/MAVProxy/modules/mavproxy_swarm.py
+++ b/MAVProxy/modules/mavproxy_swarm.py
@@ -19,7 +19,10 @@ from MAVProxy.modules.lib.wx_loader import wx
 
 def get_vehicle_name(vehtype):
     '''return vehicle type string from a heartbeat'''
-    if vehtype == mavutil.mavlink.MAV_TYPE_FIXED_WING:
+    if vehtype in [mavutil.mavlink.MAV_TYPE_FIXED_WING,
+                   mavutil.mavlink.MAV_TYPE_VTOL_DUOROTOR,
+                   mavutil.mavlink.MAV_TYPE_VTOL_QUADROTOR,
+                   mavutil.mavlink.MAV_TYPE_VTOL_TILTROTOR]:
         return 'Plane'
     if vehtype == mavutil.mavlink.MAV_TYPE_GROUND_ROVER:
         return 'Rover'
@@ -775,6 +778,9 @@ class swarm(mp_module.MPModule):
         self.allVehPos = {}
 
         self.validVehicles = frozenset([mavutil.mavlink.MAV_TYPE_FIXED_WING,
+                              mavutil.mavlink.MAV_TYPE_VTOL_DUOROTOR,
+                              mavutil.mavlink.MAV_TYPE_VTOL_QUADROTOR,
+                              mavutil.mavlink.MAV_TYPE_VTOL_TILTROTOR,
                               mavutil.mavlink.MAV_TYPE_GROUND_ROVER,
                               mavutil.mavlink.MAV_TYPE_SURFACE_BOAT,
                               mavutil.mavlink.MAV_TYPE_SUBMARINE,

--- a/MAVProxy/tools/mavflightview.py
+++ b/MAVProxy/tools/mavflightview.py
@@ -127,7 +127,10 @@ def colourmap_for_mav_type(mav_type):
                     mavutil.mavlink.MAV_TYPE_COAXIAL,
                     mavutil.mavlink.MAV_TYPE_TRICOPTER]:
         map = colour_map_copter
-    if mav_type == mavutil.mavlink.MAV_TYPE_FIXED_WING:
+    if mav_type in [mavutil.mavlink.MAV_TYPE_FIXED_WING,
+                    mavutil.mavlink.MAV_TYPE_VTOL_DUOROTOR,
+                    mavutil.mavlink.MAV_TYPE_VTOL_QUADROTOR,
+                    mavutil.mavlink.MAV_TYPE_VTOL_TILTROTOR]:
         map = colour_map_plane
     if mav_type in [mavutil.mavlink.MAV_TYPE_GROUND_ROVER,
                     mavutil.mavlink.MAV_TYPE_SURFACE_BOAT]:


### PR DESCRIPTION
Fixed a problem in which this PR(https://github.com/ArduPilot/ardupilot/pull/21596) caused quadplane's SITL startup to incorrectly display frame types.
