### PR TITLE
MAVExplorer: don't show instances with dump tab completion

### DIFF
--- a/MAVProxy/modules/lib/rline.py
+++ b/MAVProxy/modules/lib/rline.py
@@ -189,7 +189,7 @@ def complete_variable(text):
     else:
         suffix = ''
 
-    m1 = re.match("^(.*?)([A-Z0-9][A-Z0-9_]*(\[[0-9A-Z_]+\])?)[.]([A-Za-z0-9_]*)$", text)
+    m1 = re.match("^(.*?)([A-Z0-9][A-Z0-9_]*(\\[[0-9A-Z_]+\\])?)[.]([A-Za-z0-9_]*)$", text)
     if m1 is not None:
         prefix = m1.group(1)
         mtype = m1.group(2)
@@ -204,7 +204,7 @@ def complete_variable(text):
         return []
 
     # handle partially open arrays, like 'NAMED_VALUE_FLOAT[A'
-    m1 = re.match("^(.*?)([A-Z0-9][A-Z0-9_]*(\[[0-9A-Z_]+))$", text)
+    m1 = re.match("^(.*?)([A-Z0-9][A-Z0-9_]*(\\[[0-9A-Z_]*))$", text)
     if m1 is not None:
         prefix = m1.group(1)
         mtype = m1.group(2)
@@ -215,7 +215,7 @@ def complete_variable(text):
         if len(ret):
             return ret
 
-    m2 = re.match("^(.*?)([A-Z0-9][A-Z0-9_]*(\[[0-9A-Z_]+\])?)$", text)
+    m2 = re.match("^(.*?)([A-Z0-9][A-Z0-9_]*(\\[[0-9A-Z_]+\\])?)$", text)
     prefix = m2.group(1)
     mtype = m2.group(2)
     ret = []
@@ -237,7 +237,7 @@ def complete_messagetype(text):
     '''complete a MAVLink message type'''
     global rline_mpstate
 
-    return list(filter(lambda x : x.startswith(text), rline_mpstate.status.msgs.keys()))
+    return list(filter(lambda x : x.startswith(text) and "[" not in x, rline_mpstate.status.msgs.keys()))
 
 def rule_expand(component, text):
     '''expand one rule component'''

--- a/MAVProxy/tools/MAVExplorer.py
+++ b/MAVProxy/tools/MAVExplorer.py
@@ -125,7 +125,7 @@ class MEState(object):
             "set"       : ["(SETTING)"],
             "condition" : ["(VARIABLE)"],
             "graph"     : ['(VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE)'],
-            "dump"     : ['(VARIABLE)'],
+            "dump"      : ['(MESSAGETYPE)'],
             "map"       : ['(VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE)'],
             "param"     : ['download', 'check', 'help (PARAMETER)'],
             }


### PR DESCRIPTION
I very much like PR #1303 from @peterbarker - I have often typed dump and pressed tab to be met with nothing!
However, when using the code from this update, I spotted a couple of things that were not quite as I expected...

- It looks like you meant to link the dump command to new the (MESSAGETYPE) completion that you created, but used (VARIABLE) by mistake, so I changed this.
- The completion includes message instances as well as messages (i.e. both IMU and IMU[1]), but dump only works with the name without instance, so I updated the filter to remove them.

And nothing to do with the previous PR:
- When pressing tab on something like "graph BAT[" it was getting an error, so I updated the partially open array regex to use * instead of + for the text after "[" (i.e. allowed to be empty).
- The regex strings use "\\[" and "\\]", but this generates python warnings, as it tries to apply the escape sequence before passing to regex. Could have either make them raw strings r"...", but instead decided to keep as regular string and escape the "\\".