### PR TITLE
chat: use vehicle's mavlink sysid

### DIFF
--- a/MAVProxy/modules/mavproxy_chat/__init__.py
+++ b/MAVProxy/modules/mavproxy_chat/__init__.py
@@ -64,6 +64,9 @@ class chat(mp_module.MPModule):
 
     # handle mavlink packet
     def mavlink_packet(self, m):
+        # ignore messages that are not from our vehicle
+        if m.get_srcSystem() != self.mpstate.settings.target_system:
+            return
         if m.get_type() == 'COMMAND_ACK':
             self.handle_command_ack(m)
 


### PR DESCRIPTION
This changes the receiving and sending of mavlink messages so that we only communicate with the vehicle.

This allows us to ignore traffic from other GCSs which would otherwise confuse the chat module.

This doesn't go far enough to actually allow the control of multiple vehicles but it at least allows us to work in an environment where there are multiple GCSs connected to the vehicle.

Actually after some initial testing this doesn't quite seem to work in all cases.