### PR TITLE
MAVExplorer: allow arbitrary expressions to be plotted on the map

### DIFF
--- a/MAVProxy/tools/MAVExplorer.py
+++ b/MAVProxy/tools/MAVExplorer.py
@@ -455,7 +455,7 @@ def cmd_map(args):
     options.colour_source='flightmode'
     options.nkf_sample = 1
     if len(args) > 0:
-        options.types = ','.join(args)
+        options.types = ':'.join(args)
         if len(options.types) > 1:
             options.colour_source='type'
     mfv_mav_ret = mavflightview.mavflightview_mav(mestate.mlog, options, mestate.flightmode_selections)


### PR DESCRIPTION
this allows mavextra to construct new mappable objects with Lat and Lng fields, allowing for derived positions from logs

this also generalises and simplifies the handling of instances

for example:
![image](https://github.com/ArduPilot/MAVProxy/assets/831867/93252066-8711-44ed-8798-76ec9d644919)

this uses the following mavextra function:
```
def pos_offset(GPS,offs_N,offs_E):
    latlon = mp_util.gps_offset(GPS.Lat,GPS.Lng, offs_E, offs_N)
    return PosObj(latlon[0],latlon[1],GPS.Alt)
```
