### PR TITLE
MAVExplorer.py: Fix XML warnings when opening a file

### DIFF
--- a/MAVProxy/tools/MAVExplorer.py
+++ b/MAVProxy/tools/MAVExplorer.py
@@ -337,7 +337,7 @@ def load_graphs():
             continue
         # skip parameter files.  They specify an encoding, and under
         # Python3 this leads to a warning from etree
-        if os.path.basename(file) in ["ArduSub.xml", "ArduPlane.xml", "APMrover2.xml", "ArduCopter.xml", "AntennaTracker.xml"]:
+        if os.path.basename(file) in ["ArduSub.xml", "ArduPlane.xml", "APMrover2.xml", "ArduCopter.xml", "AntennaTracker.xml", "Blimp.xml", "Rover.xml"]:
             continue
         graphs = load_graph_xml(open(file).read(), file)
         if graphs:


### PR DESCRIPTION
When opening a file in MAVExplorer.py, I see the following warnings:
```
/home/simon/.mavproxy/Blimp.xml Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration.
/home/simon/.mavproxy/Rover.xml Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration.
``` 

There is already a comment and line in load_graphs function which selects XML files to _not_ to open to avoid this warning. The fix implemented is simply to add "Blimp.xml", "Rover.xml" to this list.

Tested after fix, and warning does not appear, and tool behaves as expected.