### PR TITLE
mavproxy.py: Clean up log_writer exit

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -81,7 +81,7 @@ class MPStatus(object):
         self.mav_error = 0
         self.altitude = 0
         self.last_distance_announce = 0.0
-        self.exit = False
+        self.stop_event = threading.Event()
         self.flightmode = 'MAV'
         self.last_mode_announce = 0
         self.last_mode_announced = 'MAV'
@@ -802,7 +802,7 @@ def process_stdin(line):
             print("%-15s : %s" % (cmd, help))
         return
     if cmd == 'exit' and mpstate.settings.requireexit:
-        mpstate.status.exit = True
+        mpstate.status.stop_event.set()
         return
 
     if cmd not in command_map:
@@ -935,8 +935,13 @@ def mkdir_p(dir):
 
 def log_writer():
     '''log writing thread'''
-    while not mpstate.status.exit:
-        mpstate.logfile_raw.write(bytearray(mpstate.logqueue_raw.get()))
+    while not mpstate.status.stop_event.is_set():
+        if not mpstate.logqueue_raw.empty():
+            bytes = mpstate.logqueue_raw.get(block=False)
+            mpstate.logfile_raw.write(bytearray(bytes))
+        time.sleep(0.001)
+
+        # TODO consider wait() the stop event instead
         timeout = time.time() + 10
         while not mpstate.logqueue_raw.empty() and time.time() < timeout:
             mpstate.logfile_raw.write(mpstate.logqueue_raw.get())
@@ -1008,18 +1013,17 @@ def open_telemetry_logs(logpath_telem, logpath_telem_raw):
             stat = os.statvfs(logpath_telem)
             if stat.f_bfree*stat.f_bsize < 209715200:
                 print("ERROR: Not enough free disk space for logfile")
-                mpstate.status.exit = True
+                mpstate.status.stop_event.set()
                 return
 
         # use a separate thread for writing to the logfile to prevent
         # delays during disk writes (important as delays can be long if camera
         # app is running)
         t = threading.Thread(target=log_writer, name='log_writer')
-        t.daemon = True
         t.start()
     except Exception as e:
         print("ERROR: opening log file for writing: %s" % e)
-        mpstate.status.exit = True
+        mpstate.status.stop_event.set()
         return
 
 
@@ -1120,7 +1124,7 @@ def main_loop():
         set_stream_rates()
 
     while True:
-        if mpstate is None or mpstate.status.exit:
+        if mpstate is None or mpstate.status.stop_event.is_set():
             return
 
         # enable or disable screensaver:
@@ -1220,12 +1224,12 @@ def main_loop():
 
 def input_loop():
     '''wait for user input'''
-    while mpstate.status.exit is not True:
+    while not mpstate.status.stop_event.is_set():
         try:
             line = mpstate.rl.input()
             mpstate.input_queue.put(line)
         except (EOFError, IOError):
-            mpstate.status.exit = True
+            mpstate.status.stop_event.set()
 
 
 def run_script(scriptfile):
@@ -1403,7 +1407,6 @@ if __name__ == '__main__':
 
     # global mavproxy state
     mpstate = MPState()
-    mpstate.status.exit = False
     mpstate.command_map = command_map
     mpstate.continue_mode = opts.continue_mode
     # queues for logging
@@ -1443,11 +1446,11 @@ if __name__ == '__main__':
 
     def quit_handler(signum=None, frame=None):
         # print('Signal handler called with signal', signum)
-        if mpstate.status.exit:
+        if mpstate.status.stop_event.is_set():
             print('Clean shutdown impossible, forcing an exit')
             sys.exit(0)
         else:
-            mpstate.status.exit = True
+            mpstate.status.stop_event.set()
 
     # Listen for kill signals to cleanly shutdown modules
     fatalsignals = [signal.SIGTERM]
@@ -1586,7 +1589,7 @@ if __name__ == '__main__':
 
     # use main program for input. This ensures the terminal cleans
     # up on exit
-    while (mpstate.status.exit is not True):
+    while not mpstate.status.stop_event.is_set():
         try:
             if opts.daemon or opts.non_interactive:
                 time.sleep(0.1)
@@ -1608,7 +1611,7 @@ if __name__ == '__main__':
                         m.init(mpstate)
 
             else:
-                mpstate.status.exit = True
+                mpstate.status.stop_event.set()
                 sys.exit(1)
 
     if opts.profile:


### PR DESCRIPTION
# Purpose

Closes #1414 

# Details

* The log thread was marked as [daemon=True](https://docs.python.org/3/library/threading.html#threading.Thread.daemon)
* daemon threads are [not recommended anymore by the python maintainers](https://discuss.python.org/t/getting-rid-of-daemon-threads/68836)
* The threading library recommends [using Event for thread synchronization](https://docs.python.org/3/library/threading.html#thread-objects)
* The [Queue.get() call blocks by default](https://docs.python.org/3/library/queue.html#queue.Queue.get), which may was the reason this was put as a daemon thread
* By making [Queue.get()](https://docs.python.org/3/library/queue.html#queue.Queue.get) non-blocking, and checking size before access, because it raises an exception if there is nothing to read, the log writing cleanup can continue as normal. Without this, `Queue..get` can block forever. When daemon=False, this means the thread stays hung and mavproxy is never closed unless you sigterm it with a 2nd ctrl+C (nasty)
* There are no longer exceptions when using ctrl+C to stop MAVProxy
* I use an [Event](https://docs.python.org/3/library/threading.html#threading.Event) as a signaling mechanism to stop the open threads


# Tests Performed

Linux:
- [x] Start mavproxy by itself (no vehicle), and kill it 
- [x] Start mavproxy with a vehicle, ensure it exits cleanly
- [x] Start mavproxy and observe logs are not corrupt
- [x] Test noninteractive mode
- [x] Test `exit` command : `MANUAL> Unknown command 'exit'` => exit doesn't work anymore, even on `master`
- [ ] Test lack of disk space exits mavproxy
- [x] Test permissions error opening logfile has mavproxy exit cleanly -> Mavproxy shows "AP: PreArm: Logging failed" in console, and keeps running. I assume that's ok

MacOS:
- [ ] Queue imports work in [this workaround](https://github.com/ArduPilot/MAVProxy/blob/5127953d3ed929a8643cfebbf7961a82e448e332/MAVProxy/modules/lib/multiproc.py#L70)
- [x] Start mavproxy by itself (no vehicle), and kill it 
- [ ] Start mavproxy with a vehicle, ensure it exits cleanly
- [ ] Start mavproxy and observe logs are not corrupt
- [ ] Test noninteractive mode
- [ ] Test `exit` command
- [ ] Test lack of disk space exits mavproxy
- [ ] Test permissions error opening logfile has mavproxy exit cleanly

Windows
- [ ] Start mavproxy by itself (no vehicle), and kill it 
- [ ] Start mavproxy with a vehicle, ensure it exits cleanly
- [ ] Start mavproxy and observe logs are not corrupt
- [ ] Test noninteractive mode
- [ ] Test `exit` command
- [ ] Test lack of disk space exits mavproxy
- [ ] Test permissions error opening logfile has mavproxy exit cleanly