### PR TITLE
map: fixed menu on map with multiple objects

### DIFF
--- a/MAVProxy/modules/mavproxy_map/__init__.py
+++ b/MAVProxy/modules/mavproxy_map/__init__.py
@@ -258,14 +258,14 @@ class MapModule(mp_module.MPModule):
         self.mission_list = self.module('wp').wploader.view_list()
         polygons = self.module('wp').wploader.polygon_list()
         self.map.add_object(mp_slipmap.SlipClearLayer('Mission'))
+        items = [MPMenuItem('WP Set', returnkey='popupMissionSet'),
+                     MPMenuItem('WP Remove', returnkey='popupMissionRemove'),
+                     MPMenuItem('WP Move', returnkey='popupMissionMove'),
+                     MPMenuItem('WP Split', returnkey='popupMissionSplit'),
+                    ]
         for i in range(len(polygons)):
             p = polygons[i]
             if len(p) > 1:
-                items = [MPMenuItem('WP Set', returnkey='popupMissionSet'),
-                         MPMenuItem('WP Remove', returnkey='popupMissionRemove'),
-                         MPMenuItem('WP Move', returnkey='popupMissionMove'),
-                         MPMenuItem('WP Split', returnkey='popupMissionSplit'),
-                ]
                 popup = MPMenuSubMenu('Popup', items)
                 self.map.add_object(mp_slipmap.SlipPolygon('mission %u' % i, p,
                                                                    layer='Mission', linewidth=2, colour=(255,255,255),

--- a/MAVProxy/modules/mavproxy_map/mp_slipmap_util.py
+++ b/MAVProxy/modules/mavproxy_map/mp_slipmap_util.py
@@ -282,7 +282,13 @@ class SlipPolygon(SlipObject):
         '''
         if self.hidden:
             return None
-        for i in range(len(self._pix_points)):
+        num_points = len(self._pix_points)
+        if num_points <= 0:
+            return None
+        for idx in range(num_points):
+            # the odd ordering here is to that the home point, which is index 0, is checked last
+            # as home cannot be moved
+            i = (idx+1) % num_points
             if self._pix_points[i] is None:
                 continue
             (pixx,pixy) = self._pix_points[i]


### PR DESCRIPTION
when you right click and the position matches multiple objects then check each of the objects rather than just the first one

example with both polygon and wp matching the click point
![image](https://github.com/ArduPilot/MAVProxy/assets/831867/00df618b-6c68-4743-9474-e954c312829c)
