### PR TITLE
MAVExplorer: Add verbose output of DF log messages

### DIFF
--- a/MAVProxy/tools/MAVExplorer.py
+++ b/MAVProxy/tools/MAVExplorer.py
@@ -517,6 +517,8 @@ def cmd_dump(args):
             continue
         if verbose and "pymavlink.dialects" in str(type(msg)):
             mavutil.dump_message_verbose(sys.stdout, msg)
+        elif verbose and hasattr(msg,"dump_verbose"):
+            msg.dump_verbose(sys.stdout)
         else:
             print("%s %s" % (timestring(msg), msg))
     mlog.rewind()


### PR DESCRIPTION
This PR provides the MAVExplorer side of: https://github.com/ArduPilot/pymavlink/pull/911

It enables the use of the '--verbose' argument on the dump command for DF logs.
I use hasattr to check for dump_verbose function to avoid exception in case an older pymavlink is installed.

Example of output:
```
MAV> dump --verbose POS
2023-12-30 09:59:58.079: POS
    TimeUS: 37126810 µs
    Lat: 33.810313 deglatitude
    Lng: -118.393867 deglongitude
    Alt: -0.14000000059604645 m
    RelHomeAlt: -0.535001277923584 m
    RelOriginAlt: -0.21500125527381897 m
```