### PR TITLE
Fix typo: recieved -> received in swarm module

### DIFF
--- a/MAVProxy/modules/mavproxy_swarm.py
+++ b/MAVProxy/modules/mavproxy_swarm.py
@@ -383,7 +383,7 @@ class VehiclePanel(wx.Panel):
                     ("GUIDED", sysidFollow, compidFollow))
 
     def addstatustext(self, text):
-        '''have recieved statustext, update relevant control'''
+        '''have received statustext, update relevant control'''
         self.statusText.AppendText('\n' + text)
 
     def guidedTakeoff(self, event):


### PR DESCRIPTION
Fixed a spelling error in mavproxy_swarm.py where 'recieved'