### PR TITLE
Renamed mav_type VTOL_DUOROTOR and VTOL_QUADROTOR

### DIFF
--- a/MAVProxy/modules/mavproxy_chat/chat_openai.py
+++ b/MAVProxy/modules/mavproxy_chat/chat_openai.py
@@ -270,8 +270,8 @@ class chat_openai():
         vehicle_type_str = "unknown"
         if hearbeat_msg is not None:
             if hearbeat_msg.type in [mavutil.mavlink.MAV_TYPE_FIXED_WING,
-                                     mavutil.mavlink.MAV_TYPE_VTOL_DUOROTOR,
-                                     mavutil.mavlink.MAV_TYPE_VTOL_QUADROTOR,
+                                     mavutil.mavlink.MAV_TYPE_VTOL_TAILSITTER_DUOROTOR,
+                                     mavutil.mavlink.MAV_TYPE_VTOL_TAILSITTER_QUADROTOR,
                                      mavutil.mavlink.MAV_TYPE_VTOL_TILTROTOR]:
                 vehicle_type_str = "Plane"
             if hearbeat_msg.type == mavutil.mavlink.MAV_TYPE_GROUND_ROVER:

--- a/MAVProxy/modules/mavproxy_console.py
+++ b/MAVProxy/modules/mavproxy_console.py
@@ -202,8 +202,8 @@ class ConsoleModule(mp_module.MPModule):
     def vehicle_type_string(self, hb):
         '''return vehicle type string from a heartbeat'''
         if hb.type in [mavutil.mavlink.MAV_TYPE_FIXED_WING,
-                            mavutil.mavlink.MAV_TYPE_VTOL_DUOROTOR,
-                            mavutil.mavlink.MAV_TYPE_VTOL_QUADROTOR,
+                            mavutil.mavlink.MAV_TYPE_VTOL_TAILSITTER_DUOROTOR,
+                            mavutil.mavlink.MAV_TYPE_VTOL_TAILSITTER_QUADROTOR,
                             mavutil.mavlink.MAV_TYPE_VTOL_TILTROTOR]:
             return 'Plane'
         if hb.type == mavutil.mavlink.MAV_TYPE_GROUND_ROVER:

--- a/MAVProxy/modules/mavproxy_link.py
+++ b/MAVProxy/modules/mavproxy_link.py
@@ -675,8 +675,8 @@ class LinkModule(mp_module.MPModule):
                     self.say("Mode " + self.status.flightmode)
 
             if m.type in [mavutil.mavlink.MAV_TYPE_FIXED_WING,
-                            mavutil.mavlink.MAV_TYPE_VTOL_DUOROTOR,
-                            mavutil.mavlink.MAV_TYPE_VTOL_QUADROTOR,
+                            mavutil.mavlink.MAV_TYPE_VTOL_TAILSITTER_DUOROTOR,
+                            mavutil.mavlink.MAV_TYPE_VTOL_TAILSITTER_QUADROTOR,
                             mavutil.mavlink.MAV_TYPE_VTOL_TILTROTOR]:
                 self.mpstate.vehicle_type = 'plane'
                 self.mpstate.vehicle_name = 'ArduPlane'

--- a/MAVProxy/modules/mavproxy_map/__init__.py
+++ b/MAVProxy/modules/mavproxy_map/__init__.py
@@ -1072,8 +1072,8 @@ Usage: map circle <radius> <colour>
             vname = None
             vtype = self.vehicle_type_override.get(sysid, m.type)
             if vtype in [mavutil.mavlink.MAV_TYPE_FIXED_WING,
-                            mavutil.mavlink.MAV_TYPE_VTOL_DUOROTOR,
-                            mavutil.mavlink.MAV_TYPE_VTOL_QUADROTOR,
+                            mavutil.mavlink.MAV_TYPE_VTOL_TAILSITTER_DUOROTOR,
+                            mavutil.mavlink.MAV_TYPE_VTOL_TAILSITTER_QUADROTOR,
                             mavutil.mavlink.MAV_TYPE_VTOL_TILTROTOR]:
                 vname = 'plane'
             elif vtype in [mavutil.mavlink.MAV_TYPE_GROUND_ROVER]:

--- a/MAVProxy/modules/mavproxy_swarm.py
+++ b/MAVProxy/modules/mavproxy_swarm.py
@@ -20,8 +20,8 @@ from MAVProxy.modules.lib.wx_loader import wx
 def get_vehicle_name(vehtype):
     '''return vehicle type string from a heartbeat'''
     if vehtype in [mavutil.mavlink.MAV_TYPE_FIXED_WING,
-                   mavutil.mavlink.MAV_TYPE_VTOL_DUOROTOR,
-                   mavutil.mavlink.MAV_TYPE_VTOL_QUADROTOR,
+                   mavutil.mavlink.MAV_TYPE_VTOL_TAILSITTER_DUOROTOR,
+                   mavutil.mavlink.MAV_TYPE_VTOL_TAILSITTER_QUADROTOR,
                    mavutil.mavlink.MAV_TYPE_VTOL_TILTROTOR]:
         return 'Plane'
     if vehtype == mavutil.mavlink.MAV_TYPE_GROUND_ROVER:
@@ -778,8 +778,8 @@ class swarm(mp_module.MPModule):
         self.allVehPos = {}
 
         self.validVehicles = frozenset([mavutil.mavlink.MAV_TYPE_FIXED_WING,
-                              mavutil.mavlink.MAV_TYPE_VTOL_DUOROTOR,
-                              mavutil.mavlink.MAV_TYPE_VTOL_QUADROTOR,
+                              mavutil.mavlink.MAV_TYPE_VTOL_TAILSITTER_DUOROTOR,
+                              mavutil.mavlink.MAV_TYPE_VTOL_TAILSITTER_QUADROTOR,
                               mavutil.mavlink.MAV_TYPE_VTOL_TILTROTOR,
                               mavutil.mavlink.MAV_TYPE_GROUND_ROVER,
                               mavutil.mavlink.MAV_TYPE_SURFACE_BOAT,

--- a/MAVProxy/tools/mavflightview.py
+++ b/MAVProxy/tools/mavflightview.py
@@ -128,8 +128,8 @@ def colourmap_for_mav_type(mav_type):
                     mavutil.mavlink.MAV_TYPE_TRICOPTER]:
         map = colour_map_copter
     if mav_type in [mavutil.mavlink.MAV_TYPE_FIXED_WING,
-                    mavutil.mavlink.MAV_TYPE_VTOL_DUOROTOR,
-                    mavutil.mavlink.MAV_TYPE_VTOL_QUADROTOR,
+                    mavutil.mavlink.MAV_TYPE_VTOL_TAILSITTER_DUOROTOR,
+                    mavutil.mavlink.MAV_TYPE_VTOL_TAILSITTER_QUADROTOR,
                     mavutil.mavlink.MAV_TYPE_VTOL_TILTROTOR]:
         map = colour_map_plane
     if mav_type in [mavutil.mavlink.MAV_TYPE_GROUND_ROVER,


### PR DESCRIPTION
MAV_TYPE_VTOL_DUOROTOR has been renamed to MAV_TYPE_VTOL_TAILSITTER_DUOROTOR
https://github.com/mavlink/mavlink/blob/f1d42e2774cae767a1c0651b0f95e3286c587257/message_definitions/v1.0/minimal.xml#L130

MAV_TYPE_VTOL_QUADROTOR has been renamed to MAV_TYPE_VTOL_TAILSITTER_QUADROTOR
https://github.com/mavlink/mavlink/blob/f1d42e2774cae767a1c0651b0f95e3286c587257/message_definitions/v1.0/minimal.xml#L133
