### PR TITLE
Add cesium extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,7 @@ on how to use MAVProxy.''',
                 'MAVProxy.modules.lib.optparse_gui'],
       install_requires=requirements,
       extras_require={
+        'cesium': ['tornado'],
         # restserver module
         'server': ['flask'],
         'recommended': ['flask', 'PyYAML', 'lxml', 'wxpython',


### PR DESCRIPTION
```
ryan@ryan-thinkpad:~/Dev/ardupilot_ws/src/MAVProxy$ python3 -m pip install -e .[cesium]
Defaulting to user installation because normal site-packages is not writeable
Obtaining file:///home/ryan/Dev/ardupilot_ws/src/MAVProxy
  Preparing metadata (setup.py) ... done
Requirement already satisfied: pymavlink>=2.4.14 in /home/ryan/.local/lib/python3.10/site-packages (from MAVProxy==1.8.71) (2.4.42)
Requirement already satisfied: pyserial>=3.0 in /usr/lib/python3/dist-packages (from MAVProxy==1.8.71) (3.5)
Requirement already satisfied: numpy in /usr/lib/python3/dist-packages (from MAVProxy==1.8.71) (1.21.5)
Requirement already satisfied: pynmeagps in /home/ryan/.local/lib/python3.10/site-packages (from MAVProxy==1.8.71) (1.0.43)
Requirement already satisfied: tornado in /usr/lib/python3/dist-packages (from MAVProxy==1.8.71) (6.1)
Requirement already satisfied: future in /home/ryan/.local/lib/python3.10/site-packages (from pymavlink>=2.4.14->MAVProxy==1.8.71) (1.0.0)
Requirement already satisfied: lxml in /home/ryan/.local/lib/python3.10/site-packages (from pymavlink>=2.4.14->MAVProxy==1.8.71) (5.3.0)
WARNING: Error parsing dependencies of flatbuffers: Invalid version: '1.12.1-git20200711.33e2d80-dfsg1-0.6'
Installing collected packages: MAVProxy
  Attempting uninstall: MAVProxy
    Found existing installation: MAVProxy 1.8.71
    Uninstalling MAVProxy-1.8.71:
      Successfully uninstalled MAVProxy-1.8.71
  DEPRECATION: Legacy editable install of MAVProxy[cesium]==1.8.71 from file:///home/ryan/Dev/ardupilot_ws/src/MAVProxy (setup.py develop) is deprecated. pip 25.0 will enforce this behaviour change. A possible replacement is to add a pyproject.toml or enable --use-pep517, and use setuptools >= 64. If the resulting installation is not behaving as expected, try using --config-settings editable_mode=compat. Please consult the setuptools documentation for more information. Discussion can be found at https://github.com/pypa/pip/issues/11457
  Running setup.py develop for MAVProxy
Successfully installed MAVProxy

[notice] A new release of pip is available: 24.3.1 -> 25.1.1
[notice] To update, run: python3 -m pip install --upgrade pip
```