### PR TITLE
Remove param defaults download

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -49,10 +49,6 @@ jobs:
           $wc.DownloadFile('https://autotest.ardupilot.org/Parameters/ArduPlane/apm.pdef.xml', 'Parameters\ArduPlane.xml')
           $wc.DownloadFile('https://autotest.ardupilot.org/Parameters/ArduSub/apm.pdef.xml', 'Parameters\ArduSub.xml')
           $wc.DownloadFile('https://autotest.ardupilot.org/Parameters/AntennaTracker/apm.pdef.xml', 'Parameters\AntennaTracker.xml')
-          $wc.DownloadFile('https://autotest.ardupilot.org/Rover-defaults.parm', 'Parameters\Rover-defaults.parm')
-          $wc.DownloadFile('https://autotest.ardupilot.org/Copter-defaults.parm', 'Parameters\ArduCopter-defaults.parm')
-          $wc.DownloadFile('https://autotest.ardupilot.org/Plane-defaults.parm', 'Parameters\ArduPlane-defaults.parm')
-          $wc.DownloadFile('https://autotest.ardupilot.org/Sub-defaults.parm', 'Parameters\ArduSub-defaults.parm')
       - name: Build installer
         run: |
           cd  windows

--- a/MAVProxy/modules/lib/param_help.py
+++ b/MAVProxy/modules/lib/param_help.py
@@ -17,11 +17,6 @@ class ParamHelp:
             url = 'http://autotest.ardupilot.org/Parameters/%s/apm.pdef.xml.gz' % vehicle
             path = mp_util.dot_mavproxy("%s.xml" % vehicle)
             files.append((url, path))
-            url = 'http://autotest.ardupilot.org/%s-defaults.parm' % vehicle
-            if vehicle != 'AntennaTracker':
-                # defaults not generated for AntennaTracker ATM
-                path = mp_util.dot_mavproxy("%s-defaults.parm" % vehicle)
-                files.append((url, path))
         try:
             child = multiproc.Process(target=mp_util.download_files, args=(files,))
             child.start()

--- a/MAVProxy/modules/mavproxy_paramedit/param_editor_frame.py
+++ b/MAVProxy/modules/mavproxy_paramedit/param_editor_frame.py
@@ -548,11 +548,6 @@ class ParamEditorFrame(wx.Frame):
             url = 'http://autotest.ardupilot.org/Parameters/%s/apm.pdef.xml' % vehicle
             path = mp_util.dot_mavproxy("%s.xml" % vehicle)
             files.append((url, path))
-            url = 'http://autotest.ardupilot.org/%s-defaults.parm' % vehicle
-            if vehicle != 'AntennaTracker':
-                # defaults not generated for AntennaTracker ATM
-                path = mp_util.dot_mavproxy("%s-defaults.parm" % vehicle)
-                files.append((url, path))
         try:
             child = multiproc.Process(target=mp_util.download_files, args=(files,))
             child.start()

--- a/windows/MAVProxyWinBuild.bat
+++ b/windows/MAVProxyWinBuild.bat
@@ -51,10 +51,6 @@ powershell.exe "Start-BitsTransfer -Source 'http://autotest.ardupilot.org/Parame
 powershell.exe "Start-BitsTransfer -Source 'http://autotest.ardupilot.org/Parameters/ArduPlane/apm.pdef.xml' -Destination 'Parameters\ArduPlane.xml'"
 powershell.exe "Start-BitsTransfer -Source 'http://autotest.ardupilot.org/Parameters/ArduSub/apm.pdef.xml' -Destination 'Parameters\ArduSub.xml'"
 powershell.exe "Start-BitsTransfer -Source 'http://autotest.ardupilot.org/Parameters/AntennaTracker/apm.pdef.xml' -Destination 'Parameters\AntennaTracker.xml'"
-powershell.exe "Start-BitsTransfer -Source 'http://autotest.ardupilot.org/Rover-defaults.parm' -Destination 'Parameters\Rover-defaults.parm'"
-powershell.exe "Start-BitsTransfer -Source 'http://autotest.ardupilot.org/Copter-defaults.parm' -Destination 'Parameters\ArduCopter-defaults.parm'"
-powershell.exe "Start-BitsTransfer -Source 'http://autotest.ardupilot.org/Plane-defaults.parm' -Destination 'Parameters\ArduPlane-defaults.parm'"
-powershell.exe "Start-BitsTransfer -Source 'http://autotest.ardupilot.org/Sub-defaults.parm' -Destination 'Parameters\ArduSub-defaults.parm'"
 
 rem -----Build the Installer-----
 cd .\windows


### PR DESCRIPTION
Companion to https://github.com/ArduPilot/ardupilot/commit/4317a40fef9a54d62078ff64bdf3948404d4cb02, which removed the generation of param defaults.

This PR removes all references to downloading the param defaults.