### PR TITLE
Chat: minor GUI and assistant setup enhanecments

### DIFF
--- a/MAVProxy/modules/mavproxy_chat/assistant_setup/assistant_file_checker.py
+++ b/MAVProxy/modules/mavproxy_chat/assistant_setup/assistant_file_checker.py
@@ -1,0 +1,111 @@
+'''
+AI Chat Module Assistant File Checker
+Randy Mackay, December 2023
+
+This script is used to check for inconsistencies in the Assistants and Files.
+E.g. files which are not used by any Assistants or Assistants which use files which do not exist.
+
+OpenAI Assistant API: https://platform.openai.com/docs/api-reference/assistants
+OpenAI Assistant Playground: https://platform.openai.com/playground
+'''
+
+import datetime, os
+
+try:
+    from openai import OpenAI
+except:
+    print("chat: failed to import openai. See https://ardupilot.org/mavproxy/docs/modules/chat.html")
+    exit()
+
+# main function
+def main(openai_api_key=None, delete_unused=False):
+    
+    print("Starting Assistant File checker")
+    
+    # create connection object
+    try:
+        # if api key is provided, use it to create connection object
+        if openai_api_key is not None:
+            client = OpenAI(api_key=openai_api_key)
+        else:
+          # if no api key is provided, attempt to create connection object without it
+          # user may have set the OPENAI_API_KEY environment variable 
+          client = OpenAI()
+    except:
+        # if connection object creation fails, exit with error message
+        print("assistant_file_checker: failed to connect to OpenAI.  Perhaps the API key was incorrect?")
+        exit()
+
+    # get a list of all Files
+    existing_files = client.files.list()
+    print("File list:")
+    file_found = False
+    for file in existing_files.data:
+        print("    id:" + file.id + " name:" + file.filename + " size:" + str(file.bytes) + " date:" + str(datetime.datetime.fromtimestamp(file.created_at)))
+        file_found = True
+    if not file_found:
+        print("    no files found")
+
+    # get a list of all assistants
+    assistants_list = client.beta.assistants.list()
+
+    # prepare a dictionary of file ids to the number of assistants using the file
+    file_assistant_count = {}
+
+    # can files be used by more than one assistant?
+
+    # for each assistant, retrieve the list of files it uses
+    for assistant in assistants_list.data:
+        # print assistant name
+        print("Assistant: " + assistant.name)
+
+        # print list of files used by this assistant
+        # increment the number of assistants associate with this file
+        for assistant_file in client.beta.assistants.files.list(assistant_id=assistant.id):
+            file_assistant_count[assistant_file.id] = file_assistant_count.get(assistant_file.id, 0) + 1
+            filename_size_date = get_filename_size_date_from_id(existing_files, assistant_file.id)
+            print("    id:" + assistant_file.id + " name:" + filename_size_date[0] + " size:" + str(filename_size_date[1]) + " date:" + filename_size_date[2])
+
+    # display the list of files which are not used by any Assistants
+    print_unused_files_header = True
+    for existing_file in existing_files:
+        if not existing_file.id in file_assistant_count.keys():
+            # print header if this is the first unused file
+            if print_unused_files_header:
+                print("Files not used by any Assistants:")
+                print_unused_files_header = False
+
+            # print file attributes
+            filename_size_date = get_filename_size_date_from_id(existing_files, existing_file.id)
+            print("    id:" + existing_file.id + " name:" + filename_size_date[0] + " size:" + str(filename_size_date[1]) + " date:" + filename_size_date[2])
+
+            # delete the unused file if specified by the user
+            if delete_unused:
+                client.files.delete(file_id=existing_file.id)
+                print("        deleted: " + existing_file.id + " name:" + filename_size_date[0])
+
+    # print completion message
+    print("Assistant File check complete")
+
+# searches the files_list for the specified file id and retuns the filename, size and creation date (as a string) if found
+# returns None if not found
+def get_filename_size_date_from_id(files_list, file_id):
+    for file in files_list.data:
+        if file.id == file_id:
+            return file.filename, file.bytes, str(datetime.datetime.fromtimestamp(file.created_at))
+    return "not found", "unknown", "unknown"
+
+# call main function if this is run as standalone script
+if __name__ == "__main__":
+    
+    # parse command line arguments
+    from argparse import ArgumentParser
+    parser = ArgumentParser(description="MAVProxy Chat Module Assistant File Checker")
+    parser.add_argument("--api-key", default=None, help="OpenAI API Key")
+    parser.add_argument("--delete-unused", action='store_true', help="delete unused files")
+    try:
+        args = parser.parse_args()
+    except AttributeError as err:
+        parser.print_help()
+        os.sys.exit(0)
+    main(openai_api_key=args.api_key, delete_unused=args.delete_unused)

--- a/MAVProxy/modules/mavproxy_chat/chat_window.py
+++ b/MAVProxy/modules/mavproxy_chat/chat_window.py
@@ -26,6 +26,7 @@ class chat_window():
         # create chat window
         self.app = wx.App()
         self.frame = wx.Frame(None, title="Chat", size=(650, 200))
+        self.frame.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOW))
 
         # add menu
         self.menu = wx.Menu()
@@ -63,7 +64,7 @@ class chat_window():
         self.horiz_sizer.Add(self.send_button, proportion = 0, flag = wx.ALIGN_TOP | wx.ALL, border = 5)
 
         # add a reply box and read-only text box
-        self.text_reply = wx.TextCtrl(self.frame, id=-1, size=(600, 80), style=wx.TE_READONLY | wx.TE_MULTILINE)
+        self.text_reply = wx.TextCtrl(self.frame, id=-1, size=(600, 80), style=wx.TE_READONLY | wx.TE_MULTILINE | wx.TE_RICH)
 
         # add a read-only status text box at the bottom
         self.text_status = wx.TextCtrl(self.frame, id=-1, size=(600, -1), style=wx.TE_READONLY)
@@ -158,7 +159,7 @@ class chat_window():
 
             # copy user input text to reply box
             orig_text_attr = self.text_reply.GetDefaultStyle()
-            wx.CallAfter(self.text_reply.SetDefaultStyle, wx.TextAttr(wx.RED, alignment=wx.TEXT_ALIGNMENT_RIGHT))
+            wx.CallAfter(self.text_reply.SetDefaultStyle, wx.TextAttr(wx.RED))
             wx.CallAfter(self.text_reply.AppendText, send_text + "\n")
 
             # send text to assistant and place reply in reply box

--- a/MAVProxy/modules/mavproxy_chat/chat_window.py
+++ b/MAVProxy/modules/mavproxy_chat/chat_window.py
@@ -117,21 +117,22 @@ class chat_window():
     # record button clicked
     def record_button_click_execute(self, event):
         # record audio
+        self.set_status_text("recording audio")
         rec_filename = self.chat_voice_to_text.record_audio()
         if rec_filename is None:
-            print("chat: audio recording failed")
-            self.set_status_text("Audio recording failed")
+            self.set_status_text("audio recording failed")
             return
 
         # convert audio to text and place in input box
+        self.set_status_text("converting audio to text")
         text = self.chat_voice_to_text.convert_audio_to_text(rec_filename)
-        if text is None:
-            print("chat: audio to text conversion failed")
-            self.set_status_text("Audio to text conversion failed")
+        if text is None or len(text) == 0:
+            self.set_status_text("audio to text conversion failed")
             return
         wx.CallAfter(self.text_input.SetValue, text)
 
         # send text to assistant
+        self.set_status_text("sending text to assistasnt")
         self.send_text_to_assistant()
 
     # send button clicked
@@ -140,6 +141,9 @@ class chat_window():
 
     # handle text input
     def text_input_change(self, event):
+        # protect against sending empty text
+        if self.text_input.GetValue() == "":
+            return
         # send text to assistant in a separate thread
         th = Thread(target=self.send_text_to_assistant)
         th.start()


### PR DESCRIPTION
This PR includes 3 enhancements and 1 bug fix:

Chat window improvements:

1. Reply window colours are fixed on Windows (user input now correctly appears in red so it can be more easily distinguished from the replies)
2. Blank text is no longer sent to the assistant in cases where the audio-to-text fails or the user simply presses the Send button with no text in the input box

Assistant setup script improvements

3. The assistant setup script re-uses previously uploaded files instead of creating duplicates.  This behaviour can be overridden with the "--upgrade" argument
4. an assistant_file_checker.py script helps find and delete files that were uploaded to OpenAI but never associated with any Assistant.  So far we haven't found any particular problem with having these unused files hanging around but there are known [issues with assistants occasionally not being able to find files](https://community.openai.com/t/assistant-not-able-to-access-uploaded-file/524495/13)... perhaps keeping the upload area orderly will help somehow.

These changes have all been tested on Windows and Ubuntu and it seems to be working OK.

BTW, I initially had a cool "listen" feature for the audio-to-text conversion but I wasn't able to get it reliable enough so I'll push that off to a future PR