### PR TITLE
horizon: fix oversized text on HiDPI displays

### DIFF
--- a/MAVProxy/modules/lib/wxhorizon_ui.py
+++ b/MAVProxy/modules/lib/wxhorizon_ui.py
@@ -166,8 +166,10 @@ class HorizonFrame(wx.Frame):
         if not self.resized:
             oldypx = self.ypx
             oldxpx = self.xpx
-            self.ypx = self.figure.get_size_inches()[1]*self.figure.dpi
-            self.xpx = self.figure.get_size_inches()[0]*self.figure.dpi
+            # use fixed DPI to match calcFontScaling()
+            dpi = 100.0
+            self.ypx = self.figure.get_size_inches()[1]*dpi
+            self.xpx = self.figure.get_size_inches()[0]*dpi
             if (oldypx != self.ypx) or (oldxpx != self.xpx):
                 self.resized = True
             else:


### PR DESCRIPTION
**PR Description:**
Recent matplotlib versions (3.5+) report the actual display DPI on HiDPI/Retina screens. The font scaling in calcFontScaling() multiplies by figure.dpi, which now returns ~200 on Retina displays instead of the expected 100, causing all text to render at 2x size.

Fix by using a fixed reference DPI of 100 for the font calculations.

**How Tested:**
- macOS 14.x with Retina display
- matplotlib 3.10.7
- Verified text renders at expected size before/after fix
- Confirmed window resizing still works correctly