### PR TITLE
Add Start Websocket Server to the MAVProxy console

### DIFF
--- a/MAVProxy/modules/mavproxy_link.py
+++ b/MAVProxy/modules/mavproxy_link.py
@@ -109,12 +109,24 @@ class LinkModule(mp_module.MPModule):
         self.menu_added_console = False
         if mp_util.has_wxpython:
             self.menu_rm = MPMenuSubMenu('Remove', items=[])
-            self.menu = MPMenuSubMenu('Link',
-                                      items=[MPMenuItem('Add...', 'Add...', '# link add ', handler=MPMenulinkAddDialog()),
-                                             self.menu_rm,
-                                             MPMenuItem('Ports', 'Ports', '# link ports'),
-                                             MPMenuItem('List', 'List', '# link list'),
-                                             MPMenuItem('Status', 'Status', '# link')])
+
+            items = [
+                MPMenuItem('Add...', 'Add...', '# link add ', handler=MPMenulinkAddDialog()),
+                self.menu_rm,
+                MPMenuItem('Ports', 'Ports', '# link ports'),
+                MPMenuItem('List', 'List', '# link list'),
+                MPMenuItem('Status', 'Status', '# link')]
+            # wsproto is not installed by default.
+            # Only add the menu if it's available.
+            try:
+                import wsproto  # noqa: F401
+            except ImportError:
+                pass
+            else:
+                items.append(
+                    MPMenuItem('Start Websocket Server', 'Start Websocket Server', '# output add wsserver:0.0.0.0:56781'))
+
+            self.menu = MPMenuSubMenu('Link', items=items)
             self.last_menu_update = 0
 
     def idle_task(self):


### PR DESCRIPTION
# Purpose

Add ability to add a websocket server in the MAVProxy menu. It's only added if wsproto is installed.

# Related

* https://github.com/ArduPilot/ardupilot/pull/28560
* https://github.com/ArduPilot/pymavlink/pull/967

# Demo
[mavproxy_1481_websocket_server.webm](https://github.com/user-attachments/assets/02124a5e-273e-47b8-abe4-f94c087a359e)

# Follow Up

* Give users the ability to change which port number. The current one matches webtools.
   * Any tips on other places that open up a text box when you click? 