### PR TITLE
Correct initial KML checkbox values

### DIFF
--- a/MAVProxy/modules/mavproxy_kmlread.py
+++ b/MAVProxy/modules/mavproxy_kmlread.py
@@ -316,8 +316,9 @@ class KmlReadModule(mp_module.MPModule):
 
                 # print("Adding " + point[1])
                 newcolour = (random.randint(0, 255), 0, random.randint(0, 255))
+                layer_name = point[1]+"-"+str(counter)
                 curpoly = mp_slipmap.SlipPolygon(
-                    point[1]+"-"+str(counter),
+                    layer_name,
                     point[2],
                     layer=2,
                     linewidth=2,
@@ -325,7 +326,7 @@ class KmlReadModule(mp_module.MPModule):
                 )
                 self.mpstate.map.add_object(curpoly)
                 self.allayers.append(curpoly)
-                self.curlayers.append(point[1])
+                self.curlayers.append(layer_name)
 
             # and points - barrell image and text
             if self.mpstate.map is not None and point[0] == 'Point':

--- a/MAVProxy/modules/mavproxy_kmlread.py
+++ b/MAVProxy/modules/mavproxy_kmlread.py
@@ -389,14 +389,17 @@ class KmlReadModule(mp_module.MPModule):
                 # then add all the layers to the menu, ensuring to
                 # check the active layers text elements aren't
                 # included on the menu
-                if layer.key in self.curlayers and layer.key[-5:] != "-text":
+                if layer.key.endswith('-text'):
+                    continue
+
+                if layer.key in self.curlayers:
                     self.menu.items.append(MPMenuCheckbox(
                         layer.key,
                         layer.key,
                         '# kml toggle \"' + layer.key + '\"',
                         checked=True,
                     ))
-                elif layer.key[-5:] != "-text":
+                else:
                     self.menu.items.append(MPMenuCheckbox(
                         layer.key,
                         layer.key,

--- a/MAVProxy/modules/mavproxy_kmlread.py
+++ b/MAVProxy/modules/mavproxy_kmlread.py
@@ -392,20 +392,13 @@ class KmlReadModule(mp_module.MPModule):
                 if layer.key.endswith('-text'):
                     continue
 
-                if layer.key in self.curlayers:
-                    self.menu.items.append(MPMenuCheckbox(
-                        layer.key,
-                        layer.key,
-                        '# kml toggle \"' + layer.key + '\"',
-                        checked=True,
-                    ))
-                else:
-                    self.menu.items.append(MPMenuCheckbox(
-                        layer.key,
-                        layer.key,
-                        '# kml toggle \"' + layer.key + '\"',
-                        checked=False,
-                    ))
+                checked = layer.key in self.curlayers
+                self.menu.items.append(MPMenuCheckbox(
+                    layer.key,
+                    layer.key,
+                    f'# kml toggle \"{layer.key}\"',
+                    checked=checked,
+                ))
             # and add the menu to the map popu menu
             self.module('map').add_menu(self.menu)
         self.menu_needs_refreshing = False


### PR DESCRIPTION
the addition of the counter for the layer name broke the population of the "current layers" list
