### PR TITLE
link: fix non-vehicle heartbeat filter

### DIFF
--- a/MAVProxy/modules/mavproxy_link.py
+++ b/MAVProxy/modules/mavproxy_link.py
@@ -622,8 +622,8 @@ class LinkModule(mp_module.MPModule):
             return False
 
         mav_autopilots_which_are_not_vehicles = frozenset([
-            'MAV_AUTOPILOT_INVALID',
-            'MAV_AUTOPILOT_RESERVED',
+            mavutil.mavlink.MAV_AUTOPILOT_INVALID,
+            mavutil.mavlink.MAV_AUTOPILOT_RESERVED,
         ])
         if m.autopilot in mav_autopilots_which_are_not_vehicles:
             return False


### PR DESCRIPTION
If there are multiple components sending heartbeats, MAVProxy can get confused, lock onto the wrong one, and fail to receive any messages from the real autopilot.

There is a function in pymavlink, `probably_vehicle_heartbeat`, which can check for this since this commit https://github.com/arduPilot/pymavlink/commit/67669c3b84a1f0d7792c5faa487230b94a628135.

However, MAVProxy does not use `probably_vehicle_heartbeat` (at least not for this purpose), having its own version called `heartbeat_is_from_autopilot` in the link modoule.

The corresponding check is present in that function! However (x2), it incorrectly compares an integer against a string, which never matches.

This PR changes the strings to integer constants.

Disclaimer: I am employed by Exyn Technologies, an Ardupilot partner