### PR TITLE
MAVProxy: fixed reconnection of serial port on windows after reboot

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -1116,8 +1116,11 @@ def main_loop():
 
         for master in mpstate.mav_master:
             if master.fd is None:
-                if master.port.inWaiting() > 0:
-                    process_master(master)
+                try:
+                    if master.port.inWaiting() > 0:
+                        process_master(master)
+                except serial.SerialException as e:
+                    pass
 
         periodic_tasks()
 


### PR DESCRIPTION
The line: `master.port.inWaiting()` is causing a SerialException when a reboot is sent to the flight controller from the console.

This change has been tested in windows and linux, it does not appear to have an effect on linux. The exception does not trigger in linux, but does on windows.