### PR TITLE
map: check events in idle loop

### DIFF
--- a/MAVProxy/modules/mavproxy_map/__init__.py
+++ b/MAVProxy/modules/mavproxy_map/__init__.py
@@ -878,6 +878,9 @@ Usage: map circle <radius> <colour>
             if not self.map.is_alive():
                 self.needs_unloading = True
 
+        # check for any events from the map
+        self.map.check_events()
+
     def create_vehicle_icon(self, name, colour, follow=False, vehicle_type=None):
         '''add a vehicle to the map'''
         from MAVProxy.modules.mavproxy_map import mp_slipmap


### PR DESCRIPTION
currently we only check for events when we receive mavlink packets.

That's a problem for the right-click menu option "Google Maps Link", because often when you want that option you are not actually getting packets from the vehicle....

Process packets in the idle loop as well as after receiving a mavlink packet.

![image](https://github.com/ArduPilot/MAVProxy/assets/7077857/23cc9728-34f5-4c5f-be7f-f93b9bcc9c3e)
