### PR TITLE
`wave` is a Python Standard Library module

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           python3 -m pip install -U wheel setuptools pip
           python3 -m pip install -U pywin32 lxml pymavlink numpy matplotlib pyserial opencv-python PyYAML Pygame Pillow wxpython prompt-toolkit scipy
-          python3 -m pip install -U openai wave pyaudio
+          python3 -m pip install -U openai pyaudio
           python3 -m pip install -U pyinstaller==6.7.0 packaging 
       - name: Download Inno Setup installer
         run: curl -L -o installer.exe http://files.jrsoftware.org/is/6/innosetup-6.3.1.exe

--- a/MAVProxy/modules/mavproxy_chat/chat_voice_to_text.py
+++ b/MAVProxy/modules/mavproxy_chat/chat_voice_to_text.py
@@ -5,13 +5,12 @@ Randy Mackay, December 2023
 AP_FLAKE8_CLEAN
 '''
 
-
+import wave
 try:
     import pyaudio  # install using, "sudo apt-get install python3-pyaudio"
-    import wave     # install with "pip3 install wave"
     from openai import OpenAI
 except Exception:
-    print("chat: failed to import pyaudio, wave or openai.  See https://ardupilot.org/mavproxy/docs/modules/chat.html")
+    print("chat: failed to import pyaudio or openai.  See https://ardupilot.org/mavproxy/docs/modules/chat.html")
     exit()
 
 # initializing the global list to keep and update the stop_recording state

--- a/windows/MAVProxyWinBuild.bat
+++ b/windows/MAVProxyWinBuild.bat
@@ -33,7 +33,7 @@ if exist "..\..\pymavlink" (
 rem -----Install additional Python packages-----
 python.exe -m pip install -U wheel setuptools pip
 python.exe -m pip install pywin32 lxml pymavlink numpy matplotlib pyserial opencv-python PyYAML Pygame Pillow wxpython prompt-toolkit scipy
-python.exe -m pip install -U openai wave pyaudio
+python.exe -m pip install -U openai pyaudio
 python.exe -m pip install -U pyinstaller==6.7.0 packaging 
 python.exe -m pip install -U requests
 


### PR DESCRIPTION
Installing the third-party ___Whole Architecture Verification___ module https://pypi.org/project/Wave is [breaking our builds](https://github.com/ArduPilot/MAVProxy/actions/workflows/windows_build.yml).

The Python Standard Library module  [`wave`](https://docs.python.org/3/library/wave.html) has an API that corresponds to:
https://github.com/ArduPilot/MAVProxy/blob/a45549f9bcb09603be1507c260de2bafe516212a/MAVProxy/modules/mavproxy_chat/chat_voice_to_text.py#L72-L78

Therefore, we should stop doing `pip install wave` and instead use the Standard Library.

The docs at https://ardupilot.org/mavproxy/docs/modules/chat.html#prerequisites must also be modified.
* ArduPilot/ardupilot_wiki#6947

@rmackay9 Your review, please.