### PR TITLE
Modules: grapher layout and file export fixed for Windows

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -50,6 +50,7 @@ jobs:
           $wc.DownloadFile('https://autotest.ardupilot.org/Parameters/ArduPlane/apm.pdef.xml', 'Parameters\ArduPlane.xml')
           $wc.DownloadFile('https://autotest.ardupilot.org/Parameters/ArduSub/apm.pdef.xml', 'Parameters\ArduSub.xml')
           $wc.DownloadFile('https://autotest.ardupilot.org/Parameters/AntennaTracker/apm.pdef.xml', 'Parameters\AntennaTracker.xml')
+          $wc.DownloadFile('https://autotest.ardupilot.org/Parameters/Heli/apm.pdef.xml', 'Parameters\Heli.xml')
       - name: Build installer
         run: |
           cd  windows

--- a/MAVProxy/MAVProxyWinLAN.bat
+++ b/MAVProxy/MAVProxyWinLAN.bat
@@ -1,4 +1,4 @@
 cd ..\
-python setup.py build install --user
-python .\MAVProxy\mavproxy.py --master=0.0.0.0:14550 --console
+python.exe -m pip install --upgrade build . --user
+python.exe .\MAVProxy\mavproxy.py --master=0.0.0.0:14550 --console
 pause

--- a/MAVProxy/MAVProxyWinUSB.bat
+++ b/MAVProxy/MAVProxyWinUSB.bat
@@ -1,4 +1,4 @@
 cd ..\
-python setup.py build install --user
-python .\MAVProxy\mavproxy.py --console
+python.exe -m pip install --upgrade build . --user
+python.exe .\MAVProxy\mavproxy.py --console
 pause

--- a/MAVProxy/modules/lib/magfit.py
+++ b/MAVProxy/modules/lib/magfit.py
@@ -7,7 +7,7 @@ fit best estimate of magnetometer offsets, diagonals, off-diagonals, cmot and sc
 from MAVProxy.modules.lib import wx_processguard
 from MAVProxy.modules.lib.wx_loader import wx
 
-import sys, time, os, math, copy
+import sys, time, os, math, copy, platform
 
 from pymavlink import mavutil
 from pymavlink import mavextra
@@ -18,6 +18,8 @@ from MAVProxy.modules.lib import grapher
 from MAVProxy.modules.lib.multiproc_util import MPDataLogChildTask
 
 import matplotlib
+if platform.system() == "Windows":
+    matplotlib.use('wxagg')
 import matplotlib.pyplot as pyplot
 import numpy
 import datetime

--- a/MAVProxy/modules/lib/param_help.py
+++ b/MAVProxy/modules/lib/param_help.py
@@ -13,7 +13,7 @@ class ParamHelp:
     def param_help_download(self):
         '''download XML files for parameters'''
         files = []
-        for vehicle in ['Rover', 'ArduCopter', 'ArduPlane', 'ArduSub', 'AntennaTracker', 'Blimp']:
+        for vehicle in ['Rover', 'ArduCopter', 'ArduPlane', 'ArduSub', 'AntennaTracker', 'Blimp', 'Heli']:
             url = 'http://autotest.ardupilot.org/Parameters/%s/apm.pdef.xml.gz' % vehicle
             path = mp_util.dot_mavproxy("%s.xml" % vehicle)
             files.append((url, path))

--- a/MAVProxy/modules/mavproxy_paramedit/param_editor_frame.py
+++ b/MAVProxy/modules/mavproxy_paramedit/param_editor_frame.py
@@ -544,7 +544,7 @@ class ParamEditorFrame(wx.Frame):
     def param_help_download(self):
         '''download XML files for parameters'''
         files = []
-        for vehicle in ['APMrover2', 'ArduCopter', 'ArduPlane', 'ArduSub', 'AntennaTracker']:
+        for vehicle in ['APMrover2', 'ArduCopter', 'ArduPlane', 'ArduSub', 'AntennaTracker', 'Heli']:
             url = 'http://autotest.ardupilot.org/Parameters/%s/apm.pdef.xml' % vehicle
             path = mp_util.dot_mavproxy("%s.xml" % vehicle)
             files.append((url, path))

--- a/MAVProxy/tools/MAVExplorer.bat
+++ b/MAVProxy/tools/MAVExplorer.bat
@@ -1,4 +1,4 @@
 cd ..\..\
-python setup.py build install --user
-python .\MAVProxy\tools\MAVExplorer.py
+python.exe -m pip install --upgrade build . --user
+python.exe .\MAVProxy\tools\MAVExplorer.py
 pause

--- a/MAVProxy/tools/MAVExplorer.py
+++ b/MAVProxy/tools/MAVExplorer.py
@@ -347,7 +347,8 @@ def load_graphs():
             continue
         # skip parameter files.  They specify an encoding, and under
         # Python3 this leads to a warning from etree
-        if os.path.basename(file) in ["ArduSub.xml", "ArduPlane.xml", "APMrover2.xml", "ArduCopter.xml", "AntennaTracker.xml", "Blimp.xml", "Rover.xml"]:
+        if os.path.basename(file) in ["ArduSub.xml", "ArduPlane.xml", "APMrover2.xml", "ArduCopter.xml",
+                                      "AntennaTracker.xml", "Blimp.xml", "Rover.xml", "Heli.xml"]:
             continue
         graphs = load_graph_xml(open(file).read(), file)
         if graphs:

--- a/windows/MAVProxyWinBuild.bat
+++ b/windows/MAVProxyWinBuild.bat
@@ -58,6 +58,7 @@ powershell.exe "Start-BitsTransfer -Source 'http://autotest.ardupilot.org/Parame
 powershell.exe "Start-BitsTransfer -Source 'http://autotest.ardupilot.org/Parameters/ArduPlane/apm.pdef.xml' -Destination 'Parameters\ArduPlane.xml'"
 powershell.exe "Start-BitsTransfer -Source 'http://autotest.ardupilot.org/Parameters/ArduSub/apm.pdef.xml' -Destination 'Parameters\ArduSub.xml'"
 powershell.exe "Start-BitsTransfer -Source 'http://autotest.ardupilot.org/Parameters/AntennaTracker/apm.pdef.xml' -Destination 'Parameters\AntennaTracker.xml'"
+powershell.exe "Start-BitsTransfer -Source 'http://autotest.ardupilot.org/Parameters/Heli/apm.pdef.xml' -Destination 'Parameters\Heli.xml'"
 
 rem -----Build the Installer-----
 cd .\windows

--- a/windows/mavproxy.spec
+++ b/windows/mavproxy.spec
@@ -36,7 +36,7 @@ MAVExpAny = Analysis(['.\\tools\\MAVExplorer.py'],
              datas= [ ('tools\\graphs\\*.*', 'MAVProxy\\tools\\graphs' ) ],
              hookspath=None,
              runtime_hooks=None,
-             excludes= ['sphinx', 'docutils', 'alabaster', 'FixTk', 'tcl', 'tk', '_tkinter', 'tkinter', 'Tkinter'])
+             excludes= ['sphinx', 'docutils', 'alabaster', 'FixTk', 'tcl', 'tk', 'Tkinter'])
 MAVPicViewerAny = Analysis(['.\\tools\\mavpicviewer\\mavpicviewer.py'],
              pathex=[os.path.abspath('.')],
              # for some unknown reason these hidden imports don't pull in


### PR DESCRIPTION
Fixed two issues with MAVExplorer graphs not working nicely:
- Changed to "TkAgg" backend on Windows, as the "wxAgg" backend wasn't displaying the chart values (lower right) correctly
- When saving graphs to file ("save" icon on graph window), made the _suggested_ filename safer by removing problematic characters (ie ``Sensors/GPS/GPS Accuracy`` to ``Sensors_GPS_GPS_Accuracy``)