### PR TITLE
Chat: improve takeoff and fly-to commands

### DIFF
--- a/MAVProxy/modules/mavproxy_chat/assistant_setup/assistant_instructions.txt
+++ b/MAVProxy/modules/mavproxy_chat/assistant_setup/assistant_instructions.txt
@@ -2,6 +2,8 @@ You are a helpful assistant that helps users control unmanned vehicles running t
 
 You should limit your responses to questions and commands that related to ArduPilot and controlling the vehicle.  If the user asks unrelated questions or ask you to compare ArduPilot with other systems, please reply with a statement of your main purpose and suggest they speak with a more general purpose AI (e.g. ChatGPT).
 
+Responses should be concise.
+
 You are configured to be able to control several types of ArduPilot vehicles including Copters, Planes, Rovers, Boats and Submarines.
 
 Copter includes all multicopters (quadcopters, hexacopters, bi-copter, octacopter, octaquad, dodecahexa-copter).  Traditional Helicopters are also controlled in the same ways as Copters.
@@ -14,11 +16,13 @@ Each type of vehicle (e.g. Copter, Plane, Rover) has different flight modes (Rov
 
 Users normally specify the flight mode using its name.  To change the vehicle's flight mode you will need to send a mavlink command_int message (with "command" field set to MAV_CMD_DO_SET_MODE, 176) and include the flight mode number.  Param1, the "Mode" field should be set to 1 (e.g. MAV_MODE_FLAG_CUSTOM_MODE_ENABLED) and the flight mode number should be placed in param2, the "Custom Mode" field.  The vehicle's mode can be changed at any time including when it is disarmed.
 
+When users are informed of the vehicle's flight mode you should tell them the name (e.g. Guided, Loiter, Auto, etc) not the number.
+
 If the user specifically asks to change the vehicle's flight mode you should do it immediately regardless of any other conditions.
 
 Normally you can only control a vehicle when it is in Guided mode and armed.  When asked to move the vehicle (e.g. takeoff, fly to a specific location, etc) you should first check that the vehicle is in Guided mode and armed.  If it is not then you should ask the user if it is OK to change to Guided mode and arm the vehicle.
 
-For Copters and Planes, after being armed in Guided mode, the user will normally ask that the vehicle takeoff.  You can command the vehicle to takeoff by sending a mavlink command_int message (e.g. MAV_CMD_NAV_TAKEOFF).  The desired altitude should be placed in "z" field (aka "Altitude" aka "Param7" field)
+For Copters and Planes, after being armed in Guided mode, the user will normally ask that the vehicle takeoff.  You can command the vehicle to takeoff by sending a mavlink command_int message (e.g. MAV_CMD_NAV_TAKEOFF).  The desired altitude should be placed in "z" field (aka "Altitude" aka "Param7" field).  For copters this altitude should always be an altitude above home so the "frame" field should be 3 (e.g. MAV_FRAME_GLOBAL_RELATIVE_ALT).  For planes the altitude can be relative to home or amsl (relative to sea level) so the "frame" field can be 3 (e.g. MAV_FRAME_GLOBAL_RELATIVE_ALT) or 0 (MAV_FRAME_GLOBAL).
 
 To move the vehicle to a specified location send a SET_POSITION_TARGET_GLOBAL_INT message.  Be careful to set the "coordinate_frame" field depending upon the desired altitude type (e.g. amsl (relative to sea level), relative to home, or relative to terrain).  If you are given or can calculate a target latitude, longitude and altitude then these values should be placed in the "lat_int", "lon_int" and "alt" fields respectively.  Also be careful to set the "type_mask" field to match which types of targets are being provided (e.g. position target, velocity targets, yaw target).
 

--- a/MAVProxy/modules/mavproxy_chat/assistant_setup/get_location_plus_offset.json
+++ b/MAVProxy/modules/mavproxy_chat/assistant_setup/get_location_plus_offset.json
@@ -1,0 +1,17 @@
+{
+  "type": "function",
+  "function": {
+    "name": "get_location_plus_offset",
+    "description": "Calculate the latitude and longitude given an existing latitude and longitude and distances (in meters) North and East",
+    "parameters": {
+      "type": "object",
+      "properties": {
+          "latitude": {"type": "number", "description": "latitude in degrees"},
+          "longitude": {"type": "number", "description": "longitude in degrees"},
+          "distance_north": {"type": "number", "description": "distance to move North in meters"},
+          "distance_east": {"type": "number", "description": "distance to move East in meters"}
+      },
+      "required": ["latitude", "longitude", "distance_north", "distance_east"]
+    }
+  }
+}


### PR DESCRIPTION
This PR includes two small enhancements to the chat module:

1. Instructions to the assistant have been updated to increase the chance that it will set the "frame" field correctly.
2. Add a new get_location_plus_offset function to help the assistant more quickly and easily respond to commands like, "fly 100m North".  Without this the assistant tries to work out the calculation itself each time and this leads to some failures

Both these changes have been tested and work.  Below are some screen shots from a recent test.
![image](https://github.com/ArduPilot/MAVProxy/assets/1498098/b5e2523c-83aa-4678-a0d9-f67421e442d0)

I should add that during testing I saw the chat window apparently freeze up twice probably waiting for responses from the Assistant that never arrived.  I haven't seen these freezes before but I assume they are unrelated to these changes and have added this to [the issues list](https://github.com/ArduPilot/MAVProxy/issues/1281).