### PR TITLE
Chat: target sysid fix

### DIFF
--- a/MAVProxy/modules/mavproxy_chat/assistant_setup/send_mavlink_command_int.json
+++ b/MAVProxy/modules/mavproxy_chat/assistant_setup/send_mavlink_command_int.json
@@ -6,8 +6,8 @@
     "parameters": {
       "type": "object",
       "properties": {
-          "target_system": {"type": "integer", "minimum":0, "maximum":255, "description": "vehicle autopilot System ID.  normally 1"},
-          "target_component": {"type": "integer",  "minimum":0, "maximum":255, "description": "vehicle autopilot Component ID.  normally 1"},
+          "target_system": {"type": "integer", "minimum":0, "maximum":255, "description": "vehicle autopilot System ID.  can be omitted"},
+          "target_component": {"type": "integer",  "minimum":0, "maximum":255, "description": "vehicle autopilot Component ID.  can be omitted"},
           "frame": {"type": "integer", "minimum":0, "maximum":21, "description": "altitude type.  see MAV_FRAME.  0 for altitude above sea level, 3 for altitude above home, 10 for altitude above terrain"},
           "command": {"type": "integer",  "minimum":0, "maximum":65535, "description": "MAVLink command id.  See MAV_CMD for a full list of available commands"},
           "current": {"type": "integer",  "description": "not used.  always zero"},

--- a/MAVProxy/modules/mavproxy_chat/assistant_setup/send_mavlink_set_position_target_global_int.json
+++ b/MAVProxy/modules/mavproxy_chat/assistant_setup/send_mavlink_set_position_target_global_int.json
@@ -7,8 +7,8 @@
       "type": "object",
       "properties": {
           "time_boot_ms": {"type": "integer", "description": "system timestamp.  can be left as 0"},
-          "target_system": {"type": "integer", "minimum":0, "maximum":255, "description": "vehicle autopilot System ID.  normally 1"},
-          "target_component": {"type": "integer",  "minimum":0, "maximum":255, "description": "vehicle autopilot Component ID.  normally 1"},
+          "target_system": {"type": "integer", "minimum":0, "maximum":255, "description": "vehicle autopilot System ID.  can be omitted"},
+          "target_component": {"type": "integer",  "minimum":0, "maximum":255, "description": "vehicle autopilot Component ID.  can be omitted"},
           "coordinate_frame": {"type": "integer", "minimum":0, "maximum":21, "description": "altitude type.  see MAV_FRAME.  5 for altitude above sea level, 6 for altitude above home, 11 for altitude above terrain"},
           "type_mask": {"type": "integer", "minimum":0, "maximum":65535, "description": "Bitmap to indicate which dimensions should be ignored by the vehicle.  see POSITION_TARGET_TYPEMASK.  If location (e.g. lat_int, lon_int and alt) are sent use 3576.  If a location (e.g. lat_int, lon_int and alt) and yaw are sent use 2552.  If velocity (e.g. vx, vy, vz) is sent use 2552. if velocity (e.g. vx, vy, vz) and yaw are sent use 2503.  If only yaw is sent use 2559"},
           "lat_int": {"type": "integer", "description": "latitude in degrees * 10^7"},

--- a/MAVProxy/modules/mavproxy_chat/chat_openai.py
+++ b/MAVProxy/modules/mavproxy_chat/chat_openai.py
@@ -475,7 +475,7 @@ class chat_openai():
 
     # send a mavlink command_int message to the vehicle
     def send_mavlink_command_int(self, arguments):
-        target_system = arguments.get("target_system", 1)
+        target_system = arguments.get("target_system", self.mpstate.settings.target_system)
         target_component = arguments.get("target_component", 1)
         frame = arguments.get("frame", 0)
         if ("command" not in arguments):
@@ -519,7 +519,7 @@ class chat_openai():
         if arguments is None:
             return "send_mavlink_set_position_target_global_int: arguments is None"
         time_boot_ms = arguments.get("time_boot_ms", 0)
-        target_system = arguments.get("target_system", 1)
+        target_system = arguments.get("target_system", self.mpstate.settings.target_system)
         target_component = arguments.get("target_component", 1)
         coordinate_frame = arguments.get("coordinate_frame", 5)
         type_mask = arguments.get("type_mask", 0)


### PR DESCRIPTION
This fixes a bug allowing the chat module to control vehicles with a non-default system id (e.g. SYSID_THISMAV != 1).

The fix has two parts:

1. Assistant instructions updated so that normally the assistant will not specify the target system id
2. Chat module default fixed to use the system id that the user has selected using the Vehicle menu

This has been lightly tested in SITL.

There's a much bigger enhancement still on [the to-do list](https://github.com/ArduPilot/MAVProxy/issues/1281) to support multiple vehicles.