### PR TITLE
Show all IMUs with devid

### DIFF
--- a/MAVProxy/modules/mavproxy_misc.py
+++ b/MAVProxy/modules/mavproxy_misc.py
@@ -488,7 +488,7 @@ class MiscModule(mp_module.MPModule):
             if p.startswith('COMPASS_DEV_ID') or p.startswith('COMPASS_PRIO') or (
                     p.startswith('COMPASS') and p.endswith('DEV_ID')):
                 mp_util.decode_devid(self.mav_param[p], p)
-            if p.startswith('INS_') and p.endswith('_ID'):
+            if p.startswith('INS') and p.endswith('_ID'):
                 mp_util.decode_devid(self.mav_param[p], p)
             if p.startswith('GND_BARO') and p.endswith('_ID'):
                 mp_util.decode_devid(self.mav_param[p], p)

--- a/MAVProxy/tools/MAVExplorer.py
+++ b/MAVProxy/tools/MAVExplorer.py
@@ -1246,7 +1246,7 @@ def cmd_devid(args):
         if p.startswith('COMPASS_DEV_ID') or p.startswith('COMPASS_PRIO') or (
                 p.startswith('COMPASS') and p.endswith('DEV_ID')):
             mp_util.decode_devid(params[p], p)
-        if p.startswith('INS_') and p.endswith('_ID'):
+        if p.startswith('INS') and p.endswith('_ID'):
             mp_util.decode_devid(params[p], p)
         if p.startswith('GND_BARO') and p.endswith('_ID'):
             mp_util.decode_devid(params[p], p)


### PR DESCRIPTION
IMU decoding with devid expects the parameter to be `INS_GYRn` or `INS_ACCn`.
Since more than 3 IMUs were added, the parameter in the flight controller is `INSn_GYR` and `INSn_ACC`.

This opens up `devid` to be able to decode all the IMUs available.