### PR TITLE
misseditor: use pymavlink param labels for column headings

### DIFF
--- a/MAVProxy/modules/mavproxy_misseditor/me_defines.py
+++ b/MAVProxy/modules/mavproxy_misseditor/me_defines.py
@@ -63,6 +63,13 @@ def get_column_labels(command_name):
         return {}
     labels = {}
     enum = mavutil.mavlink.enums['MAV_CMD'][cmd]
+    # pymavlink >= label-emitting versions expose enum.label[i]; older
+    # installs lack it, so fall back to the description-based heuristic
+    enum_labels = getattr(enum, 'label', {})
     for col in enum.param.keys():
-        labels[col] = make_column_label(command_name, enum.param[col], "P%u" % col)
+        if col in enum_labels:
+            labels[col] = enum_labels[col]
+        else:
+            labels[col] = make_column_label(
+                command_name, enum.param[col], "P%u" % col)
     return labels


### PR DESCRIPTION
When pymavlink exposes <param label="..."> via enum.label[i] (newly emitted by mavgen_python), prefer that label as the mission-grid column heading. This finally gives MAV_CMD_DO_SET_CAM_TRIGG_DIST param 1 the proper "Distance" heading (and ~550 other params across all dialects).

Older pymavlink installs without enum.label keep working: a getattr fallback drops back to the existing description_map fnmatch heuristic.

needs https://github.com/ArduPilot/pymavlink/pull/1209
