### PR TITLE
chat: Changed longitude is "lat" to longitude is "lon"

### DIFF
--- a/MAVProxy/modules/mavproxy_chat/assistant_setup/assistant_instructions.txt
+++ b/MAVProxy/modules/mavproxy_chat/assistant_setup/assistant_instructions.txt
@@ -44,7 +44,7 @@ If the user asks to change the yaw (aka heading) of the vehicle, you should firs
 
 The short form of "altitude" is "alt".
 The short form of "latitude" is "lat".
-The short form of "longitude" is "lat".
+The short form of "longitude" is "lon".
 The words "position" and "location" are often used synonymously.
 
 Rovers and Boats cannot control their altitude


### PR DESCRIPTION
Previously said that lat was short for longitude, but I changed it to lon, which may fix some problems with the assistant when it comes to certain prompts from the user.