### PR TITLE
mavproxy_battery: consume BATTERY_STATUS.voltages_ext to calculate total voltage

### DIFF
--- a/MAVProxy/modules/mavproxy_battery.py
+++ b/MAVProxy/modules/mavproxy_battery.py
@@ -125,6 +125,9 @@ class BatteryModule(mp_module.MPModule):
         for vraw in BATTERY_STATUS.voltages:
             if vraw != 65535:
                 self.voltage_level[id] += vraw * 0.001
+        for vraw in BATTERY_STATUS.voltages_ext:
+            if vraw != 0:
+                self.voltage_level[id] += vraw * 0.001
         self.current_battery[id] = BATTERY_STATUS.current_battery*0.01
         if self.numcells(id) > 0:
             self.per_cell[id] = self.voltage_level[id] / self.numcells(id)


### PR DESCRIPTION
When i connected my flashy 14s smart battery I've seen this in MAVProxy:
<img width="1320" height="700" alt="Screenshot 2026-05-19 at 11 25 15" src="https://github.com/user-attachments/assets/06736146-3b6c-43a8-b60e-ba6917f23798" />
42.3 / 14 = 3 V per cell, very bad, I thought the battery was already damaged lol.

The real reason is that mavproxy doesn't consume the `voltages_ext` in `BATTERY_STATUS` message, so it sums only the first 10 cells to calculate total voltage.
```
BATTERY_STATUS {id : 0, battery_function : 0, type : 0, temperature : 2810, voltages : [4230, 4230, 4238, 4242, 4234, 4226, 4226, 4234, 4226, 4226], current_battery : -19, current_consumed : 752, energy_consumed : 1440, battery_remaining : 97, time_remaining : 0, charge_state : 1, voltages_ext : [4230, 4234, 4226, 4234], mode : 0, fault_bitmask : 0}
```

With this PR the voltage is calculated properly:
<img width="1294" height="648" alt="Screenshot 2026-05-19 at 11 18 41" src="https://github.com/user-attachments/assets/6d0cc570-c480-4bd9-a749-ec49ed5509f1" />
