### PR TITLE
Fix mavflightview for renamed mav_type VTOL_DUOROTOR and VTOL_QUADROTOR

### DIFF
--- a/MAVProxy/tools/mavflightview.py
+++ b/MAVProxy/tools/mavflightview.py
@@ -128,8 +128,8 @@ def colourmap_for_mav_type(mav_type):
                     mavutil.mavlink.MAV_TYPE_TRICOPTER]:
         map = colour_map_copter
     if mav_type in [mavutil.mavlink.MAV_TYPE_FIXED_WING,
-                    mavutil.mavlink.MAV_TYPE_VTOL_DUOROTOR,
-                    mavutil.mavlink.MAV_TYPE_VTOL_QUADROTOR,
+                    mavutil.mavlink.MAV_TYPE_VTOL_TAILSITTER_DUOROTOR,
+                    mavutil.mavlink.MAV_TYPE_VTOL_TAILSITTER_QUADROTOR,
                     mavutil.mavlink.MAV_TYPE_VTOL_TILTROTOR]:
         map = colour_map_plane
     if mav_type in [mavutil.mavlink.MAV_TYPE_GROUND_ROVER,


### PR DESCRIPTION
MAV_TYPE_VTOL_DUOROTOR has been renamed to MAV_TYPE_VTOL_TAILSITTER_DUOROTOR
https://github.com/mavlink/mavlink/blob/f1d42e2774cae767a1c0651b0f95e3286c587257/message_definitions/v1.0/minimal.xml#L130

MAV_TYPE_VTOL_QUADROTOR has been renamed to MAV_TYPE_VTOL_TAILSITTER_QUADROTOR
https://github.com/mavlink/mavlink/blob/f1d42e2774cae767a1c0651b0f95e3286c587257/message_definitions/v1.0/minimal.xml#L133