### PR TITLE
mavproxy_joystick: Improve scale for joystick axis

### DIFF
--- a/MAVProxy/modules/mavproxy_joystick/controls.py
+++ b/MAVProxy/modules/mavproxy_joystick/controls.py
@@ -79,7 +79,7 @@ class Axis (Control):
         if self.invert:
             val = -val
 
-        return scale(val, outlow=self.outlow, outhigh=self.outhigh)
+        return scale(val, inlow=self.inlow, inhigh=self.inhigh, outlow=self.outlow, outhigh=self.outhigh)
 
 
 class Hat (Control):


### PR DESCRIPTION
Improve scale for joystick axis. If inputLow and inputHigh are not -1 and 1, the scaling function must use the actual joystick input values.