### PR TITLE
ntrip: Added support for NTRIP Rev1 servers

### DIFF
--- a/MAVProxy/modules/lib/ntrip.py
+++ b/MAVProxy/modules/lib/ntrip.py
@@ -154,6 +154,7 @@ class NtripClient(object):
                 # Ignore non ascii characters in HTTP response
                 casterResponse = str(casterResponse, 'ascii', 'ignore')
             header_lines = casterResponse.split("\r\n")
+            is_ntrip_rev1 = False
             for line in header_lines:
                 if line == "":
                     self.found_header = True
@@ -165,7 +166,14 @@ class NtripClient(object):
                     raise NtripError("Mount Point does not exist")
                 elif line.find(" 200 OK") != -1:
                     # Request was valid
+                    if line == "ICY 200 OK":
+                        is_ntrip_rev1 = True
                     self.send_gga()
+
+            # NTRIP Rev1 allows for responses that do not contain headers and an extra blank line.
+            if is_ntrip_rev1 and not self.found_header:
+                self.found_header = True
+
             return None
         # normal data read
         while True:


### PR DESCRIPTION
I ran into an issue getting the popular RTK base station system, [rtkbase](https://github.com/Stefal/rtkbase) working with MAVProxy. Doing some deeper analysis, it looks like rtkbase uses the `str2str` utility provided in the popular [RTKLIB](https://github.com/tomojitakasu/RTKLIB) project.

What I found is that the str2str NTRIP caster returns a response that looks like this:

```
ICY 200 OK
(rtcm-bytes)
```

Notice how the server response does not include any headers and just goes straight to the response body without a blank line? Because of this, the ntrip.py library will never find a blank line, and `self.found_header` will never equal `True` which means the ntrip library will always be "stuck" waiting for headers.

At first I debated whether or not this library should be updated in order to fix the "bad behavior" of an NTRIP server. But after a bit of research I found that according to [this](https://www.use-snip.com/kb/knowledge-base/ntrip-rev1-versus-rev2-formats/), it is actually valid and expected behavior under the NTRIP Rev1 protocol. So in a sense we're just adding support for NTRIP Rev1 with this small update.

Potential issues:
I think it is also possible for NTRIP Rev1 to optionally contain headers, so there might be a case where if the headers are over 4096 characters in length that this might falsely think the headers are finished and parsed, when they aren't. But it's not clear to me that this would cause anything bad to happen since the headers are not used in any capacity.