### PR TITLE
MAVCesium: Switch to newer fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "MAVProxy/modules/mavproxy_cesium"]
 	path = MAVProxy/modules/mavproxy_cesium
-	url = https://github.com/SamuelDudley/MAVCesium.git
+	url = https://github.com/ArduPilot/MAVCesium.git


### PR DESCRIPTION
# Purpose

Add my MAVCesium fork and expose it a bit better in MAVProxy.

# Expectations

With `mavproxy.py --cesium`, it will start the web server, which you can open at `http://0.0.0.0:5000/mavcesium/#`.

You can also still do `module load cesium`.

Currently, mavproxy does not connect properly when launched in this mode. It works best with the standalone mode, where you launch mavproxy, then launch mavcesium separately in another terminal. 

```bash
python3 cesium_web_server.py
```

I'll chase that down soon - it's likely a difference in default options because the websocket receives no data.
I'd like to propose merging this as-is with the known deficiency because it's still a large improvement.

Here's what you get:

Birds eye view of Kaga (default on open when you start SITL in Kaga)
![image](https://github.com/user-attachments/assets/0b143845-36b2-404a-8f60-2a90e4859fc3)

Once you take off, the takeoff orbit is marked in pink.
![image](https://github.com/user-attachments/assets/9d8e157a-e55a-4e53-b84f-dacdee38312c)
There is a known issue of the vehicle model being yawed 90 off. I'll fix it later.

The forward facing view works too
![image](https://github.com/user-attachments/assets/a67946bf-11c1-4bf7-9459-e593c67d72dd)


If you switch to FBWB, you can turn on the camera projection, and get a good idea of what it looks like.
![image](https://github.com/user-attachments/assets/089b8025-f7c5-4f99-b46d-5176378bd846)

# Follow up

I'd like to get it fully working (integrated as a mavproxy module) and fix any obvious bugs. 