### PR TITLE
Correct tab completion of the dump command commandline

### DIFF
--- a/MAVProxy/modules/lib/rline.py
+++ b/MAVProxy/modules/lib/rline.py
@@ -41,6 +41,7 @@ class rline(object):
             '(FILENAME)' : complete_filename,
             '(PARAMETER)' : complete_parameter,
             '(VARIABLE)' : complete_variable,
+            '(MESSAGETYPE)' : complete_messagetype,
             '(SETTING)' : rline_mpstate.settings.completion,
             '(COMMAND)' : complete_command,
             '(ALIAS)' : complete_alias,
@@ -231,6 +232,12 @@ def complete_variable(text):
         pass
 
     return []
+
+def complete_messagetype(text):
+    '''complete a MAVLink message type'''
+    global rline_mpstate
+
+    return list(filter(lambda x : x.startswith(text), rline_mpstate.status.msgs.keys()))
 
 def rule_expand(component, text):
     '''expand one rule component'''

--- a/MAVProxy/tools/MAVExplorer.py
+++ b/MAVProxy/tools/MAVExplorer.py
@@ -125,6 +125,7 @@ class MEState(object):
             "set"       : ["(SETTING)"],
             "condition" : ["(VARIABLE)"],
             "graph"     : ['(VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE)'],
+            "dump"     : ['(VARIABLE)'],
             "map"       : ['(VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE)'],
             "param"     : ['download', 'check', 'help (PARAMETER)'],
             }


### PR DESCRIPTION
Imagine the `<tab><tab>`s in the following:
```
MAV> dump 
AHR2     DU32     IMU      MAVC     NKF3     NKQ2     PAY5     SRTL
ATT      EV       IMU2     MAV[3]   NKF4     NKT2     PM       TERR
BAR2     FMT      IMU3     MODE     NKF5     ORGN     POS      UNIT
BARO     FMTU     ISBD     MOTB     NKF6     PARM     POWR     VIBE
BAT      GPA      ISBH     MSG      NKF7     PAY1     PPO2     __MAV__
CMD      GPS      MAG      MULT     NKF8     PAY2     RATE     
CTUN     GUID     MAG2     NKF1     NKF9     PAY3     RCIN     
DSF      HEAT     MAV      NKF2     NKQ1     PAY4     RCOU     
MAV> dump I
IMU   IMU2  IMU3  ISBD  ISBH  
MAV> dump I
```