### PR TITLE
mavproxy_link: add moddebug=4 for full stack trace

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -252,7 +252,7 @@ class MPState(object):
                         range=(0,100), increment=1, tab='Announcements'),
               MPSetting('distreadout', int, 200, 'Distance Readout', range=(0,10000), increment=1),
 
-              MPSetting('moddebug', int, opts.moddebug, 'Module Debug Level', range=(0,3), increment=1, tab='Debug'),
+              MPSetting('moddebug', int, opts.moddebug, 'Module Debug Level', range=(0,4), increment=1, tab='Debug'),
               MPSetting('script_fatal', bool, False, 'fatal error on bad script', tab='Debug'),
               MPSetting('compdebug', int, 0, 'Computation Debug Mask', range=(0,3), tab='Debug'),
               MPSetting('flushlogs', bool, False, 'Flush logs on every packet'),

--- a/MAVProxy/modules/mavproxy_link.py
+++ b/MAVProxy/modules/mavproxy_link.py
@@ -978,12 +978,19 @@ class LinkModule(mp_module.MPModule):
                 try:
                     mod.mavlink_packet(m)
                 except Exception as msg:
-                    if self.mpstate.settings.moddebug == 1:
-                        print(msg)
+                    exc_type, exc_value, exc_traceback = sys.exc_info()
+                    if self.mpstate.settings.moddebug > 3:
+                        traceback.print_exception(
+                            exc_type,
+                            exc_value,
+                            exc_traceback,
+                            file=sys.stdout
+                        )
                     elif self.mpstate.settings.moddebug > 1:
-                        exc_type, exc_value, exc_traceback = sys.exc_info()
                         traceback.print_exception(exc_type, exc_value, exc_traceback,
                                                   limit=2, file=sys.stdout)
+                    elif self.mpstate.settings.moddebug == 1:
+                        print(msg)
 
     def cmd_vehicle(self, args):
         '''handle vehicle commands'''


### PR DESCRIPTION
this is like moddebug >1 but prints full stack trace rather than just two lines

In the following code a call to a "fail" method was inserted in mavproxy_wp.py in send_wp_requests.  You can see that not limiting the stack trace depth a more useful debug message is produced.

with moddebug 3:
```
STABILIZE> Requesting 0 waypoints t=Fri Jul 28 18:19:44 2023 now=Fri Jul 28 18:19:44 2023 Traceback (most recent call last):
  File "/home/pbarker/.local/lib/python3.10/site-packages/MAVProxy-1.8.65-py3.10.egg/MAVProxy/modules/mavproxy_link.py", line 979, in master_callback
    mod.mavlink_packet(m)
  File "/home/pbarker/.local/lib/python3.10/site-packages/MAVProxy-1.8.65-py3.10.egg/MAVProxy/modules/mavproxy_wp.py", line 164, in mavlink_packet
    self.send_wp_requests()
NameError: name 'fail' is not defined
```
with moddebug 4:

```
STABILIZE> Requesting 0 waypoints t=Fri Jul 28 18:20:28 2023 now=Fri Jul 28 18:20:28 2023 Traceback (most recent call last):
  File "/home/pbarker/.local/lib/python3.10/site-packages/MAVProxy-1.8.65-py3.10.egg/MAVProxy/modules/mavproxy_link.py", line 979, in master_callback
    mod.mavlink_packet(m)
  File "/home/pbarker/.local/lib/python3.10/site-packages/MAVProxy-1.8.65-py3.10.egg/MAVProxy/modules/mavproxy_wp.py", line 164, in mavlink_packet
    self.send_wp_requests()
  File "/home/pbarker/.local/lib/python3.10/site-packages/MAVProxy-1.8.65-py3.10.egg/MAVProxy/modules/mavproxy_wp.py", line 127, in send_wp_requests
    fail()
```
