### PR TITLE
Correct plotting of mission in MAVExplorer

### DIFF
--- a/MAVProxy/tools/MAVExplorer.py
+++ b/MAVProxy/tools/MAVExplorer.py
@@ -453,10 +453,10 @@ def cmd_map(args):
     options._flightmodes = mestate.mlog._flightmodes
     options.show_flightmode_legend = mestate.settings.show_flightmode
     options.colour_source='flightmode'
-    options.nkf_sample = 1
     if len(args) > 0:
         options.types = ':'.join(args)
-        if len(options.types) > 1:
+        filtered_args = list(filter(lambda x : x != "CMD", options.types))
+        if len(filtered_args) > 1:
             options.colour_source='type'
     mfv_mav_ret = mavflightview.mavflightview_mav(mestate.mlog, options, mestate.flightmode_selections)
     if mfv_mav_ret is None:

--- a/MAVProxy/tools/mavflightview.py
+++ b/MAVProxy/tools/mavflightview.py
@@ -337,7 +337,7 @@ def mavflightview_mav(mlog, options=None, flightmode_selections=[]):
             type_list = options.types.split(',')
         expressions.extend(pos_expressions(type_list))
     else:
-        expressions.extend(pos_expressions(['POS', 'GLOBAL_POSITION_INT']))
+        expressions.extend(pos_expressions(['POS', 'GLOBAL_POSITION_INT', 'CMD']))
         if options.rawgps or options.dualgps:
             expressions.extend(pos_expressions(['GPS', 'GPS_RAW_INT']))
         if options.rawgps2 or options.dualgps:


### PR DESCRIPTION
We used to get the uploaded mission by default; restore that behaviour.

![image](https://github.com/user-attachments/assets/11824b57-c14b-4370-8df1-01ff8cff9537)
