### PR TITLE
signing: support a $HOME/.mavproxy/signing.keys file

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -1473,6 +1473,11 @@ if __name__ == '__main__':
 
     mpstate.load_module('link', quiet=True)
 
+    # load signing early to allow for use of ~/.mavproxy/signing.keys
+    standard_modules = opts.default_modules.split(',')
+    if 'signing' in standard_modules:
+        mpstate.load_module('signing', quiet=True)
+
     mpstate.settings.source_system = opts.SOURCE_SYSTEM
     mpstate.settings.source_component = opts.SOURCE_COMPONENT
 
@@ -1544,7 +1549,6 @@ if __name__ == '__main__':
 
     if not opts.setup:
         # some core functionality is in modules
-        standard_modules = opts.default_modules.split(',')
         for m in standard_modules:
             if m:
                 mpstate.load_module(m, quiet=True)

--- a/MAVProxy/modules/mavproxy_link.py
+++ b/MAVProxy/modules/mavproxy_link.py
@@ -437,7 +437,7 @@ class LinkModule(mp_module.MPModule):
         # if we are using signing then sign the new link
         signing = self.mpstate.module('signing')
         if signing:
-            signing.setup_signing_link(conn)
+            signing.setup_signing_device(conn, device)
 
         self.mpstate.mav_master.append(conn)
         self.status.counters['MasterIn'].append(0)


### PR DESCRIPTION
allows for pre-setup signing keys for different MAVLink URIs

for example:
```
tcp:support.ardupilot.org:33271 MyPassPhrase
udpout:192.168.2.20 OtherPassPhase
```
