### PR TITLE
fix altMarker set_data error

### DIFF
--- a/MAVProxy/modules/lib/wxhorizon_ui.py
+++ b/MAVProxy/modules/lib/wxhorizon_ui.py
@@ -515,7 +515,7 @@ class HorizonFrame(wx.Frame):
         # Display Plot
         self.altHistRect.set_x(self.leftPos+(self.vertSize/10.0))
         self.altPlot.set_data(x,y)
-        self.altMarker.set_data(self.leftPos+(self.vertSize/10.0)+0.5,val)
+        self.altMarker.set_data([self.leftPos+(self.vertSize/10.0)+0.5],[val])
         self.altText2.set_position((self.leftPos+(4*self.vertSize/10.0)+0.5,val))
         self.altText2.set_size(self.fontSize)
         self.altText2.set_text('%.f m' % self.relAlt)


### PR DESCRIPTION
fix 2D line set_data error in ui update loop
https://matplotlib.org/stable/api/_as_gen/matplotlib.lines.Line2D.html#matplotlib.lines.Line2D.set_data
```
RuntimeError: x must be a sequence
Traceback (most recent call last):
  File "/opt/homebrew/lib/python3.9/site-packages/MAVProxy/modules/lib/wxhorizon_ui.py", line 627, in on_timer
    self.updateAltHistory()
  File "/opt/homebrew/lib/python3.9/site-packages/MAVProxy/modules/lib/wxhorizon_ui.py", line 518, in updateAltHistory
    self.altMarker.set_data([self.leftPos+(self.vertSize/10.0)+0.5,val])
  File "/opt/homebrew/lib/python3.9/site-packages/matplotlib/lines.py", line 665, in set_data
    self.set_xdata(x)
  File "/opt/homebrew/lib/python3.9/site-packages/matplotlib/lines.py", line 1289, in set_xdata
    raise RuntimeError('x must be a sequence')
RuntimeError: x must be a sequence
```