### PR TITLE
mavproxy_adsb: don't render real ADSB aircraft as the OBC flag icon

### DIFF
--- a/MAVProxy/modules/mavproxy_adsb.py
+++ b/MAVProxy/modules/mavproxy_adsb.py
@@ -239,7 +239,17 @@ class ADSBModule(mp_module.MPModule):
         altitude_km = state['altitude']
         callsign = state['callsign']
         heading = state['heading']
-        emitter_type = get_internal_emitter(state['ICAO_address'])
+        # OBC test framework reserves specific ICAO bands for synthetic
+        # obstacles (drones/aircraft/birds/clouds) and maps them to
+        # internal emitter types via get_internal_emitter(); for real
+        # ADSB addresses (0x004000..0x9FFFFF) trust the supplied
+        # emitter_type so we don't render every live aircraft as the
+        # placeholder "flag" icon.
+        icao = state['ICAO_address']
+        if icao <= 0x003FFF or icao >= 0xA00000:
+            emitter_type = get_internal_emitter(icao)
+        else:
+            emitter_type = state.get('emitter_type', 0) or 0
         squawk = state['squawk']
 
         if id not in self.threat_vehicles.keys():  # check to see if the vehicle is in the dict


### PR DESCRIPTION
add_vehicle() was deriving emitter_type purely from get_internal_emitter(state['ICAO_address']), which is an OBC test helper: it maps a handful of synthetic ICAO bands (drones, weather, birds, OBC aircraft) to specific internal types and falls through to 99 ('flag.png', commented "dummy it for now") for everything else.

Real-world ADSB feeds supply genuine 24-bit ICAOs in the 0x004000..0x9FFFFF range, so every live aircraft was being shown as the flag placeholder instead of a plane.

Only consult get_internal_emitter() for ICAOs inside the OBC bands (<=0x003FFF or >=0xA00000); for everything else trust the supplied state['emitter_type'] so live ADSB data displays with its proper ADSB_EMITTER_TYPE icon.