### PR TITLE
Correct rover param download

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -45,10 +45,10 @@ jobs:
         run: |          
           mkdir Parameters
           $wc = New-Object System.Net.WebClient
-          $wc.DownloadFile('https://autotest.ardupilot.org/Parameters/APMrover2/apm.pdef.xml', 'Parameters\Rover.xml')
-          $wc.DownloadFile('https://autotest.ardupilot.org/Parameters/ArduCopter/apm.pdef.xml', 'Parameters\ArduCopter.xml')
-          $wc.DownloadFile('https://autotest.ardupilot.org/Parameters/ArduPlane/apm.pdef.xml', 'Parameters\ArduPlane.xml')
-          $wc.DownloadFile('https://autotest.ardupilot.org/Parameters/ArduSub/apm.pdef.xml', 'Parameters\ArduSub.xml')
+          $wc.DownloadFile('https://autotest.ardupilot.org/Parameters/Rover/apm.pdef.xml', 'Parameters\Rover.xml')
+          $wc.DownloadFile('https://autotest.ardupilot.org/Parameters/Copter/apm.pdef.xml', 'Parameters\Copter.xml')
+          $wc.DownloadFile('https://autotest.ardupilot.org/Parameters/Plane/apm.pdef.xml', 'Parameters\Plane.xml')
+          $wc.DownloadFile('https://autotest.ardupilot.org/Parameters/Sub/apm.pdef.xml', 'Parameters\Sub.xml')
           $wc.DownloadFile('https://autotest.ardupilot.org/Parameters/AntennaTracker/apm.pdef.xml', 'Parameters\AntennaTracker.xml')
           $wc.DownloadFile('https://autotest.ardupilot.org/Parameters/Heli/apm.pdef.xml', 'Parameters\Heli.xml')
       - name: Build installer

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -51,6 +51,7 @@ jobs:
           $wc.DownloadFile('https://autotest.ardupilot.org/Parameters/Sub/apm.pdef.xml', 'Parameters\Sub.xml')
           $wc.DownloadFile('https://autotest.ardupilot.org/Parameters/AntennaTracker/apm.pdef.xml', 'Parameters\AntennaTracker.xml')
           $wc.DownloadFile('https://autotest.ardupilot.org/Parameters/Heli/apm.pdef.xml', 'Parameters\Heli.xml')
+          $wc.DownloadFile('https://autotest.ardupilot.org/Parameters/Blimp/apm.pdef.xml', 'Parameters\Blimp.xml')
       - name: Build installer
         run: |
           cd  windows

--- a/MAVProxy/modules/lib/param_help.py
+++ b/MAVProxy/modules/lib/param_help.py
@@ -13,7 +13,7 @@ class ParamHelp:
     def param_help_download(self):
         '''download XML files for parameters'''
         files = []
-        for vehicle in ['Rover', 'ArduCopter', 'ArduPlane', 'ArduSub', 'AntennaTracker', 'Blimp', 'Heli']:
+        for vehicle in ['Rover', 'Copter', 'Plane', 'Sub', 'AntennaTracker', 'Blimp', 'Heli']:
             url = 'http://autotest.ardupilot.org/Parameters/%s/apm.pdef.xml.gz' % vehicle
             path = mp_util.dot_mavproxy("%s.xml" % vehicle)
             files.append((url, path))
@@ -25,6 +25,21 @@ class ParamHelp:
 
     def param_use_xml_filepath(self, filepath):
         self.xml_filepath = filepath
+
+    def convert_vehicle_name(self):
+        '''convert vehicle name new format'''
+        if self.vehicle_name is None:
+            return None
+        if self.vehicle_name == 'APMrover2':
+            return 'Rover'
+        elif self.vehicle_name == 'ArduPlane':
+            return 'Plane'
+        elif self.vehicle_name == 'ArduSub':
+            return 'Sub'
+        elif self.vehicle_name == 'ArduCopter':
+            return 'Copter'
+        else:
+            return self.vehicle_name
 
     def param_help_tree(self, verbose=False):
         '''return a "help tree", a map between a parameter and its metadata.  May return None if help is not available'''
@@ -39,13 +54,14 @@ class ParamHelp:
                 if verbose:
                     print("Unknown vehicle type")
                 return None
-            path = mp_util.dot_mavproxy("%s.xml" % self.vehicle_name)
+            # Map between new and old names
+            path = mp_util.dot_mavproxy("%s.xml" % self.convert_vehicle_name())
+            # Otherwise try legacy name
             if not os.path.exists(path):
-                if self.vehicle_name == 'APMrover2':
-                    path = mp_util.dot_mavproxy("%s.xml" % "Rover")
+                path = mp_util.dot_mavproxy("%s.xml" % self.vehicle_name)
             if not os.path.exists(path):
                 if verbose:
-                    print("Please run 'param download' first (vehicle_name=%s)" % self.vehicle_name)
+                    print("Please run 'param download' first (vehicle_name=%s)" % self.convert_vehicle_name())
                 return None
         if not os.path.exists(path):
             if verbose:

--- a/MAVProxy/modules/mavproxy_param.py
+++ b/MAVProxy/modules/mavproxy_param.py
@@ -446,13 +446,9 @@ class ParamState:
         wildcard = '*'
         if len(args) < 1 or args[0].find('*') != -1:
             defaults = self.default_params
-            if defaults is None and self.vehicle_name is not None:
-                filename = mp_util.dot_mavproxy("%s-defaults.parm" % self.vehicle_name)
-                if not os.path.exists(filename):
-                    print("Please run 'param download' first (vehicle_name=%s)" % self.vehicle_name)
-                    return
-                defaults = mavparm.MAVParmDict()
-                defaults.load(filename)
+            if defaults is None:
+                print("Cannot find default parameters")
+                return
             if len(args) >= 1:
                 wildcard = args[0]
         else:

--- a/windows/MAVProxyWinBuild.bat
+++ b/windows/MAVProxyWinBuild.bat
@@ -53,10 +53,10 @@ rem -----Create version Info-----
 rem -----Download parameter files-----
 cd  ..\
 mkdir Parameters
-powershell.exe "Start-BitsTransfer -Source 'http://autotest.ardupilot.org/Parameters/APMrover2/apm.pdef.xml' -Destination 'Parameters\Rover.xml'"
-powershell.exe "Start-BitsTransfer -Source 'http://autotest.ardupilot.org/Parameters/ArduCopter/apm.pdef.xml' -Destination 'Parameters\ArduCopter.xml'"
-powershell.exe "Start-BitsTransfer -Source 'http://autotest.ardupilot.org/Parameters/ArduPlane/apm.pdef.xml' -Destination 'Parameters\ArduPlane.xml'"
-powershell.exe "Start-BitsTransfer -Source 'http://autotest.ardupilot.org/Parameters/ArduSub/apm.pdef.xml' -Destination 'Parameters\ArduSub.xml'"
+powershell.exe "Start-BitsTransfer -Source 'http://autotest.ardupilot.org/Parameters/Rover/apm.pdef.xml' -Destination 'Parameters\Rover.xml'"
+powershell.exe "Start-BitsTransfer -Source 'http://autotest.ardupilot.org/Parameters/Copter/apm.pdef.xml' -Destination 'Parameters\Copter.xml'"
+powershell.exe "Start-BitsTransfer -Source 'http://autotest.ardupilot.org/Parameters/Plane/apm.pdef.xml' -Destination 'Parameters\Plane.xml'"
+powershell.exe "Start-BitsTransfer -Source 'http://autotest.ardupilot.org/Parameters/Sub/apm.pdef.xml' -Destination 'Parameters\Sub.xml'"
 powershell.exe "Start-BitsTransfer -Source 'http://autotest.ardupilot.org/Parameters/AntennaTracker/apm.pdef.xml' -Destination 'Parameters\AntennaTracker.xml'"
 powershell.exe "Start-BitsTransfer -Source 'http://autotest.ardupilot.org/Parameters/Heli/apm.pdef.xml' -Destination 'Parameters\Heli.xml'"
 

--- a/windows/MAVProxyWinBuild.bat
+++ b/windows/MAVProxyWinBuild.bat
@@ -59,6 +59,7 @@ powershell.exe "Start-BitsTransfer -Source 'http://autotest.ardupilot.org/Parame
 powershell.exe "Start-BitsTransfer -Source 'http://autotest.ardupilot.org/Parameters/Sub/apm.pdef.xml' -Destination 'Parameters\Sub.xml'"
 powershell.exe "Start-BitsTransfer -Source 'http://autotest.ardupilot.org/Parameters/AntennaTracker/apm.pdef.xml' -Destination 'Parameters\AntennaTracker.xml'"
 powershell.exe "Start-BitsTransfer -Source 'http://autotest.ardupilot.org/Parameters/Heli/apm.pdef.xml' -Destination 'Parameters\Heli.xml'"
+powershell.exe "Start-BitsTransfer -Source 'http://autotest.ardupilot.org/Parameters/Blimp/apm.pdef.xml' -Destination 'Parameters\Blimp.xml'"
 
 rem -----Build the Installer-----
 cd .\windows


### PR DESCRIPTION
For the rover param downloads, there was an inconsistency between using "APMrover2.xml" and "Rover.xml", leading to the param module not using the correct xml file.

I've standardised on "APMrover2.xml"