### PR TITLE
wxconsole_ui: reorder setting of terxt and fg/bg colours

### DIFF
--- a/MAVProxy/modules/lib/wxconsole_ui.py
+++ b/MAVProxy/modules/lib/wxconsole_ui.py
@@ -126,11 +126,11 @@ class ConsoleFrame(wx.Frame):
                     self.status[obj.row].AddSpacer(20)
                     self.values[obj.name] = value
                 value = self.values[obj.name]
+                value.SetLabel(obj.text)
                 value.SetForegroundColour(obj.fg)
                 value.SetBackgroundColour(obj.bg)
                 # workaround wx bug on windows
                 value._foregroundColour = obj.fg
-                value.SetLabel(obj.text)
                 self.panel.Layout()
             elif isinstance(obj, Text):
                 '''request to add text to the console'''


### PR DESCRIPTION
Windows fails to update colours on text in the wx console.  Rearranging the setting ofthe text and colours fixes this.