### PR TITLE
module Joystick: adding Sparkfun pro micro as joystick

### DIFF
--- a/MAVProxy/modules/mavproxy_joystick/joysticks/SparkFun Pro Micro.yml
+++ b/MAVProxy/modules/mavproxy_joystick/joysticks/SparkFun Pro Micro.yml
@@ -1,0 +1,32 @@
+description: >
+ SUMD -> Joystick adapter using SparkFun Pro Micro AtMega 32u4
+
+match:
+  - '*SparkFun Pro Micro*'
+
+controls:
+  - channel: 1
+    type: axis
+    id: 0
+  - channel: 2
+    type: axis
+    id: 1
+  - channel: 3
+    type: axis
+    id: 2
+  - channel: 4
+    type: axis
+    id: 3
+  - channel: 5
+    type: axis
+    id: 4
+  - channel: 6
+    type: axis
+    id: 5
+  - channel: 7
+    type: axis
+    id: 6
+  - channel: 8
+    type: axis
+    id: 7
+


### PR DESCRIPTION
"Sparkfun pro micro" is a cheap 32u4 microcontroller that using Arduino joystick library is easy to act as a USB joystick.
It is easy to use for PPM input, or analog joystick interface.
