### PR TITLE
Use importlib to handle version and package resources, where available

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -24,13 +24,7 @@ import threading
 import time
 import traceback
 
-try:
-    reload
-except NameError:
-    try:
-        from importlib import reload
-    except ImportError:
-        from imp import reload
+from importlib import reload
 
 from pymavlink import mavutil
 
@@ -1400,14 +1394,8 @@ if __name__ == '__main__':
 
     # version information
     if opts.version:
-        # pkg_resources doesn't work in the windows exe build, so read the version file
-        try:
-            import pkg_resources
-            version = pkg_resources.require("mavproxy")[0].version
-        except Exception:
-            start_script = mp_util.dot_mavproxy("version.txt")
-            f = open(start_script, 'r')
-            version = f.readline()
+        import importlib.metadata
+        version = importlib.metadata.version("mavproxy")
 
         print("MAVProxy is a modular ground station using the mavlink protocol")
         print("MAVProxy Version: " + version)

--- a/MAVProxy/modules/mavproxy_fieldcheck/__init__.py
+++ b/MAVProxy/modules/mavproxy_fieldcheck/__init__.py
@@ -28,7 +28,7 @@ from MAVProxy.modules.lib.mp_settings import MPSetting
 from pymavlink import mavutil
 from MAVProxy.modules.lib import mp_util
 
-import pkg_resources
+import importlib.resources
 
 if mp_util.has_wxpython:
     from MAVProxy.modules.lib.mp_menu import MPMenuItem
@@ -69,7 +69,8 @@ class FieldCheck(object):
     def flightdata_filepath(self, filename):
         if os.path.exists(filename):
             return filename
-        return pkg_resources.resource_filename(__name__, filename)
+        with importlib.resources.path(__package__, filename) as p:
+            return str(p)
 
     def loadRally(self):
         filepath = self.flightdata_filepath(self.fc_settings.rally_filename)

--- a/MAVProxy/modules/mavproxy_help.py
+++ b/MAVProxy/modules/mavproxy_help.py
@@ -24,15 +24,8 @@ class HelpModule(mp_module.MPModule):
         self.add_command('mavhelp', self.cmd_help, "help and version information", "<about|site>")
         self.have_list = False
 
-        #  versioning info
-        #  pkg_resources doesn't work in the windows exe build, so read the version file
-        try:
-            import pkg_resources
-            self.version = pkg_resources.Environment()["mavproxy"][0].version
-        except Exception:
-            start_script = mp_util.dot_mavproxy("version.txt")
-            f = open(start_script, 'r')
-            self.version = f.readline()
+        import importlib.metadata
+        self.version = importlib.metadata.version("mavproxy")
         self.host = platform.system() + platform.release()
         self.pythonversion = str(platform.python_version())
         if mp_util.has_wxpython:
@@ -99,7 +92,7 @@ class HelpModule(mp_module.MPModule):
 
     def about_string(self):
         bits = {
-            "MAVProxy Version": self.version,
+            "MAVProxy": self.version,
             "OS": self.host,
             "Python": self.pythonversion,
             "WXPython": self.wxVersion,

--- a/MAVProxy/modules/mavproxy_joystick/__init__.py
+++ b/MAVProxy/modules/mavproxy_joystick/__init__.py
@@ -1,8 +1,9 @@
 import os
 import pygame
-import pkg_resources
 import yaml
 import fnmatch
+
+import importlib.resources
 
 from MAVProxy.modules.lib import mp_module
 from MAVProxy.modules.lib import mp_util
@@ -64,8 +65,6 @@ class Joystick(mp_module.MPModule):
         if userjoysticks is not None and os.path.isdir(userjoysticks):
             search.append(userjoysticks)
 
-        search.append(pkg_resources.resource_filename(__name__, 'joysticks'))
-
         for path in search:
             self.log('Looking for joystick definitions in {}'.format(path),
                      2)
@@ -82,6 +81,15 @@ class Joystick(mp_module.MPModule):
                         joydef = yaml.safe_load(fd)
                         joydef['path'] = joypath
                         self.joydefs.append(joydef)
+
+        # now look for joystick definitions shipped with MAVProxy:
+        with importlib.resources.path(__package__, 'joysticks') as p:
+            print(f"Joystick directory path: {p}")
+            for joypath in p.iterdir():
+                with open(joypath, 'r') as fd:
+                    joydef = yaml.safe_load(fd)
+                    joydef['path'] = joypath
+                    self.joydefs.append(joydef)
 
     def probe(self):
         self.load_definitions()

--- a/MAVProxy/modules/mavproxy_map/mp_tile.py
+++ b/MAVProxy/modules/mavproxy_map/mp_tile.py
@@ -614,25 +614,15 @@ def mp_icon(filename):
     # when we may be in a package zip file
     raw = None
     try:
-        import pkg_resources
-        name = __name__
-        if name == "__main__":
-            name = "MAVProxy.modules.mavproxy_map.mp_tile"
-        stream = pkg_resources.resource_stream(name, f"data/{filename}")
-        raw = np.frombuffer(stream.read(), dtype=np.uint8)
+        import importlib.resources
+        package = __package__ + ".data"
+        if __name__ == "__main__":
+            package = "MAVProxy.modules.mavproxy_map.data"
+        with importlib.resources.open_binary(package, filename) as stream:
+            raw = np.frombuffer(stream.read(), dtype=np.uint8)
     except Exception:
-        try:
-            with open(os.path.join(os.path.dirname(__file__), 'data', filename), 'rb') as f:
-                raw = np.frombuffer(f.read(), dtype=np.uint8)
-        except Exception:
-            try:
-                import pkgutil
-                stream = pkgutil.get_data('MAVProxy', f'modules/mavproxy_map/data/{filename}')
-                raw = np.frombuffer(stream, dtype=np.uint8)
-            except Exception as e:
-                print(f"Failed to load image '{filename}': {e}")
-                return None
-
+        with open(os.path.join(os.path.dirname(__file__), 'data', filename)).read() as stream:
+            raw = np.frombuffer(stream.read(), dtype=np.uint8)
     img = cv2.imdecode(raw, cv2.IMREAD_COLOR)
     return img
 

--- a/MAVProxy/tools/MAVExplorer.py
+++ b/MAVProxy/tools/MAVExplorer.py
@@ -33,7 +33,10 @@ from MAVProxy.modules.lib.mp_settings import MPSettings, MPSetting
 from MAVProxy.modules.lib import wxsettings
 from MAVProxy.modules.lib.graphdefinition import GraphDefinition
 from lxml import objectify
-import pkg_resources
+
+import importlib
+import importlib.resources
+
 from builtins import input
 import datetime
 import matplotlib
@@ -367,30 +370,26 @@ def load_graphs():
         if graphs:
             mestate.graphs.extend(graphs)
             mestate.console.writeln("Loaded %s" % file)
+
     # also load the built in graphs
-    try:
-        dlist = pkg_resources.resource_listdir("MAVProxy", "tools/graphs")
-        for f in dlist:
-            raw = pkg_resources.resource_stream("MAVProxy", "tools/graphs/%s" % f).read()
-            graphs = load_graph_xml(raw, None)
-            if graphs:
-                mestate.graphs.extend(graphs)
-                mestate.console.writeln("Loaded %s" % f)
-    except Exception:
-        #we're in a Windows exe, where pkg_resources doesn't work
-        import pkgutil
-        for f in ["ekf3Graphs.xml", "ekfGraphs.xml", "mavgraphs.xml", "mavgraphs2.xml"]:
-            raw = pkgutil.get_data( 'MAVProxy', 'tools//graphs//' + f)
-            graphs = load_graph_xml(raw, None)
-            if graphs:
-                mestate.graphs.extend(graphs)
-                mestate.console.writeln("Loaded %s" % f)
+    load_built_in_graphs()
+
     mestate.graphs = sorted(mestate.graphs, key=lambda g: g.name)
     # Update completions with actual graph names
     if len(mestate.graphs) > 0:
         # Some default graph names have spaces: replace with -
         graph_names = [g.name.replace(' ', '-') for g in mestate.graphs]
         mestate.completions["graphs"] = graph_names
+
+def load_built_in_graphs():
+    '''load graph definitions from packaged resources'''
+    dlist = importlib.resources.files("MAVProxy.tools.graphs")
+    for f in dlist.iterdir():
+        raw = importlib.resources.files("MAVProxy.tools.graphs").joinpath(f).open('r').read()
+        graphs = load_graph_xml(raw, None)
+        if graphs:
+            mestate.graphs.extend(graphs)
+            mestate.console.writeln("Loaded %s" % f)
 
 def flightmode_colours():
     '''return mapping of flight mode to colours'''
@@ -1775,16 +1774,11 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.version:
-        #pkg_resources doesn't work in the windows exe build, so read the version file
-        try:
-            version = pkg_resources.require("mavproxy")[0].version
-        except Exception as e:
-            start_script = mp_util.dot_mavproxy("version.txt")
-            f = open(start_script, 'r')
-            version = f.readline()
+        import importlib.metadata
+        version = importlib.metadata.version("mavproxy")
         print("MAVExplorer Version: " + version)
         sys.exit(1)
-    
+
     mestate = MEState()
     setup_file_menu()
 


### PR DESCRIPTION
We fall back to the previous efforts on failure.

Tested back to 3.6

2.7 was a complete write-off due to pre-existing changes.
