### PR TITLE
rline.py: Fix undefined name `redisplay`

### DIFF
--- a/MAVProxy/modules/lib/rline.py
+++ b/MAVProxy/modules/lib/rline.py
@@ -74,7 +74,7 @@ class rline(object):
         '''redisplay prompt'''
         try:
             redisplay()
-        except Exception as ex:
+        except (Exception, NameError) as ex:
             pass
             
     def get_prompt(self):


### PR DESCRIPTION
flake8 rule F821 -- Undefined names will be placated by a targeted NameError but not by a too broad Exception.