### PR TITLE
camera_projection.py: Fix undefined names 'json' and 'self'

### DIFF
--- a/MAVProxy/modules/lib/camera_projection.py
+++ b/MAVProxy/modules/lib/camera_projection.py
@@ -3,17 +3,19 @@
 class to project a camera view onto the map
 '''
 
+import json
+import math
+import time
+
 import numpy
 from numpy import array, eye, zeros, uint64
 from numpy import linalg, dot, transpose
 from numpy import sin, cos, pi
 from math import pi
-import math
 import cv2
 from MAVProxy.modules.lib import mp_elevation
 from pymavlink.rotmat import Vector3
 from MAVProxy.modules.lib import mp_util
-import time
 
 class CameraParams:
     '''
@@ -83,7 +85,7 @@ class CameraParams:
     @staticmethod
     def fromdict(data):
         if data['version'] != 0:
-            raise Exception('version %d of camera params unsupported' % (self.version))
+            raise Exception('version %d of camera params unsupported' % (data['version']))
         try:
             K = array(data['K'])
             D = array(data['D'])


### PR DESCRIPTION
flake8 rule F821 -- Undefined names have the potential to raise NameError at runtime.

`import json` needed for lines 64 and 106.
~`self` needed for line 87.~
Line 87 mistakenly used `self`.