### PR TITLE
MAVEXplorer.py: reassemble STATUSTEXT message chunks into single line ouput

### DIFF
--- a/MAVProxy/tools/MAVExplorer.py
+++ b/MAVProxy/tools/MAVExplorer.py
@@ -16,6 +16,9 @@ import threading
 import shlex
 import traceback
 from math import *
+
+os.environ['MAVLINK20'] = '1'
+
 from MAVProxy.modules.lib import multiproc
 from MAVProxy.modules.lib import rline
 from MAVProxy.modules.lib import wxconsole


### PR DESCRIPTION
... in messages command

Before:
![image](https://github.com/ArduPilot/MAVProxy/assets/7077857/ea27b93e-6851-4ceb-9eba-2cf5f444e200)


After:
![image](https://github.com/ArduPilot/MAVProxy/assets/7077857/b9d76a75-58ce-440e-88f8-b2c7519f8cb3)

also before (large terminal):
![image](https://github.com/ArduPilot/MAVProxy/assets/7077857/68c40a23-8112-4de0-a56b-a15343bf06e7)

also after (large terminal):
![image](https://github.com/ArduPilot/MAVProxy/assets/7077857/cddc03fb-d089-44ef-86ba-ecc4923205e5)

