### PR TITLE
CI: Update inno setup URL for Windows build

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -28,7 +28,7 @@ jobs:
           python3 -m pip install -U openai pyaudio
           python3 -m pip install -U pyinstaller==6.7.0 packaging 
       - name: Download Inno Setup installer
-        run: curl -L -o installer.exe http://files.jrsoftware.org/is/6/innosetup-6.3.1.exe
+        run: curl -L -o installer.exe https://github.com/jrsoftware/issrc/releases/download/is-6_7_1/innosetup-6.7.1.exe
       - name: Install Inno Setup
         run: ./installer.exe /verysilent /allusers /dir=inst
       - name: Build MAVProxy


### PR DESCRIPTION
The URL for the Inno setup utility changed, so am updating.