### PR TITLE
Ntrip: Fix SSL connection exception

### DIFF
--- a/MAVProxy/modules/lib/ntrip.py
+++ b/MAVProxy/modules/lib/ntrip.py
@@ -219,7 +219,8 @@ class NtripClient(object):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.setblocking(0)
         if self.ssl:
-            sock = ssl.wrap_socket(sock)
+            context = ssl.create_default_context()
+            sock = context.wrap_socket(sock, server_hostname=self.caster)
         try:
             if self.caster_ip is None:
                 try:


### PR DESCRIPTION
The NTRIP module currently fails for SSL connections. Fixed by added a ``ssl.create_default_context()``

Tested with ``ntrip.data.gnss.ga.gov.au:443``