### PR TITLE
Add recommended modules

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -33,7 +33,7 @@ jobs:
         run: ./installer.exe /verysilent /allusers /dir=inst
       - name: Build MAVProxy
         run: |
-          python -m pip install . --user
+          python -m pip install .[recommended] --user
           python -m pip list
       - name: Prepare installer
         run: |

--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,9 @@ on how to use MAVProxy.''',
       extras_require={
         # restserver module
         'server': ['flask'],
+        'recommended': ['flask', 'PyYAML', 'lxml', 'wxpython',
+                        'pymonocypher', 'openai', 'paho-mqtt',
+                        'piexif', 'pynmea2', 'Pygame', 'Pillow']
       },
       scripts=['MAVProxy/mavproxy.py',
                'MAVProxy/tools/mavflightview.py',

--- a/windows/MAVProxyWinBuild.bat
+++ b/windows/MAVProxyWinBuild.bat
@@ -38,7 +38,7 @@ python.exe -m pip install -U pyinstaller==6.7.0 packaging
 
 rem -----Build MAVProxy-----
 cd ..\
-python.exe -m pip install . --user
+python.exe -m pip install .[recommended] --user
 cd .\MAVProxy
 copy ..\windows\mavproxy.spec
 pyinstaller -y --clean mavproxy.spec


### PR DESCRIPTION
Add a [recommended] section to setup.py, where we can put all the optional module requirements.

Can use this via ``pip install mavproxy[recommended] --user``

Fixes #1423 