### PR TITLE
MAVExplorer: Add message descriptions to stats command

### DIFF
--- a/MAVProxy/modules/lib/msgstats.py
+++ b/MAVProxy/modules/lib/msgstats.py
@@ -87,7 +87,15 @@ def show_stats(mlog):
     pairs = sorted(pairs, key = lambda p : p[1])
     for (name,size) in pairs:
         if size > 0:
-            print("%-*s %.2f%%" % (maxnamelen, name, 100.0 * size / total_size))
+            descstr = ''
+            if hasattr(mlog, 'metadata'):
+                desc = mlog.metadata.get_description(name)
+                if desc:
+                    if len(desc) > (68 - maxnamelen):
+                        descstr = "  [%s...]" % desc[:(65 - maxnamelen)]
+                    else:
+                        descstr = "  [%s]" % desc
+            print("%-*s %5.2f%%%s" % (maxnamelen, name, 100.0 * size / total_size, descstr))
 
     print("")
     category_total = 0


### PR DESCRIPTION
The idea of this PR is to add the message description to the 'stats' command in MAVExplorer, using the downloaded XML metadata.
When I was first getting the hang of looking at logged data, I found myself using the stats command as a good to way to have an index of what messages exist, but the 4-letter names can take a while to get the hang of, so I thought that something like this would have made it easier!

Output is like this:
```
MODE  0.00%  [vehicle control mode information]
ARM   0.00%  [Arming status changes]
EV    0.00%  [Specifically coded event messages]
AUXF  0.00%  [Auxiliary function invocation information]
VER   0.00%  [Ardupilot version]
LAND  0.00%  [Slope Landing data]
DSF   0.03%  [Onboard logging statistics]
TERR  0.03%  [Terrain database information]
FMTU  0.03%  [Message defining units and multipliers used for fields of oth...]
RAD   0.03%  [Telemetry radio statistics]
ISBH  0.04%
MAV   0.06%  [GCS MAVLink link statistics]
...
```
As you see with FMTU, I have chosen to abbreviate long descriptions, to avoid making the actual stats bit any less readable.