### PR TITLE
Substitution of depracated numpy.fromstring call

### DIFF
--- a/MAVProxy/modules/mavproxy_map/mp_tile.py
+++ b/MAVProxy/modules/mavproxy_map/mp_tile.py
@@ -623,15 +623,16 @@ def mp_icon(filename):
         if name == "__main__":
             name = "MAVProxy.modules.mavproxy_map.mp_tile"
         stream = pkg_resources.resource_stream(name, "data/%s" % filename).read()
-        raw = np.fromstring(stream, dtype=np.uint8)
+        raw = np.frombuffer(stream, dtype=np.uint8)
     except Exception:
         try:
-            stream = open(os.path.join(os.path.dirname(__file__), 'data', filename)).read()
-            raw = np.fromstring(stream, dtype=np.uint8)
+            with open(os.path.join(os.path.dirname(__file__), 'data', filename), 'rb') as f:
+                raw = np.frombuffer(f.read(), dtype=np.uint8)
         except Exception:
             #we're in a Windows exe, where pkg_resources doesn't work
             import pkgutil
             raw = pkgutil.get_data( 'MAVProxy', 'modules//mavproxy_map//data//' + filename)
+            raw = np.frombuffer(raw, dtype=np.uint8)
     img = cv2.imdecode(raw, cv2.IMREAD_COLOR)
     return img
 


### PR DESCRIPTION
## The problem
After following the installation tutorial of ArduPilot's [Setting up the Build Environment (Linux/Ubuntu)](https://ardupilot.org/dev/docs/building-setup-linux.html) on Fedora 42 with an Ubuntu 24.04 distrobox with root and trying to run SITL with `sim_vehicle.py -v copter --console --map -w` as indicated on [Setting up SITL on Linux](https://ardupilot.org/dev/docs/setting-up-sitl-on-linux.html#start-sitl-simulator), I'm presented with the following error that stopped the map from opening:
```
Traceback (most recent call last):
  File "/usr/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/usr/lib/python3.12/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/home/nickyecen/venv-ardupilot/lib/python3.12/site-packages/MAVProxy/modules/mavproxy_map/mp_slipmap.py", line 87, in child_task
    self.mt = mp_tile.MPTile(download=self.download,
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nickyecen/venv-ardupilot/lib/python3.12/site-packages/MAVProxy/modules/mavproxy_map/mp_tile.py", line 213, in __init__
    self._loading = mp_icon('loading.jpg')
                    ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nickyecen/venv-ardupilot/lib/python3.12/site-packages/MAVProxy/modules/mavproxy_map/mp_tile.py", line 635, in mp_icon
    img = cv2.imdecode(raw, cv2.IMREAD_COLOR)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cv2.error: OpenCV(4.11.0) :-1: error: (-5:Bad argument) in function 'imdecode'
```
## The fix
The fix was changing the **deprecated** [numpy.fromstring](https://numpy.org/doc/stable/reference/generated/numpy.fromstring.html) call to [numpy.frombuffer](https://numpy.org/doc/stable/reference/generated/numpy.frombuffer.html). This fixed the issue and running the same command worked as intended.

## Notes
This was only tested on a Ubuntu 24.04 distrobox with root access running on Fedora 42 KDE, and should probably be more thoroughly tested before merge.