### PR TITLE
mavproxy_link.py: fix websocket output sending mavlink pkt during hanshake

### DIFF
--- a/MAVProxy/modules/mavproxy_link.py
+++ b/MAVProxy/modules/mavproxy_link.py
@@ -1054,6 +1054,10 @@ class LinkModule(mp_module.MPModule):
             if self.mpstate.settings.mavfwd_rate or mtype != 'REQUEST_DATA_STREAM':
                 if mtype not in self.no_fwd_types:
                     for r in self.mpstate.mav_outputs:
+                        if hasattr(r, 'ws') and r.ws is not None:
+                            from wsproto.connection import ConnectionState
+                            if r.ws.state != ConnectionState.OPEN:  # Ensure Websocket handshake is done
+                                continue
                         r.write(m.get_msgbuf())
 
             sysid = m.get_srcSystem()


### PR DESCRIPTION
``` shell
wsproto.utilities.LocalProtocolError: Event BytesMessage(data=bytearray(b'\xfd\x0f\x00\x00$\x01\x01\x82\x01\x00}\x04\x04\x98\xff\x00\x00\x07\xcb\x92\xb8G\x00\x00\xcc\xd5\xb4'), frame_finished=True, message_finished=True) cannot be sent during the handshake
```
fix raised error when sending mavlink packet during websocket handshake