### PR TITLE
MAVProxy support retries from cmd line

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -1301,6 +1301,7 @@ if __name__ == '__main__':
     parser.add_option("--version", action='store_true', help="version information")
     parser.add_option("--default-modules", default="log,signing,wp,rally,fence,ftp,param,relay,tuneopt,arm,mode,calibration,rc,auxopt,misc,cmdlong,battery,terrain,output,adsb,layout", help='default module list')
     parser.add_option("--udp-timeout",dest="udp_timeout", default=0.0, type='float', help="Timeout for udp clients in seconds")
+    parser.add_option("--retries", type=int, help="number of times to retry connection", default=3)
 
     (opts, args) = parser.parse_args()
     if len(args) != 0:
@@ -1402,9 +1403,9 @@ if __name__ == '__main__':
     for mdev in opts.master:
         if mdev.find('?') != -1 or mdev.find('*') != -1:
             for m in glob.glob(mdev):
-                if not mpstate.module('link').link_add(m, force_connected=opts.force_connected):
+                if not mpstate.module('link').link_add(m, force_connected=opts.force_connected, retries=opts.retries):
                     sys.exit(1)
-        elif not mpstate.module('link').link_add(mdev, force_connected=opts.force_connected):
+        elif not mpstate.module('link').link_add(mdev, force_connected=opts.force_connected, retries=opts.retries):
             sys.exit(1)
 
     if not opts.master and len(serial_list) == 1:

--- a/MAVProxy/modules/mavproxy_link.py
+++ b/MAVProxy/modules/mavproxy_link.py
@@ -323,7 +323,7 @@ class LinkModule(mp_module.MPModule):
             print("Applying attribute to link: %s = %s" % (attr, optional_attributes[attr]))
             setattr(conn, attr, optional_attributes[attr])
 
-    def link_add(self, descriptor, force_connected=False):
+    def link_add(self, descriptor, force_connected=False, retries=3):
         '''add new link'''
         try:
             (device, optional_attributes) = self.parse_link_descriptor(descriptor)
@@ -342,13 +342,15 @@ class LinkModule(mp_module.MPModule):
                 conn = mavutil.mavlink_connection(device, autoreconnect=True,
                                                   source_system=self.settings.source_system,
                                                   baud=self.settings.baudrate,
-                                                  force_connected=force_connected)
+                                                  force_connected=force_connected,
+                                                  retries=retries)
             except Exception as e:
                 # try the same thing but without force-connected for
                 # backwards-compatability
                 conn = mavutil.mavlink_connection(device, autoreconnect=True,
                                                   source_system=self.settings.source_system,
-                                                  baud=self.settings.baudrate)
+                                                  baud=self.settings.baudrate,
+                                                  retries=retries)
             conn.mav.srcComponent = self.settings.source_component
         except Exception as msg:
             print("Failed to connect to %s : %s" % (descriptor, msg))


### PR DESCRIPTION
In some debugging applications, I use more retries than the default 3 that are given.

This exposes retries to the command line, allowing to increase how many attempts before mavproxy gives up.