### PR TITLE
mavproxy.py: correct printing of shlex exception

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -753,7 +753,7 @@ def process_stdin(line):
     try:
         args = shlex_quotes(line)
     except Exception as e:
-        print("Caught shlex exception: %s" % e.message);
+        print("Caught shlex exception: %s" % str(e));
         return
 
     # strip surrounding quotes - shlex leaves them in place


### PR DESCRIPTION
message is not an attribute of e (any more?)

Before:

```
MANUAL>   File "/home/pbarker/.local/lib/python3.10/site-packages/MAVProxy-1.8.70-py3.10.egg/EGG-INFO/scripts/mavproxy.py", line 756, in process_stdin
MANUAL> AttributeError: 'ValueError' object has no attribute 'message'
MANUAL> Unknown command 'File "/home/pbarker/.local/lib/python3.10/site-packages/MAVProxy-1.8.70-py3.10.egg/EGG-INFO/scripts/mavproxy.py", line 756, in process_stdin'
Unknown command 'AttributeError: 'ValueError' object has no attribute 'message''
```

after:
```
MANUAL> Caught shlex exception: No closing quotation
```
