### PR TITLE
Fix warnings after clearing mission

### DIFF
--- a/MAVProxy/modules/lib/mission_item_protocol.py
+++ b/MAVProxy/modules/lib/mission_item_protocol.py
@@ -787,6 +787,7 @@ on'''
         self.wploader.clear()
         if getattr(self.wploader, 'expected_count', None) is not None:
             self.wploader.expected_count = 0
+        self.wploader.expected_count = 0
         self.loading_waypoint_lasttime = time.time()
 
     def cmd_list(self, args):

--- a/MAVProxy/modules/mavproxy_misseditor/mission_editor.py
+++ b/MAVProxy/modules/mavproxy_misseditor/mission_editor.py
@@ -290,7 +290,7 @@ class MissionEditorMain(object):
             #write has been sent by the mission editor:
             elif (self.num_wps_expected > 1):
                 if (m.count != self.num_wps_expected):
-                    self.mpstate.console.error("Unexpected waypoint count from vehicle after write (Editor)")
+                    self.mpstate.console.error("wpedit: mission is stale")
                 #since this is a write operation from the Editor there
                 #should be no need to update number of table rows
 

--- a/MAVProxy/modules/mavproxy_misseditor/mission_editor.py
+++ b/MAVProxy/modules/mavproxy_misseditor/mission_editor.py
@@ -306,6 +306,12 @@ class MissionEditorMain(object):
                         lat=m.x,lon=m.y,alt=m.z,frame=m.frame))
 
                     self.wps_received[m.seq] = True
+                    if len(self.wps_received) == self.num_wps_expected:
+                        # if we have received everything then reset
+                        # our state to indicate we're not currently
+                        # expecting waypoints.  That way if we receive
+                        # a count we don't expect we don't spew errors
+                        self.num_wps_expected = -1
 
     def child_task(self, q, l, gq, gl, cw_sem, elemodel):
         '''child process - this holds GUI elements'''


### PR DESCRIPTION
Steps to reproduce:

```
./Tools/autotest/sim_vehicle.py -v ArduCopter --gdb --debug --map

wp load Tools/autotest/ArduCopter_Tests/copter_terrain_mission.txt
```

Kill the simulation and restart

```
wpedit
```

"Read WPs` in the Mission Editor interface

Right-click in the map and select Mission -> Clear

Observe the error messages in the console:

![image](https://github.com/ArduPilot/MAVProxy/assets/7077857/f4ac4f13-49c8-4be4-ba27-3db49146d882)

After this patch no errors in console.
