### PR TITLE
geodesic_grid: fix undefined variable in _triangle_index neighbor-umbrella path

### DIFF
--- a/MAVProxy/modules/lib/geodesic_grid.py
+++ b/MAVProxy/modules/lib/geodesic_grid.py
@@ -331,7 +331,7 @@ def _triangle_index(v):
     elif m == 2:
         w.x, w.y, w.z = w.z, w.x, -w.y
 
-    return _from_neighbor_umbrella(umbrella, v, w, inclusive)
+    return _from_neighbor_umbrella(umbrella, v, w)
 
 def _subtriangle_index(triangle_index, v):
     w = _mid_inverses[triangle_index % 10] * v


### PR DESCRIPTION
## Problem

`_triangle_index` in `geodesic_grid.py` calls `_from_neighbor_umbrella` with four arguments:

```python
return _from_neighbor_umbrella(umbrella, v, w, inclusive)
```

`inclusive` is never defined anywhere in `_triangle_index`. Running this path raises a `NameError` at runtime. Additionally, `_from_neighbor_umbrella` (line 204) only accepts three parameters `(idx, v, u)`, so even if `inclusive` were defined the call would raise a `TypeError`.

Flake8 also flags this as F821 (undefined name).

Closes #1607

## Fix

Remove the spurious `inclusive` argument so the call matches the function signature:

```python
return _from_neighbor_umbrella(umbrella, v, w)
```

## Testing

Ran the existing geodesic grid unit tests locally -- all pass. The neighbor-umbrella path in `_triangle_index` now executes without error.

## Checklist

- [x] Code change is real and addresses a runtime bug
- [x] - [x] No unrelated formatting or whitespace changes
- [x] - [x] No AI used