### PR TITLE
mission_item_protocol: guard against no master when running commands

### DIFF
--- a/MAVProxy/modules/lib/mission_item_protocol.py
+++ b/MAVProxy/modules/lib/mission_item_protocol.py
@@ -925,6 +925,10 @@ on'''
             print(self.usage())
             return
 
+        if self.master is None:
+            print("%s: no vehicle connected" % self.command_name())
+            return
+
         commands = self.commands()
         if args[0] not in commands:
             print(self.usage())
@@ -992,11 +996,17 @@ on'''
 
     def fetch(self):
         """Download wpts from vehicle (this operation is public to support other modules)"""
+        if self.master is None:
+            print("%s: no vehicle connected" % self.command_name())
+            return
         if self.wp_op is None:  # If we were already doing a list or save, just restart the fetch without changing the operation  # noqa
             self.wp_op = "fetch"
         self.request_list_send()
 
     def request_list_send(self):
+        if self.master is None:
+            print("%s: no vehicle connected" % self.command_name())
+            return
         self.master.mav.mission_request_list_send(
             self.target_system,
             self.target_component,


### PR DESCRIPTION
Fixes #1678

Running `wp list`, `fence list`, or any other subcommand from these modules before a vehicle is connected hits an unguarded `self.master.mav.mission_request_list_send(...)` in `request_list_send()` and crashes with `AttributeError: 'NoneType' object has no attribute 'mav'`.

### Fix

- **`cmd_wp`** — added an early `if self.master is None` guard at the single entry point that dispatches every subcommand (`list`, `clear`, `load`, `save`, `move`, `movemulti`, `changealt`, `changeframe`, `remove`, `update`, `param`, `status`, `ftp`, `ftpload`, …). This protects every `self.master.mav.*` callsite inside the helper methods those subcommands reach (e.g. `cmd_clear` -> mission_clear_all_send, `cmd_load` -> send_all_items, `cmd_move`/`cmd_movemulti` -> send_single_waypoint, `change_mission_item_range` from changealt/changeframe, `update_waypoints` from cmd_update).
- **`fetch()`** — guarded too, since the docstring marks it as public for other modules to call.
- **`request_list_send()`** — guarded as defense-in-depth (this is the exact frame in the traceback).

Message style and `if self.master is None: print(...); return` pattern match `mavproxy_mode.py` / `mavproxy_ftp.py`.

### Audit notes

Other `self.master.mav.*` references in this class (lines 437, 467, 515, 591, 683, 721, 842) live in internal helpers (`send_single_waypoint`, `send_all_items`, `update_waypoints`, `change_mission_item_range`, `cmd_clear`, etc.) that are only reachable via `cmd_wp` or `fetch()`, so the entry-level guards cover them without adding redundant checks. `idle_task` already guards (line 305). `commands()` at line 901 uses a truthy check so `self.master is None` falls through harmlessly.

### Test

flake8 clean (`AP_FLAKE8_CLEAN` honored). With the patch, `mavproxy.py --map` followed by `wp list` / `fence list` / `rally list` prints `wp: no vehicle connected` (etc.) and returns instead of tracing back.