### PR TITLE
mavproxy_ftp: Handle if no master when sending

### DIFF
--- a/MAVProxy/modules/mavproxy_ftp.py
+++ b/MAVProxy/modules/mavproxy_ftp.py
@@ -187,6 +187,9 @@ class FTPModule(mp_module.MPModule):
         plen = len(payload)
         if plen < MAX_Payload + HDR_Len:
             payload.extend(bytearray([0]*((HDR_Len+MAX_Payload)-plen)))
+        if self.master is None:
+            print("FTP: Can't send request, no master...")
+            return
         self.master.mav.file_transfer_protocol_send(self.network, self.target_system, self.target_component, payload)
         self.seq = (self.seq + 1) % 256
         self.last_op = op


### PR DESCRIPTION

If you aren't connected, there is no master to send data to
```
MAV> ftp list APM
Listing APM
MAV> ERROR in command ['list', 'APM']: 'NoneType' object has no attribute 'mav'
Traceback (most recent call last):
  File "/home/ryan/Dev/ardu_ws/src/MAVProxy/MAVProxy/mavproxy.py", line 825, in process_stdin
    fn(args[1:])
  File "/home/ryan/Dev/ardu_ws/src/MAVProxy/MAVProxy/modules/mavproxy_ftp.py", line 159, in cmd_ftp
    self.cmd_list(args[1:])
  File "/home/ryan/Dev/ardu_ws/src/MAVProxy/MAVProxy/modules/mavproxy_ftp.py", line 238, in cmd_list
    self.send(op)
  File "/home/ryan/Dev/ardu_ws/src/MAVProxy/MAVProxy/modules/mavproxy_ftp.py", line 190, in send
    self.master.mav.file_transfer_protocol_send(self.network, self.target_system, self.target_component, payload)
AttributeError: 'NoneType' object has no attribute 'mav'
```