### PR TITLE
optparse_gui: Keyword 'unicode' was removed in Python 3

### DIFF
--- a/MAVProxy/modules/lib/optparse_gui/__init__.py
+++ b/MAVProxy/modules/lib/optparse_gui/__init__.py
@@ -15,6 +15,11 @@ from MAVProxy.modules.lib import multiproc
 __version__ = 0.1
 __revision__ = '$Id$'
 
+try:
+    unicode  # Removed in Python 3
+except NameError:
+    unicode = str
+
 class OptparseDialog( wx.Dialog ):
     '''The dialog presented to the user with dynamically generated controls,
     to fill in the required options.


### PR DESCRIPTION
flake8 rule F821 -- Undefined names have the potential to raise NameError at runtime.

`unicode()` appears on line 90.