### PR TITLE
macOS: remove deprecated and unused imports

### DIFF
--- a/MAVProxy/modules/lib/MacOS/backend_wxagg.py
+++ b/MAVProxy/modules/lib/MacOS/backend_wxagg.py
@@ -4,9 +4,9 @@ from matplotlib.figure import Figure
 
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.backends import backend_wx    # already uses wxversion.ensureMinimal('2.8')
-from matplotlib.backends.backend_wx import error_msg_wx, NavigationToolbar2Wx
-from matplotlib.backends.backend_wxagg import FigureManager, FigureCanvasWxAgg, \
-    FigureFrameWx, draw_if_interactive, show, backend_version
+from matplotlib.backends.backend_wx import FigureFrameWx
+from matplotlib.backends.backend_wx import NavigationToolbar2Wx
+from matplotlib.backends.backend_wxagg import FigureCanvasWxAgg
 import wx
 
 class FigureFrameWxAgg(FigureFrameWx):


### PR DESCRIPTION
Fixes #1304 

Remove deprecated and unused imports from the macOS `wx` backend.

Summary of deprecated APIs:

- https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.8.0.html#removal-of-deprecated-apis

Tested with `matplotlib==3.7.4` for backwards compatibility and `matplotlib==3.8.2`.