### PR TITLE
Enforce flake8 cleanliness on AP_FLAKE8_CLEAN-marked files

### DIFF
--- a/.github/workflows/python-cleanliness.yml
+++ b/.github/workflows/python-cleanliness.yml
@@ -1,0 +1,25 @@
+name: test Python cleanliness
+
+on: [push, pull_request, workflow_dispatch]
+
+concurrency:
+  group: ci-${{github.workflow}}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    steps:
+      # git checkout the PR
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U flake8
+
+      - name: Check Python with Flake8
+        run: |
+            scripts/run_flake8.py MAVProxy

--- a/MAVProxy/modules/mavproxy_fieldcheck/__init__.py
+++ b/MAVProxy/modules/mavproxy_fieldcheck/__init__.py
@@ -12,6 +12,9 @@ TODO:
  - ensure parameters are correct
  - add check that battery is within tolerances (chemistry issues...)
  - autodetect numcells being incorrect
+
+AP_FLAKE8_CLEAN
+
 '''
 
 import math
@@ -30,6 +33,7 @@ import pkg_resources
 if mp_util.has_wxpython:
     from MAVProxy.modules.lib.mp_menu import MPMenuItem
     from MAVProxy.modules.lib.mp_menu import MPMenuSubMenu
+
 
 class FieldCheck(object):
     def __init__(self):
@@ -370,7 +374,7 @@ class FieldCheck(object):
         self.check_map_menu()
 
     def FC_MPSetting(self, name, atype, default, description):
-        xname = "fc_%s_%s" % (self.lc_name, name)
+        # xname = "fc_%s_%s" % (self.lc_name, name)
         return MPSetting(name, atype, default, description)
 
     def select(self):
@@ -443,17 +447,21 @@ class FieldCheck(object):
             print(usage)
             return
 
+
 class FieldCMAC(FieldCheck):
     lc_name = "cmac"
     location = mavutil.location(-35.363261, 149.165230, 584, 353)
+
 
 class FieldSpringValley(FieldCheck):
     location = mavutil.location(-35.281315, 149.005329, 581, 280)
     lc_name = "springvalley"
 
+
 class FieldSpringValleyBottom(FieldCheck):
     location = mavutil.location(-35.2824450, 149.0053668, 593, 0)
     lc_name = "springvalleybottom"
+
 
 class FieldCheckModule(mp_module.MPModule):
     def __init__(self, mpstate):
@@ -489,7 +497,6 @@ class FieldCheckModule(mp_module.MPModule):
                 self.whinge("Selecting field (%s)" % field.lc_name)
                 self.select_field(field)
 
-
     def idle_task(self):
         '''run periodic tasks'''
         if self.field is not None:
@@ -509,6 +516,7 @@ class FieldCheckModule(mp_module.MPModule):
         if self.field is None:
             return
         self.field.mavlink_packet(m)
+
 
 def init(mpstate):
     '''initialise module'''

--- a/scripts/run_flake8.py
+++ b/scripts/run_flake8.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+
+"""
+Runs flake8 over Python files which contain a marker indicating
+they are clean, ensures that they actually are
+
+ AP_FLAKE8_CLEAN
+"""
+
+import os
+import subprocess
+import sys
+
+import argparse
+
+os.environ['PYTHONUNBUFFERED'] = '1'
+
+
+class Flake8Checker(object):
+    def __init__(self, basedirs):
+        self.retcode = 0
+        self.files_to_check = []
+        self.basedirs = basedirs
+
+    def progress(self, string):
+        print("****** %s" % (string,))
+
+    def check(self):
+        if len(self.files_to_check) == 0:
+            return
+        for path in self.files_to_check:
+            self.progress("Checking (%s)" % path)
+        ret = subprocess.run(["flake8", "--show-source"] + self.files_to_check,
+                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        if ret.returncode != 0:
+            self.progress("Flake8 check failed: (%s)" % (ret.stdout))
+            self.retcode = 1
+
+    def run(self):
+        for basedir in self.basedirs:
+            for (dirpath, dirnames, filenames) in os.walk(basedir):
+                for filename in filenames:
+                    if os.path.splitext(filename)[1] != ".py":
+                        continue
+                    filepath = os.path.join(dirpath, filename)
+                    content = open(filepath).read()
+                    if "AP_FLAKE8_CLEAN" not in content:
+                        continue
+                    self.files_to_check.append(filepath)
+        self.check()
+        return self.retcode
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Check all Python files for flake8 cleanliness')
+    parser.add_argument('DIRPATH', nargs="+", default=[], help='directory to recurse into')
+    args = parser.parse_args()
+
+    checker = Flake8Checker(args.DIRPATH)
+    sys.exit(checker.run())


### PR DESCRIPTION
Similarly to what we do in ArduPilot - enforce that a file meets certain rules iif it has the string `AP_FLAKE8_CLEAN` in it.

![image](https://github.com/ArduPilot/MAVProxy/assets/7077857/e6e0d942-e937-468a-a423-3159ce1b9853)
