### PR TITLE
Fix useralerts module to use MAV_CMD_REQUEST_MESSAGE

### DIFF
--- a/MAVProxy/modules/mavproxy_misc.py
+++ b/MAVProxy/modules/mavproxy_misc.py
@@ -322,23 +322,22 @@ class MiscModule(mp_module.MPModule):
         else:
             print("Usage: land [abort]")
 
-    def cmd_version(self, args):
-        '''show version'''
+    def request_message(self, message_id, p1=0):
         self.master.mav.command_long_send(
             self.settings.target_system,
             self.settings.target_component,
             mavutil.mavlink.MAV_CMD_REQUEST_MESSAGE,
             0, # confirmation
-            mavutil.mavlink.MAVLINK_MSG_ID_AUTOPILOT_VERSION, 0, 0, 0, 0, 0, 0)
+            message_id, 0, 0, 0, 0, 0, 0)
+
+    def cmd_version(self, args):
+        '''show version'''
+        self.request_message(mavutil.mavlink.MAVLINK_MSG_ID_AUTOPILOT_VERSION)
 
     def cmd_capabilities(self, args):
         '''show capabilities'''
-        self.master.mav.command_long_send(self.settings.target_system,
-                                          self.settings.target_component,
-                                          mavutil.mavlink.MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES,
-                                          0,
-                                          1, 0, 0, 0, 0, 0, 0)
-        
+        self.request_message(mavutil.mavlink.MAVLINK_MSG_ID_AUTOPILOT_VERSION)
+
     def cmd_rcbind(self, args):
         '''start RC bind'''
         if len(args) < 1:

--- a/MAVProxy/modules/mavproxy_useralerts.py
+++ b/MAVProxy/modules/mavproxy_useralerts.py
@@ -142,31 +142,24 @@ class UserAlertsModule(mp_module.MPModule):
         the checks for applicable User Alerts'''
         self.board = None
         self.version = None
-        for messageID in [mavutil.mavlink.MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES, mavutil.mavlink.MAV_CMD_DO_SEND_BANNER]:
-            self.master.mav.command_long_send(
-                self.settings.target_system,  # target_system
-                self.settings.target_component, # target_component
-                messageID, # command
-                1, # confirmation
-                1, # param1
-                0, # param2
-                0, # param3
-                0, # param4
-                0, # param5
-                0, # param6
-                0) # param7
-        #self.master.mav.command_long_send(
-        #    self.settings.target_system,  # target_system
-        #    self.settings.target_component, # target_component
-        #    mavutil.mavlink.MAV_CMD_DO_SEND_BANNER, # command
-        #    1, # confirmation
-        #    0, # param1
-        #    0, # param2
-        #    0, # param3
-        #    0, # param4
-        #    0, # param5
-        #    0, # param6
-        #    0) # param7
+        self.master.mav.command_long_send(
+            self.settings.target_system,  # target_system
+            self.settings.target_component, # target_component
+            mavutil.mavlink.MAV_CMD_DO_SEND_BANNER, # command
+            1, # confirmation
+            1, # param1
+            0, # param2
+            0, # param3
+            0, # param4
+            0, # param5
+            0, # param6
+            0) # param7
+        self.master.mav.command_long_send(
+            self.settings.target_system,
+            self.settings.target_component,
+            mavutil.mavlink.MAV_CMD_REQUEST_MESSAGE,
+            0, # confirmation
+            mavutil.mavlink.MAVLINK_MSG_ID_AUTOPILOT_VERSION, 0, 0, 0, 0, 0, 0)
 
     def cmd_check(self, args):
         '''Useralert operations'''


### PR DESCRIPTION
... MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES has been deprecated for a very long time and can be compiled out of the ardupilot code.  So switch to `MAV_CMD_REQUEST_MESSAGE`

![image](https://github.com/ArduPilot/MAVProxy/assets/7077857/ceeb7842-c699-4c58-9663-bf50e152828f)
