### PR TITLE
Add support for OpenTX and EdgeTX in Taranis config

### DIFF
--- a/MAVProxy/modules/mavproxy_joystick/joysticks/taranis.yml
+++ b/MAVProxy/modules/mavproxy_joystick/joysticks/taranis.yml
@@ -3,6 +3,9 @@ description: >
 
 match:
   - 'FrSky FrSky Taranis*'
+  - 'OpenTX FrSky Taranis*'
+  - 'EdgeTX FrSky Taranis*'
+  - 'FrSky Taranis*'
 
 controls:
   - channel: 1


### PR DESCRIPTION
Fix Taranis joystick detection in MAVProxy

Modern FrSky Taranis radios running OpenTX/EdgeTX identify as OpenTX FrSky Taranis… or EdgeTX FrSky Taranis…, but the existing taranis.yml only matches FrSky FrSky Taranis*. This causes MAVProxy to find the joystick but fail to load its config.

Personally tested with an OpenTX Taranis radio over USB, and the joystick module worked correctly after this change.