### PR TITLE
mission_item_protocol: fix 'move' on items we have not downloaded

### DIFF
--- a/MAVProxy/modules/lib/mission_item_protocol.py
+++ b/MAVProxy/modules/lib/mission_item_protocol.py
@@ -569,8 +569,12 @@ on'''
             alt2 = self.module('terrain').ElevationModel.GetElevation(wp.x, wp.y)
             if alt1 is not None and alt2 is not None:
                 wp.z += alt1 - alt2
-        wp.x = lat
-        wp.y = lon
+        if isinstance(wp, pymavlink.dialects.v20.ardupilotmega.MAVLink_mission_item_int_message):
+            wp.x = int(lat * 1e7)
+            wp.y = int(lon * 1e7)
+        else:
+            wp.x = lat
+            wp.y = lon
 
         wp.target_system    = self.target_system
         wp.target_component = self.target_component

--- a/MAVProxy/modules/lib/mission_item_protocol.py
+++ b/MAVProxy/modules/lib/mission_item_protocol.py
@@ -10,8 +10,10 @@ import copy
 import os
 import re
 import struct
+import sys
 import time
 
+import pymavlink
 from pymavlink import mavutil
 from MAVProxy.modules.lib import mp_module
 from MAVProxy.modules.lib import mp_util
@@ -345,6 +347,10 @@ on'''
            MISSION_ITEM_INT to give cm level accuracy
         '''
         if wp.get_type() == 'MISSION_ITEM_INT':
+            if not isinstance(wp.x, int):
+                print("BUG! wp.x is not integer")
+            if not isinstance(wp.y, int):
+                print("BUG! wp.y is not integer")
             return wp
         if self.has_location(wp.command):
             p5 = int(wp.x*1.0e7)
@@ -428,7 +434,12 @@ on'''
         if wp.mission_type != self.mav_mission_type():
             print("Wrong mission type in (%s)" % str(wp))
 
-        self.master.mav.send(wp_send)
+        try:
+            self.master.mav.send(wp_send)
+        except struct.error:
+            # this is often "required argument is not an integer"
+            mavutil.dump_message_verbose(sys.stderr, wp_send)
+            raise
 
         self.loading_waypoint_lasttime = time.time()
 


### PR DESCRIPTION
rally clear
<<click on map>>
rally add
rally move 1

Before this patch that fails to pack the mission_item_int message as we are inserting floating point values into the item_int message x and y fields.

... same is true of waypoints
