### PR TITLE
mavflightview.py: increase error threshold for bad colour exporession

### DIFF
--- a/MAVProxy/tools/mavflightview.py
+++ b/MAVProxy/tools/mavflightview.py
@@ -193,7 +193,7 @@ def colour_for_point(mlog, point, instance, options):
         except KeyError:
             colour_expression_exceptions[str_e] = 0
             count = 0
-        if count > 100:
+        if count > 10000:
             print("Too many exceptions processing (%s): %s" % (source, str_e))
             sys.exit(1)
         colour_expression_exceptions[str_e] += 1


### PR DESCRIPTION
we probably need something more nuanced than this, but if a message in your expression doesn't exist for a long time in your log the you can end up bombing out here