### PR TITLE
mavproxy_rc: add status command

### DIFF
--- a/MAVProxy/modules/mavproxy_rc.py
+++ b/MAVProxy/modules/mavproxy_rc.py
@@ -90,6 +90,16 @@ class RCModule(mp_module.MPModule):
         '''this is a public method for use by drone API or other scripting'''
         return self.override[channel]
 
+    def cmd_rc_status(self):
+        print("")
+        for i in range(self.count):
+            value = "%u" % self.override[i]
+            if value == "65535":
+                value += "      (ignored)"
+            elif value == "0":
+                value += "      (no override)"
+            print("%2d: %s" % (i+1, value))
+
     def cmd_rc(self, args):
         '''handle RC value override'''
         if len(args) > 0 and args[0] == 'set':
@@ -101,8 +111,12 @@ class RCModule(mp_module.MPModule):
                 channels[i] = 0
             self.set_override(channels)
             return
+        if len(args) == 1 and args[0] == "status":
+            self.cmd_rc_status()
+            return
+
         if len(args) != 2:
-            print("Usage: rc <set|channel|all|clear> <pwmvalue>")
+            print("Usage: rc <set|channel|all|clear|status> <pwmvalue>")
             return
         value = int(args[1])
         if value > 65535 or value < -1:


### PR DESCRIPTION
```
rc 3 1000
MANUAL> rc 4 65535
MANUAL> rc status
MANUAL> 
 1: 0      (no override)
 2: 0      (no override)
 3: 1000
 4: 65535      (ignored)
 5: 0      (no override)
 6: 0      (no override)
 7: 0      (no override)
 8: 0      (no override)
 9: 0      (no override)
10: 0      (no override)
11: 0      (no override)
12: 0      (no override)
13: 0      (no override)
14: 0      (no override)
15: 0      (no override)
16: 0      (no override)
17: 0      (no override)
18: 0      (no override)
```
