### PR TITLE
MAVExplorer: Fix stats command for DF text and TLOG logs

### DIFF
--- a/MAVProxy/modules/lib/multiproc_util.py
+++ b/MAVProxy/modules/lib/multiproc_util.py
@@ -269,7 +269,7 @@ class MPDataLogChildTask(MPChildTask):
         '''
         Parameters
         ----------
-        mlog : DFReader
+        mlog : DFReader / mavmmaplog
             A dataflash or telemetry log
         '''
         super(MPDataLogChildTask, self).__init__(*args, **kwargs)
@@ -282,10 +282,16 @@ class MPDataLogChildTask(MPChildTask):
         '''Apply custom pickle wrappers to non-pickleable attributes'''
 
         # wrap filehandle and mmap in mlog for pickling
-        filehandle = self._mlog.filehandle
+        if hasattr(self._mlog,'filehandle'):
+            filehandle = self._mlog.filehandle
+        elif hasattr(self._mlog,'f'):
+            filehandle = self._mlog.f
         data_map = self._mlog.data_map
         data_len = self._mlog.data_len
-        self._mlog.filehandle = WrapFileHandle(filehandle)
+        if hasattr(self._mlog,'filehandle'):
+            self._mlog.filehandle = WrapFileHandle(filehandle)
+        elif hasattr(self._mlog,'f'):
+            self._mlog.f = WrapFileHandle(filehandle)
         self._mlog.data_map = WrapMMap(data_map, filehandle, data_len)
 
     # @override
@@ -293,11 +299,14 @@ class MPDataLogChildTask(MPChildTask):
         '''Unwrap custom pickle wrappers of non-pickleable attributes'''
 
         # restore the state of mlog
-        self._mlog.filehandle = self._mlog.filehandle.unwrap()
+        if hasattr(self._mlog,'filehandle'):
+            self._mlog.filehandle = self._mlog.filehandle.unwrap()
+        elif hasattr(self._mlog,'f'):
+            self._mlog.f = self._mlog.f.unwrap()
         self._mlog.data_map = self._mlog.data_map.unwrap()
 
     @property
     def mlog(self):
-        '''The dataflash log (DFReader)'''
+        '''The dataflash or telemetry log (DFReader / mavmmaplog)'''
 
         return self._mlog


### PR DESCRIPTION
When looking at something else, I noticed that when using the 'stats' command in MAVExplorer with either DF text logs or TLOGs it raises an Exception for different reasons.
* DF Text logs: `KeyError: 128`
* TLOGs: `ERROR in command []: 'mavmmaplog' object has no attribute 'filehandle'`

It looks like TLOGs were not supported, but should at least have given a nicer error message. But while here, I have added the support for them.

Summary of changes needed:
For DF text logs:
* message name rather than message id is used to index the counts dict, and it is unset for messages that are never seen.
* needs: https://github.com/ArduPilot/pymavlink/pull/906

For TLOG:
* As there isn't a formats attribute on the mavmmaplog class (as used for Tlogs), I am counting message instances rather than size in bytes. Output formatting is adjusted to take account of the longest name.
* The 'filehandle' attribute is named 'f' instead in mavmmaplog class (as used for Tlogs), so updated MPDataLogChildTask class of multiproc_util.py to handle either, using 'hasattr'.

The new output for TLogs looks something like this (abbreviated):
```
Total number of messages: 96576
REMOTE_LOG_BLOCK_STATUS    0.00%
AUTOPILOT_VERSION          0.00%
...
VIBRATION                  3.17%
MISSION_CURRENT            3.17%
HEARTBEAT                  3.50%
NAMED_VALUE_FLOAT          6.25%

@OTHER 100.00%
```

I've tested files of all three types (bin, log, tlog), and checked stats command works in each case.
