### PR TITLE
mavproxy.py: strip enclosing quotes from parsed shlex results

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -756,6 +756,18 @@ def process_stdin(line):
         print("Caught shlex exception: %s" % e.message);
         return
 
+    # strip surrounding quotes - shlex leaves them in place
+    new_args = []
+    for arg in args:
+        done = False
+        new_arg = arg
+        for q in "'", '"':
+            if arg.startswith(q) and arg.endswith(q):
+                new_arg = arg[1:-1]
+                break
+        new_args.append(new_arg)
+    args = new_args
+
     cmd = args[0]
     while cmd in mpstate.aliases:
         line = mpstate.aliases[cmd]


### PR DESCRIPTION
A command-line of kml load "/home/pbarker/e0/sypaq/carbonix-flying-sites/Carbonix Flight Areas.kmz" gets turned into a 3-element list.

Past this PR the last element will not be enclosed in quotes, which means that modules don't need to do their own quote-stripping