### PR TITLE
MAVExplorer: Autocompletion on dump --verbose command

### DIFF
--- a/MAVProxy/tools/MAVExplorer.py
+++ b/MAVProxy/tools/MAVExplorer.py
@@ -125,7 +125,7 @@ class MEState(object):
             "set"       : ["(SETTING)"],
             "condition" : ["(VARIABLE)"],
             "graph"     : ['(VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE)'],
-            "dump"      : ['(MESSAGETYPE)'],
+            "dump"      : ['(MESSAGETYPE)', '--verbose (MESSAGETYPE)'],
             "map"       : ['(VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE)'],
             "param"     : ['download', 'check', 'help (PARAMETER)'],
             }


### PR DESCRIPTION
This PR allows autocompletion in MAVExplorer when using "dump --verbose \<tab\>".
Previously the autocompletion was added for "dump \<tab\>", but with "--verbose" argument it did not work.
Tested on my local version.