### PR TITLE
modules: grapher.py: fix regex-escape-sequence warning

### DIFF
--- a/MAVProxy/modules/lib/grapher.py
+++ b/MAVProxy/modules/lib/grapher.py
@@ -601,7 +601,7 @@ class MavGraph(object):
         self.axes = []
         self.first_only = []
         re_caps = re.compile('[A-Z_][A-Z0-9_]+')
-        re_instance = re.compile('([A-Z_][A-Z0-9_]+)\[([0-9A-Z_]+)\]')
+        re_instance = re.compile(r'([A-Z_][A-Z0-9_]+)\[([0-9A-Z_]+)\]')
         for f in self.fields:
             caps = set(re.findall(re_caps, f))
             self.msg_types = self.msg_types.union(caps)


### PR DESCRIPTION
/home/pbarker/.local/lib/python3.12/site-packages/MAVProxy-1.8.71-py3.12.egg/MAVProxy/modules/lib/grapher.py:604: SyntaxWarning: invalid escape sequence '\['