### PR TITLE
Chat: add wakeup timer support

### DIFF
--- a/MAVProxy/modules/mavproxy_chat/assistant_setup/delete_wakeup_timers.json
+++ b/MAVProxy/modules/mavproxy_chat/assistant_setup/delete_wakeup_timers.json
@@ -1,0 +1,14 @@
+{
+  "type": "function",
+  "function": {
+    "name": "delete_wakeup_timers",
+    "description": "Delete all active wakeup timers. You can optionally provide a message parameter to filter which timers will be deleted based on their message. When specifying the message parameter, you can use regular expressions (regex) to match patterns within the timer messages. This is useful when you want to delete timers with specific keywords or patterns in their message. For example, to delete all timers containing the word 'hello', you can use the regex '.*hello.*', where the dot-star (.*) pattern matches any character sequence.",
+    "parameters": {
+      "type": "object",
+      "properties": {
+          "message": {"type": "string", "description": "wakeup message of timers to be deleted.  regex values are accepted."}
+      },
+      "required": []
+    }
+  }
+}

--- a/MAVProxy/modules/mavproxy_chat/assistant_setup/get_wakeup_timers.json
+++ b/MAVProxy/modules/mavproxy_chat/assistant_setup/get_wakeup_timers.json
@@ -1,0 +1,14 @@
+{
+  "type": "function",
+  "function": {
+    "name": "get_wakeup_timers",
+    "description": "Retrieves a list of all active wakeup timers. You can optionally provide a message parameter to filter timers by their associated messages. When specifying the message parameter, you can use regular expressions (regex) to match patterns within the timer messages. This is useful when you want to find timers with specific keywords or patterns in their messages. For example, to retrieve all timers containing the word 'hello', you can use the regex '.*hello.*', where the dot-star (.*) pattern matches any character sequence.",
+    "parameters": {
+      "type": "object",
+      "properties": {
+          "message": {"type": "string", "description": "wakeup message of timers to be retrieved.  regex values are accepted."}
+      },
+      "required": []
+    }
+  }
+}

--- a/MAVProxy/modules/mavproxy_chat/assistant_setup/set_wakeup_timer.json
+++ b/MAVProxy/modules/mavproxy_chat/assistant_setup/set_wakeup_timer.json
@@ -1,0 +1,15 @@
+{
+  "type": "function",
+  "function": {
+    "name": "set_wakeup_timer",
+    "description": "Set a timer to wake you up in a specified number of seconds in the future.  This allows taking actions in the future.  The wakeup message will appear with the user role but will look something like WAKEUP:<message>.  Multiple wakeup messages are supported",
+    "parameters": {
+      "type": "object",
+      "properties": {
+          "seconds": {"type": "number", "description": "number of seconds in the future that the timer will wake you up"},
+          "message": {"type": "string", "description": "wakeup message that will be sent to you"}
+      },
+      "required": ["seconds", "message"]
+    }
+  }
+}


### PR DESCRIPTION
This PR adds three new functions that allow the Assistant to set, get or delete wakeup timers.

Having timer support allows the Assistants to more easily handle request to perform a sequence of tasks.  For example, fly North 100m, then west 100m and then RTL.

This has been tested, below are some screen shots of the basic timer get, set and delete functions.
![image](https://github.com/ArduPilot/MAVProxy/assets/1498098/6856d707-b198-4d71-9f0b-bb474fcec741)

Below is a screenshot of a test of a sequence of tasks.  In fact during this test it sadly switch to Drift instead of RTL at the end but that's a different issue that I'm looking into.
![image](https://github.com/ArduPilot/MAVProxy/assets/1498098/09efa105-6f7e-44c9-8d03-1bfdd31fa5c6)
