### PR TITLE
dataflash_logger: make module public

### DIFF
--- a/MAVProxy/modules/mavproxy_dataflash_logger.py
+++ b/MAVProxy/modules/mavproxy_dataflash_logger.py
@@ -33,7 +33,8 @@ class dataflash_logger(mp_module.MPModule):
         super(dataflash_logger, self).__init__(
             mpstate,
             "dataflash_logger",
-            "logging of mavlink dataflash messages"
+            "logging of mavlink dataflash messages",
+            public=True
         )
         self.sender = None
         self.stopped = False


### PR DESCRIPTION
This will make the module accessible from other modules with the module('name').