### PR TITLE
Added future to dependencies to fix issues with pipx install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pymavlink>=2.4.14
 pyserial>=3.0
 numpy
+future

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ package_data.extend(package_files('MAVProxy/modules/mavproxy_cesium/app'))
 requirements=['pymavlink>=2.4.14',
               'pyserial>=3.0',
               'numpy',
-              'pynmeagps']
+              'pynmeagps',
+              'future']
 
 if platform.system() == "Darwin":
     # on MacOS we can have a more complete requirements list


### PR DESCRIPTION
Have had issues installing mavproxy via pipx, citing that future not being present as the issue. From my understanding adding it as a requirement should fix this issue and allow mavproxy to be installed easily using pipx.
 