### PR TITLE
mavproxy_param: fixes broken parameter setting

### DIFF
--- a/MAVProxy/modules/mavproxy_param.py
+++ b/MAVProxy/modules/mavproxy_param.py
@@ -645,7 +645,7 @@ class ParamState:
             return
 
         # Update the parameter
-        self.set_parameter(master, uname, value, attempts=3, parm_type=ptype)
+        self.set_parameter(master, uname, value, attempts=3, param_type=ptype)
 
     def set_parameter(self, master, name, value, attempts=None, param_type=None):
         '''convenient intermediate method which determines parameter type for


### PR DESCRIPTION
Fixes a change made in #1408 that passes in an incorrect keyword argument into set_parameter