### PR TITLE
mavproxy_mode: use MAV_CMD_DO_REPOSITION for 'Fly To'

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -267,6 +267,7 @@ class MPState(object):
               MPSetting('rallyalt', int, 90, 'Default Rally Altitude', range=(0,10000), increment=1),
               MPSetting('terrainalt', str, 'Auto', 'Use terrain altitudes', choice=['Auto','True','False']),
               MPSetting('guidedalt', int, 100, 'Default "Fly To" Altitude', range=(0,10000), increment=1),
+              MPSetting('guided_use_reposition', bool, True, 'Use MAV_CMD_DO_REPOSITION for guided fly-to'),
               MPSetting('rally_breakalt', int, 40, 'Default Rally Break Altitude', range=(0,10000), increment=1),
               MPSetting('rally_flags', int, 0, 'Default Rally Flags', range=(0,10000), increment=1),
 

--- a/MAVProxy/modules/mavproxy_mode.py
+++ b/MAVProxy/modules/mavproxy_mode.py
@@ -84,6 +84,25 @@ class ModeModule(mp_module.MPModule):
             altitude = float(args[0])
 
         print("Guided %s %s" % (str(latlon), str(altitude)))
+
+        if self.settings.guided_use_reposition:
+            self.master.mav.command_int_send(
+                self.settings.target_system,
+                self.settings.target_component,
+                self.module('wp').get_default_frame(),
+                mavutil.mavlink.MAV_CMD_DO_REPOSITION,
+                0,  # current
+                0,  # autocontinue
+                -1,   # p1 - ground speed, -1 is use-default
+                mavutil.mavlink.MAV_DO_REPOSITION_FLAGS_CHANGE_MODE,   # p2 - flags
+                0,   # p3 - loiter radius for Planes, 0 is ignored
+                0,   # p4 - yaw - 0 is loiter clockwise
+                int(latlon[0]*1.0e7),
+                int(latlon[1]*1.0e7),
+                altitude
+            )
+            return
+
         self.master.mav.mission_item_int_send(
             self.settings.target_system,
             self.settings.target_component,


### PR DESCRIPTION
this has the advantage that you don't need to be in guided mode to start the command.  Prevents some clunk interactions between pilot and GCS operator as the vehicle does not need to be somewhere safe to loiter before the command can be safely issued.

Tested Copter, Plane and Rover in SITL.  Altitudes appear to be correct.
