### PR TITLE
NTRIP: use pynmeagps for correct gga generation

### DIFF
--- a/MAVProxy/modules/lib/ntrip.py
+++ b/MAVProxy/modules/lib/ntrip.py
@@ -14,8 +14,9 @@ import select
 from MAVProxy.modules.lib import rtcm3
 import ssl
 from optparse import OptionParser
+from pynmeagps import NMEAMessage, GET
 
-version = 0.1
+version = 0.2
 useragent = "NTRIP MAVProxy/%.1f" % version
 
 
@@ -70,26 +71,8 @@ class NtripClient(object):
             self.ssl = True
 
     def setPosition(self, lat, lon):
-        self.flagN = "N"
-        self.flagE = "E"
-        if lon > 180:
-            lon = (lon-360)*-1
-            self.flagE = "W"
-        elif lon < 0 and lon >= -180:
-            lon = lon*-1
-            self.flagE = "W"
-        elif lon < -180:
-            lon = lon+360
-            self.flagE = "E"
-        else:
-            self.lon = lon
-        if lat < 0:
-            lat = lat*-1
-            self.flagN = "S"
-        self.lonDeg = int(lon)
-        self.latDeg = int(lat)
-        self.lonMin = (lon-self.lonDeg)*60
-        self.latMin = (lat-self.latDeg)*60
+        self.lon = lon
+        self.lat = lat
 
     def getMountPointString(self):
         userstr = self.user
@@ -105,19 +88,28 @@ class NtripClient(object):
         mountPointString += "\r\n"
         return mountPointString
 
-    def getGGAString(self):
-        now = datetime.datetime.utcnow()
-        ggaString = "GPGGA,%02d%02d%04.2f,%02d%011.8f,%1s,%03d%011.8f,%1s,1,05,0.19,+00400,M,%5.3f,M,," % (
-                     now.hour, now.minute, now.second, self.latDeg, self.latMin, self.flagN,
-                     self.lonDeg, self.lonMin, self.flagE, self.height)
-        checksum = self.calculateCheckSum(ggaString)
-        return "$%s*%s\r\n" % (ggaString, checksum)
+    def getGGAByteString(self):
+        gga_msg = NMEAMessage(
+            "GP",
+            "GGA",
+            GET,  # msgmode is expected by this lib
+            lat=self.lat,
+            NS="S" if self.lat < 0 else "N",
+            lon=self.lon,
+            EW="W" if self.lon < 0 else "E",
+            quality=1,
+            numSV=15,
+            HDOP=0,
+            alt=self.height,
+            altUnit="M",
+            sep=0,
+            sepUnit="M",
+            diffAge="",
+            diffStation=0,
+        )
 
-    def calculateCheckSum(self, stringToCheck):
-        xsum_calc = 0
-        for char in stringToCheck:
-            xsum_calc = xsum_calc ^ ord(char)
-        return "%02X" % xsum_calc
+        raw_gga: bytes = gga_msg.serialize()
+        return raw_gga
 
     def get_ID(self):
         '''get ID of last packet'''
@@ -248,9 +240,8 @@ class NtripClient(object):
             print("got: ", len(data))
 
     def send_gga(self):
-        gga = self.getGGAString()
-        if sys.version_info.major >= 3:
-            gga = bytearray(gga, "ascii")
+        gga = self.getGGAByteString()
+
         try:
             self.socket.sendall(gga)
             self.dt_last_gga_sent = time.time()

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ package_data.extend(package_files('MAVProxy/modules/mavproxy_cesium/app'))
 # large numbers of modules like numpy etc which may be already installed
 requirements=['pymavlink>=2.4.14',
               'pyserial>=3.0',
-              'numpy']
+              'numpy',
+              'pynmeagps']
 
 if platform.system() == "Darwin":
     # on MacOS we can have a more complete requirements list


### PR DESCRIPTION
The MAVproxy NTRIP client does not work with several NTRIP casters, because the GGA messages are sent in an incompatible format. this is described in #1131 

This PR solves that problem, by using the same library for gga generation that [pygpsclient](https://github.com/semuconsulting/PyGPSClient) uses ([pynmeagps](https://github.com/semuconsulting/pynmeagps)), which I experienced to be working with all casters. 

The ntrip client of pygpsclient works quite well, so I might open an Issue in the future to request that the MAVproxy ntrip could be refactored as a wraper of that NTRIP client. It has more active developers than the built-in NTRIP Client of MAVproxy.

For now, this PR should provide a solution that is tested with skylark and I am confident that it also solves the problem with topcon, but I can't test it atm, because I don't have an active subscription.