### PR TITLE
Add terrain contours to map

### DIFF
--- a/MAVProxy/modules/mavproxy_map/mp_slipmap_util.py
+++ b/MAVProxy/modules/mavproxy_map/mp_slipmap_util.py
@@ -214,7 +214,7 @@ class SlipCircle(SlipObject):
 
 class SlipPolygon(SlipObject):
     '''a polygon to display on the map'''
-    def __init__(self, key, points, layer, colour, linewidth, arrow = False, popup_menu=None, showlines=True):
+    def __init__(self, key, points, layer, colour, linewidth, arrow = False, popup_menu=None, showlines=True, showcircles=True):
         SlipObject.__init__(self, key, layer, popup_menu=popup_menu)
         self.points = points
         self.colour = colour
@@ -225,6 +225,7 @@ class SlipPolygon(SlipObject):
         self._selected_vertex = None
         self._has_timestamps = False
         self._showlines = showlines
+        self._showcircles = showcircles
 
     def set_colour(self, colour):
         self.colour = colour
@@ -250,7 +251,8 @@ class SlipPolygon(SlipObject):
             return
         if self._showlines:
             cv2.line(img, pix1, pix2, colour, linewidth)
-        cv2.circle(img, pix2, linewidth*2, colour)
+        if self._showcircles:
+            cv2.circle(img, pix2, linewidth*2, colour)
         if len(self._pix_points) == 0:
             self._pix_points.append(pix1)
         self._pix_points.append(pix2)


### PR DESCRIPTION
Use data available in the terrain module to overlay terrain contours on the map.

![mavproxy_contour_ardnamurchan](https://github.com/user-attachments/assets/b4582e9f-f769-4fd5-991e-34acc3ce4643)

## Motivation

- Be able to overlay terrain contour lines on the existing slip map.
- Use existing terrain data sources to match information available on the FC.
- Initial step in adding support to mavproxy for configuring off-board terrain planning for planes. The idea is to replace the dependency on rviz and simplify the user workflow the example used here https://discuss.ardupilot.org/t/offboard-terrain-navigation-for-plane-with-ros-2-ap-dds/114418. 

## Use

Select the number of contour levels, grid resolution and grid extent using the map settings:

```bash
STABILIZE> map set
STABILIZE>           
          brightness 1
    circle_linewidth 1
 contour_grid_extent 20000.0
contour_grid_spacing 30.0
      contour_levels 20
           font_size 0.5
        loitercircle False
         rallycircle False
     setpos_accuracy 50
        showahrs2pos 0
        showahrs3pos 0
         showahrspos 1
       showclicktime 2
       showdirection False
         showgps2pos 1
          showgpspos 1
          showsimpos 0
           showwpnum True
```

The terrain resolution is determined by the source used. The default is `SRTM3` which may be switched before loading the contours using:

```bash
STABILIZE> terrain set source SRTM1
```

To show the contours use the context menu:

![terrain_contours_show](https://github.com/user-attachments/assets/ba35a9ee-21ac-4425-b28f-ab3a63bdb3c7)

Hide the contours (but do not remove - saves recalculating when showing again):

![terrain_contours_hide](https://github.com/user-attachments/assets/5e310f24-ad8f-4fa1-8f83-35e57d7cda52)

To select a different region, remove then show again: 

![terrain_contours_move](https://github.com/user-attachments/assets/92aa970b-c191-4f52-b2cc-e0d03438a6fb)

## Tasks

- [x] add menu item to toggle contour visibility
- [x] add settings to control number of levels (and/or spacing)

## Follow up / optional

- [ ] add settings to control the contour colour map
- [ ] add contour labels
- [ ] replace dependency on [matplotlib.pyplot.contour](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.contour.html) with [ContourPy](https://contourpy.readthedocs.io/en/v1.3.1/index.html)
- [ ] automatically update / calculate contours as the map is moved / zoomed as it's currently fixed
- [ ] shade areas above a certain altitude