### PR TITLE
Map: Use correct file path for icons

### DIFF
--- a/MAVProxy/modules/mavproxy_map/mp_tile.py
+++ b/MAVProxy/modules/mavproxy_map/mp_tile.py
@@ -626,7 +626,7 @@ def mp_icon(filename):
         raw = np.fromstring(stream, dtype=np.uint8)
     except Exception:
         try:
-            stream = open(os.path.join(__file__, 'data', filename)).read()
+            stream = open(os.path.join(os.path.dirname(__file__), 'data', filename)).read()
             raw = np.fromstring(stream, dtype=np.uint8)
         except Exception:
             #we're in a Windows exe, where pkg_resources doesn't work


### PR DESCRIPTION
For for #1582. Turns out the method of getting the map icon folder was incorrect.