### PR TITLE
Make mavproxy executable directly

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 mavproxy - a MAVLink proxy program
 


### PR DESCRIPTION
Makes mavproxy executable so that it's easier to spin up a debugger in VSCode.

# Usage

```
cd MAVProxy/MAVProxy
./mavproxy.py -h
```