### PR TITLE
map3d: native 3D terrain map module

### DIFF
--- a/MAVProxy/modules/mavproxy_kmlread.py
+++ b/MAVProxy/modules/mavproxy_kmlread.py
@@ -44,6 +44,7 @@ class KmlReadModule(mp_module.MPModule):
         self.menu_needs_refreshing = True
         self.map_objects = {}
         self.counter = 0
+        self.last_change = 0
 
         # the fence manager
         self.snap_points = []
@@ -217,7 +218,8 @@ class KmlReadModule(mp_module.MPModule):
         del self.map_objects[obj.layer][obj.key]
         if len(self.map_objects[obj.layer]) == 0:
             del self.map_objects[obj.layer]
-        self.remove_object_from_maps(obj.key)
+        self.last_change += 1
+        self.remove_object_from_maps(obj)
 
     def remove_all_map_objects(self):
         for layer in copy.deepcopy(self.map_objects):
@@ -233,6 +235,7 @@ class KmlReadModule(mp_module.MPModule):
         if obj.layer not in self.map_objects:
             self.map_objects[obj.layer] = {}
         self.map_objects[obj.layer][obj.key] = obj
+        self.last_change += 1
         self.add_object_to_maps(obj)
 
     def add_objects_to_map_module_from_map_objects(self):

--- a/MAVProxy/modules/mavproxy_map3d/__init__.py
+++ b/MAVProxy/modules/mavproxy_map3d/__init__.py
@@ -1,0 +1,183 @@
+'''
+3D map module: draped satellite imagery over ArduPilot quantized-mesh terrain,
+rendered natively with VTK. Shows the same elements as the 2D map (flight path,
+mission, fence, rally, vehicle) for both live telemetry and log review.
+
+Andrew Tridgell / CanberraUAV
+'''
+
+import time
+
+from MAVProxy.modules.lib import mp_module
+from MAVProxy.modules.lib import mp_settings
+from MAVProxy.modules.mavproxy_map3d.map3d import Map3D
+
+
+class Map3DModule(mp_module.MPModule):
+    def __init__(self, mpstate):
+        super(Map3DModule, self).__init__(mpstate, "map3d", "3D map display", public=True)
+        self.map3d_settings = mp_settings.MPSettings([
+            ('service', str, 'MicrosoftSat'),
+            ('zexag', float, 1.0),
+            ('debug', bool, False),
+        ])
+        self.add_command('map3d', self.cmd_map3d,
+                         "3D map control", ['<start|stop|follow|nofollow|center>',
+                                            'set (MAP3DSETTING)'])
+        self.map = None
+        self.wp_change_time = 0
+        self.fence_change_time = 0
+        self.rally_change_time = 0
+        self.last_vehicle_send = 0
+        self.last_attitude = (0.0, 0.0, 0.0)
+
+    # ------------------------------------------------------------------ command
+    def cmd_map3d(self, args):
+        if len(args) == 0:
+            print("usage: map3d <start|stop|follow|nofollow|center|set>")
+            return
+        cmd = args[0]
+        if cmd == "start":
+            self.start_map()
+        elif cmd == "stop":
+            self.stop_map()
+        elif cmd == "follow":
+            if self.map:
+                self.map.set_follow(True)
+        elif cmd == "nofollow":
+            if self.map:
+                self.map.set_follow(False)
+        elif cmd == "center":
+            if self.map:
+                self.map.center_on_vehicle()
+        elif cmd == "set":
+            self.map3d_settings.command(args[1:])
+        else:
+            print("unknown map3d command: %s" % cmd)
+
+    def start_map(self):
+        if self.map is not None and self.map.is_alive():
+            print("map3d already running")
+            return
+        self.map = Map3D(title="MAVProxy 3D Map",
+                         service=self.map3d_settings.service,
+                         zexag=self.map3d_settings.zexag,
+                         debug=self.map3d_settings.debug)
+        # push whatever we already know
+        self.send_mission()
+        self.send_fence()
+        self.send_rally()
+
+    def stop_map(self):
+        if self.map is not None:
+            self.map.close()
+            self.map = None
+
+    # --------------------------------------------------------------- data feeds
+    def terrain_alt(self, lat, lon):
+        '''terrain elevation (m AMSL) at lat/lon. Prefer the quantized mesh (same
+        source rendered in 3D); fall back to the terrain module's SRTM model.'''
+        try:
+            from MAVProxy.modules.mavproxy_map3d.terrain import sample_terrain
+            alt = sample_terrain(lat, lon)
+            if alt is not None:
+                return alt
+        except Exception:
+            pass
+        tm = self.module('terrain')
+        if tm is not None and getattr(tm, 'ElevationModel', None) is not None:
+            return tm.ElevationModel.GetElevation(lat, lon)
+        return None
+
+    def send_mission(self):
+        try:
+            wploader = self.module('wp').wploader
+        except Exception:
+            return
+        items = []
+        for w in wploader.wpoints:
+            frame = getattr(w, 'frame', 0)
+            if w.x == 0 and w.y == 0 and w.command not in (16, 22, 82):
+                continue
+            z = w.z
+            if frame in (10, 11):    # terrain-relative -> resolve to AMSL
+                terr = self.terrain_alt(w.x, w.y)
+                if terr is not None:
+                    z = terr + w.z
+                    frame = 0
+            items.append((w.x, w.y, z, frame, w.command, w.seq))
+        self.map.set_mission(items)
+
+    def send_fence(self):
+        try:
+            fence_mod = self.module('fence')
+            pts = [(p.x, p.y) for p in fence_mod.wploader.wpoints]
+        except Exception:
+            return
+        self.map.set_fence(pts)
+
+    def send_rally(self):
+        try:
+            rally_mod = self.module('rally')
+            pts = []
+            for i in range(rally_mod.rallyloader.rally_count()):
+                r = rally_mod.rallyloader.rally_point(i)
+                pts.append((r.lat * 1.0e-7, r.lng * 1.0e-7, r.alt))
+        except Exception:
+            return
+        self.map.set_rally(pts)
+
+    def idle_task(self):
+        if self.map is None:
+            return
+        if not self.map.is_alive():
+            self.map = None
+            return
+        # poll change times like the 2D map / cesium modules
+        try:
+            wp_change = self.module('wp').wploader.last_change
+            if wp_change != self.wp_change_time:
+                self.wp_change_time = wp_change
+                self.send_mission()
+        except Exception:
+            pass
+        try:
+            fence_change = self.module('fence').wploader.last_change
+            if fence_change != self.fence_change_time:
+                self.fence_change_time = fence_change
+                self.send_fence()
+        except Exception:
+            pass
+
+    def mavlink_packet(self, m):
+        if self.map is None or not self.map.is_alive():
+            return
+        mtype = m.get_type()
+        if mtype == 'HOME_POSITION':
+            self.map.set_home(m.altitude * 1.0e-3)   # AMSL (mm -> m)
+        elif mtype == 'ATTITUDE':
+            self.last_attitude = (m.roll, m.pitch, m.yaw)
+        elif mtype == 'GLOBAL_POSITION_INT':
+            now = time.time()
+            if now - self.last_vehicle_send < 0.1:
+                return
+            self.last_vehicle_send = now
+            lat = m.lat * 1.0e-7
+            lon = m.lon * 1.0e-7
+            alt = m.alt * 1.0e-3            # AMSL (mm -> m)
+            rel = m.relative_alt * 1.0e-3   # above home
+            if not self.map.origin_set():
+                self.map.set_origin(lat, lon, alt)
+                self.map.set_home(alt - rel)   # home AMSL = current AMSL - relative
+                self.send_mission()
+                self.send_fence()
+                self.send_rally()
+            (roll, pitch, yaw) = self.last_attitude
+            self.map.set_vehicle(lat, lon, alt, roll, pitch, yaw)
+
+    def unload(self):
+        self.stop_map()
+
+
+def init(mpstate):
+    return Map3DModule(mpstate)

--- a/MAVProxy/modules/mavproxy_map3d/__init__.py
+++ b/MAVProxy/modules/mavproxy_map3d/__init__.py
@@ -6,6 +6,7 @@ mission, fence, rally, vehicle) for both live telemetry and log review.
 Andrew Tridgell / CanberraUAV
 '''
 
+import math
 import time
 
 from MAVProxy.modules.lib import mp_module
@@ -15,21 +16,36 @@ from MAVProxy.modules.mavproxy_map3d.map3d import Map3D
 
 class Map3DModule(mp_module.MPModule):
     def __init__(self, mpstate):
-        super(Map3DModule, self).__init__(mpstate, "map3d", "3D map display", public=True)
+        # Do not register as a public "map*" module. ADS-B, AIS, KML and other
+        # modules use that wildcard for the 2D SlipMap API (add_object,
+        # remove_object, set_position), which Map3D intentionally does not
+        # implement.
+        super(Map3DModule, self).__init__(mpstate, "map3d", "3D map display")
         self.map3d_settings = mp_settings.MPSettings([
             ('service', str, 'MicrosoftSat'),
             ('zexag', float, 1.0),
             ('debug', bool, False),
+            mp_settings.MPSetting('fpvfov', float, 90.0, range=(20.0, 150.0)),
+            mp_settings.MPSetting('terrainbrightness', float, 1.25,
+                                  range=(0.25, 2.0)),
+            ('terrainshading', bool, True),
+            ('terrainwireframe', bool, False),
         ])
         self.add_command('map3d', self.cmd_map3d,
                          "3D map control", ['<start|stop|follow|nofollow|center>',
                                             'set (MAP3DSETTING)'])
+        self.add_completion_function('(MAP3DSETTING)',
+                                     self.map3d_settings.completion)
         self.map = None
         self.wp_change_time = 0
         self.fence_change_time = 0
         self.rally_change_time = 0
         self.last_vehicle_send = 0
+        self.last_global_position = 0
         self.last_attitude = (0.0, 0.0, 0.0)
+        self.home_amsl = None
+        self.follow = True
+        self.start_map()
 
     # ------------------------------------------------------------------ command
     def cmd_map3d(self, args):
@@ -42,9 +58,11 @@ class Map3DModule(mp_module.MPModule):
         elif cmd == "stop":
             self.stop_map()
         elif cmd == "follow":
+            self.follow = True
             if self.map:
                 self.map.set_follow(True)
         elif cmd == "nofollow":
+            self.follow = False
             if self.map:
                 self.map.set_follow(False)
         elif cmd == "center":
@@ -52,6 +70,12 @@ class Map3DModule(mp_module.MPModule):
                 self.map.center_on_vehicle()
         elif cmd == "set":
             self.map3d_settings.command(args[1:])
+            if self.map is not None and self.map.is_alive():
+                self.map.set_fpv_fov(self.map3d_settings.fpvfov)
+                self.map.set_render_settings(
+                    self.map3d_settings.terrainbrightness,
+                    self.map3d_settings.terrainshading,
+                    self.map3d_settings.terrainwireframe)
         else:
             print("unknown map3d command: %s" % cmd)
 
@@ -62,11 +86,17 @@ class Map3DModule(mp_module.MPModule):
         self.map = Map3D(title="MAVProxy 3D Map",
                          service=self.map3d_settings.service,
                          zexag=self.map3d_settings.zexag,
-                         debug=self.map3d_settings.debug)
+                         debug=self.map3d_settings.debug,
+                         fpvfov=self.map3d_settings.fpvfov,
+                         terrain_brightness=self.map3d_settings.terrainbrightness,
+                         terrain_shading=self.map3d_settings.terrainshading,
+                         terrain_wireframe=self.map3d_settings.terrainwireframe,
+                         follow=self.follow)
         # push whatever we already know
         self.send_mission()
         self.send_fence()
         self.send_rally()
+        self.send_cached_state()
 
     def stop_map(self):
         if self.map is not None:
@@ -74,6 +104,60 @@ class Map3DModule(mp_module.MPModule):
             self.map = None
 
     # --------------------------------------------------------------- data feeds
+    def send_cached_state(self):
+        '''Seed an auto-started map from MAVProxy's latest known state.'''
+        try:
+            messages = self.master.messages
+        except Exception:
+            return
+
+        attitude = messages.get('ATTITUDE')
+        if attitude is not None:
+            self.last_attitude = (attitude.roll, attitude.pitch, attitude.yaw)
+        else:
+            # DataFlash ATT angles are in degrees.
+            attitude = messages.get('ATT')
+            if attitude is not None:
+                self.last_attitude = tuple(math.radians(v) for v in
+                                           (attitude.Roll, attitude.Pitch,
+                                            attitude.Yaw))
+
+        home = messages.get('HOME_POSITION')
+        if home is not None:
+            self.home_amsl = home.altitude * 1.0e-3
+
+        # Prefer the estimator position, then DataFlash POS, then raw GPS.
+        position = (messages.get('GLOBAL_POSITION_INT') or
+                    messages.get('POS') or
+                    messages.get('GPS_RAW_INT'))
+        if position is not None:
+            self.mavlink_packet(position, force=True)
+
+    def send_vehicle_position(self, lat, lon, alt, home_amsl=None,
+                              attitude=None, force=False):
+        if lat == 0 and lon == 0:
+            return
+        now = time.time()
+        if not force and now - self.last_vehicle_send < 0.1:
+            return
+        self.last_vehicle_send = now
+
+        if not self.map.origin_set():
+            self.map.set_origin(lat, lon, alt)
+            if home_amsl is None:
+                home_amsl = self.home_amsl
+            if home_amsl is None:
+                home_amsl = alt
+            self.home_amsl = home_amsl
+            self.map.set_home(home_amsl)
+            self.send_mission()
+            self.send_fence()
+            self.send_rally()
+
+        if attitude is None:
+            attitude = self.last_attitude
+        self.map.set_vehicle(lat, lon, alt, *attitude)
+
     def terrain_alt(self, lat, lon):
         '''terrain elevation (m AMSL) at lat/lon. Prefer the quantized mesh (same
         source rendered in 3D); fall back to the terrain module's SRTM model.'''
@@ -133,6 +217,15 @@ class Map3DModule(mp_module.MPModule):
         if not self.map.is_alive():
             self.map = None
             return
+        for event in self.map.check_events():
+            if event[0] == 'render_settings':
+                (_, brightness, shading, wireframe, fpvfov) = event
+                self.map3d_settings.terrainbrightness = brightness
+                self.map3d_settings.terrainshading = shading
+                self.map3d_settings.terrainwireframe = wireframe
+                self.map3d_settings.fpvfov = fpvfov
+            elif event[0] == 'follow':
+                self.follow = bool(event[1])
         # poll change times like the 2D map / cesium modules
         try:
             wp_change = self.module('wp').wploader.last_change
@@ -149,31 +242,46 @@ class Map3DModule(mp_module.MPModule):
         except Exception:
             pass
 
-    def mavlink_packet(self, m):
+    def mavlink_packet(self, m, force=False):
         if self.map is None or not self.map.is_alive():
             return
         mtype = m.get_type()
         if mtype == 'HOME_POSITION':
-            self.map.set_home(m.altitude * 1.0e-3)   # AMSL (mm -> m)
+            self.home_amsl = m.altitude * 1.0e-3     # AMSL (mm -> m)
+            self.map.set_home(self.home_amsl)
         elif mtype == 'ATTITUDE':
             self.last_attitude = (m.roll, m.pitch, m.yaw)
+        elif mtype == 'ATT':
+            # ArduPilot DataFlash attitude is recorded in degrees.
+            self.last_attitude = tuple(math.radians(v) for v in
+                                       (m.Roll, m.Pitch, m.Yaw))
         elif mtype == 'GLOBAL_POSITION_INT':
-            now = time.time()
-            if now - self.last_vehicle_send < 0.1:
-                return
-            self.last_vehicle_send = now
+            self.last_global_position = time.time()
             lat = m.lat * 1.0e-7
             lon = m.lon * 1.0e-7
             alt = m.alt * 1.0e-3            # AMSL (mm -> m)
             rel = m.relative_alt * 1.0e-3   # above home
-            if not self.map.origin_set():
-                self.map.set_origin(lat, lon, alt)
-                self.map.set_home(alt - rel)   # home AMSL = current AMSL - relative
-                self.send_mission()
-                self.send_fence()
-                self.send_rally()
-            (roll, pitch, yaw) = self.last_attitude
-            self.map.set_vehicle(lat, lon, alt, roll, pitch, yaw)
+            self.send_vehicle_position(lat, lon, alt, alt - rel, force=force)
+        elif mtype == 'POS':
+            # DataFlash log playback does not contain GLOBAL_POSITION_INT.
+            if not force and time.time() - self.last_global_position < 1.0:
+                return
+            rel = getattr(m, 'RelHomeAlt', 0.0)
+            self.send_vehicle_position(m.Lat, m.Lng, m.Alt, m.Alt - rel,
+                                       force=force)
+        elif mtype == 'GPS_RAW_INT':
+            # Raw GPS is a live fallback until estimator position is available.
+            if not force and time.time() - self.last_global_position < 1.0:
+                return
+            if getattr(m, 'fix_type', 0) < 2:
+                return
+            lat = m.lat * 1.0e-7
+            lon = m.lon * 1.0e-7
+            alt = m.alt * 1.0e-3
+            yaw = math.radians(m.cog * 0.01)
+            attitude = (self.last_attitude[0], self.last_attitude[1], yaw)
+            self.send_vehicle_position(lat, lon, alt, attitude=attitude,
+                                       force=force)
 
     def unload(self):
         self.stop_map()

--- a/MAVProxy/modules/mavproxy_map3d/__init__.py
+++ b/MAVProxy/modules/mavproxy_map3d/__init__.py
@@ -7,11 +7,28 @@ Andrew Tridgell / CanberraUAV
 '''
 
 import math
+import queue
+import threading
 import time
 
 from MAVProxy.modules.lib import mp_module
 from MAVProxy.modules.lib import mp_settings
 from MAVProxy.modules.mavproxy_map3d.map3d import Map3D
+
+# fence colours as the 2D map's PolyFence layer uses them (OpenCV BGR)
+FENCE_INCLUSION_BGR = (0, 255, 0)
+FENCE_HOME_INCLUSION_BGR = (0, 255, 96)
+FENCE_EXCLUSION_BGR = (255, 0, 0)
+FENCE_RETURN_BGR = (255, 127, 127)
+FENCE_RETURN_RADIUS = 10.0
+
+
+def bgr_to_rgb(bgr, default=(1.0, 0.0, 1.0)):
+    '''SlipMap/OpenCV colours are BGR; VTK wants RGB floats'''
+    try:
+        return tuple(max(0, min(255, int(bgr[i]))) / 255.0 for i in (2, 1, 0))
+    except (IndexError, TypeError, ValueError):
+        return default
 
 
 class Map3DModule(mp_module.MPModule):
@@ -44,8 +61,14 @@ class Map3DModule(mp_module.MPModule):
         self.last_global_position = 0
         self.last_attitude = (0.0, 0.0, 0.0)
         self.home_amsl = None
+        self.home_position = None
         self.follow = True
         self.kml_change_state = None
+        self.terrain_lock = threading.Lock()
+        self.terrain_lookups = queue.Queue()
+        self.terrain_requested = set()
+        self.terrain_running = False
+        self.terrain_resolved = False
         self.start_map()
 
     # ------------------------------------------------------------------ command
@@ -127,6 +150,8 @@ class Map3DModule(mp_module.MPModule):
         home = messages.get('HOME_POSITION')
         if home is not None:
             self.home_amsl = home.altitude * 1.0e-3
+            self.set_home_position(home.latitude * 1.0e-7,
+                                   home.longitude * 1.0e-7)
 
         # Prefer the estimator position, then DataFlash POS, then raw GPS.
         position = (messages.get('GLOBAL_POSITION_INT') or
@@ -162,18 +187,57 @@ class Map3DModule(mp_module.MPModule):
 
     def terrain_alt(self, lat, lon):
         '''terrain elevation (m AMSL) at lat/lon. Prefer the quantized mesh (same
-        source rendered in 3D); fall back to the terrain module's SRTM model.'''
+        source rendered in 3D); fall back to the terrain module's SRTM model.
+
+        This runs on the main loop, so it never fetches: an uncached mesh tile is
+        handed to a background thread and the mission is re-sent once it lands.
+        The SRTM fallback is already non-blocking (timeout=0 returns None until
+        the terrain module has downloaded the tile).
+        '''
         try:
             from MAVProxy.modules.mavproxy_map3d.terrain import sample_terrain
-            alt = sample_terrain(lat, lon)
+            alt = sample_terrain(lat, lon, cache_only=True)
             if alt is not None:
                 return alt
+            self.request_terrain_lookup(lat, lon)
         except Exception:
             pass
         tm = self.module('terrain')
         if tm is not None and getattr(tm, 'ElevationModel', None) is not None:
             return tm.ElevationModel.GetElevation(lat, lon)
         return None
+
+    def request_terrain_lookup(self, lat, lon):
+        '''queue an uncached terrain sample for the background resolver'''
+        with self.terrain_lock:
+            if (lat, lon) in self.terrain_requested:
+                return
+            self.terrain_requested.add((lat, lon))
+            self.terrain_lookups.put((lat, lon))
+            if self.terrain_running:
+                return
+            self.terrain_running = True
+        threading.Thread(target=self.terrain_resolver, daemon=True).start()
+
+    def terrain_resolver(self):
+        '''background: fetch/decode mesh tiles so the main loop never blocks'''
+        from MAVProxy.modules.mavproxy_map3d.terrain import sample_terrain
+        while True:
+            with self.terrain_lock:
+                try:
+                    (lat, lon) = self.terrain_lookups.get_nowait()
+                except queue.Empty:
+                    self.terrain_running = False
+                    return
+            try:
+                resolved = sample_terrain(lat, lon) is not None
+            except Exception:
+                resolved = False
+            if resolved:
+                # terrain is reachable, so let points that failed earlier retry
+                with self.terrain_lock:
+                    self.terrain_requested.clear()
+                self.terrain_resolved = True
 
     def send_mission(self):
         try:
@@ -194,13 +258,64 @@ class Map3DModule(mp_module.MPModule):
             items.append((w.x, w.y, z, frame, w.command, w.seq))
         self.map.set_mission(items)
 
+    def set_home_position(self, lat, lon):
+        '''home moved: around-home fence circles are centred on it'''
+        if (lat, lon) == self.home_position:
+            return
+        self.home_position = (lat, lon)
+        self.send_fence()
+
+    @staticmethod
+    def _fence_latlon(item):
+        '''fence items are MISSION_ITEM_INT (1e7 scaled); MISSION_ITEM is degrees'''
+        (lat, lon) = (item.x, item.y)
+        if item.get_type() == 'MISSION_ITEM_INT':
+            lat *= 1.0e-7
+            lon *= 1.0e-7
+        return (lat, lon)
+
     def send_fence(self):
+        '''Mirror the 2D map's PolyFence layer: each inclusion/exclusion polygon
+        and circle is its own shape, not one flattened ring.'''
+        if self.map is None:
+            return
+        fence_mod = self.module('fence')
+        if fence_mod is None:
+            return
+        shapes = []
         try:
-            fence_mod = self.module('fence')
-            pts = [(p.x, p.y) for p in fence_mod.wploader.wpoints]
+            for (polygons, bgr) in ((fence_mod.inclusion_polygons(),
+                                     FENCE_INCLUSION_BGR),
+                                    (fence_mod.exclusion_polygons(),
+                                     FENCE_EXCLUSION_BGR)):
+                for polygon in polygons:
+                    points = [self._fence_latlon(p) for p in polygon]
+                    if len(points) >= 2:
+                        shapes.append(('polygon', points, bgr_to_rgb(bgr)))
+
+            for (circles, bgr) in ((fence_mod.inclusion_circles(),
+                                    FENCE_INCLUSION_BGR),
+                                   (fence_mod.exclusion_circles(),
+                                    FENCE_EXCLUSION_BGR)):
+                for circle in circles:
+                    shapes.append(('circle', self._fence_latlon(circle),
+                                   circle.param1, bgr_to_rgb(bgr)))
+
+            # home circles are centred on home, not on their own lat/lon
+            home_circles = fence_mod.home_inclusion_circles()
+            if home_circles and self.home_position is not None:
+                for circle in home_circles:
+                    shapes.append(('circle', self.home_position, circle.param1,
+                                   bgr_to_rgb(FENCE_HOME_INCLUSION_BGR)))
+
+            returnpoint = fence_mod.returnpoint()
+            if returnpoint is not None:
+                shapes.append(('circle', self._fence_latlon(returnpoint),
+                               FENCE_RETURN_RADIUS,
+                               bgr_to_rgb(FENCE_RETURN_BGR)))
         except Exception:
             return
-        self.map.set_fence(pts)
+        self.map.set_fence(shapes)
 
     def send_rally(self):
         try:
@@ -239,13 +354,7 @@ class Map3DModule(mp_module.MPModule):
                         continue
                     if len(points) < 2:
                         continue
-                    # SlipMap/OpenCV colours are BGR; VTK expects RGB.
-                    bgr = getattr(obj, 'colour', (255, 0, 255))
-                    try:
-                        rgb = tuple(max(0, min(255, int(bgr[i]))) / 255.0
-                                    for i in (2, 1, 0))
-                    except (IndexError, TypeError, ValueError):
-                        rgb = (1.0, 0.0, 1.0)
+                    rgb = bgr_to_rgb(getattr(obj, 'colour', (255, 0, 255)))
                     width = max(1.0, float(getattr(obj, 'linewidth', 2.0)))
                     features.append(("%s:%s" % (layer, key), points,
                                      rgb, width))
@@ -286,6 +395,17 @@ class Map3DModule(mp_module.MPModule):
                 self.send_fence()
         except Exception:
             pass
+        try:
+            rally_change = self.module('rally').rallyloader.last_change
+            if rally_change != self.rally_change_time:
+                self.rally_change_time = rally_change
+                self.send_rally()
+        except Exception:
+            pass
+        if self.terrain_resolved:
+            # a deferred terrain lookup landed: redo the terrain-frame items
+            self.terrain_resolved = False
+            self.send_mission()
 
     def mavlink_packet(self, m, force=False):
         if self.map is None or not self.map.is_alive():
@@ -294,6 +414,7 @@ class Map3DModule(mp_module.MPModule):
         if mtype == 'HOME_POSITION':
             self.home_amsl = m.altitude * 1.0e-3     # AMSL (mm -> m)
             self.map.set_home(self.home_amsl)
+            self.set_home_position(m.latitude * 1.0e-7, m.longitude * 1.0e-7)
         elif mtype == 'ATTITUDE':
             self.last_attitude = (m.roll, m.pitch, m.yaw)
         elif mtype == 'ATT':

--- a/MAVProxy/modules/mavproxy_map3d/__init__.py
+++ b/MAVProxy/modules/mavproxy_map3d/__init__.py
@@ -45,6 +45,7 @@ class Map3DModule(mp_module.MPModule):
         self.last_attitude = (0.0, 0.0, 0.0)
         self.home_amsl = None
         self.follow = True
+        self.kml_change_state = None
         self.start_map()
 
     # ------------------------------------------------------------------ command
@@ -97,6 +98,7 @@ class Map3DModule(mp_module.MPModule):
         self.send_fence()
         self.send_rally()
         self.send_cached_state()
+        self.send_kml()
 
     def stop_map(self):
         if self.map is not None:
@@ -211,6 +213,46 @@ class Map3DModule(mp_module.MPModule):
             return
         self.map.set_rally(pts)
 
+    @staticmethod
+    def _kml_state(kml_mod):
+        if kml_mod is None:
+            return None
+        return (id(kml_mod), getattr(kml_mod, 'last_change', 0))
+
+    def send_kml(self, kml_mod=None):
+        '''Mirror the visible KML polylines, using their 2D map colours.'''
+        if self.map is None:
+            return
+        if kml_mod is None:
+            kml_mod = self.module('kmlread')
+        features = []
+        if kml_mod is not None:
+            for layer, objects in kml_mod.map_objects.items():
+                for key, obj in objects.items():
+                    points = getattr(obj, 'points', None)
+                    if points is None or getattr(obj, 'hidden', False):
+                        continue
+                    try:
+                        points = [(float(p[0]), float(p[1]))
+                                  for p in points]
+                    except (IndexError, TypeError, ValueError):
+                        continue
+                    if len(points) < 2:
+                        continue
+                    # SlipMap/OpenCV colours are BGR; VTK expects RGB.
+                    bgr = getattr(obj, 'colour', (255, 0, 255))
+                    try:
+                        rgb = tuple(max(0, min(255, int(bgr[i]))) / 255.0
+                                    for i in (2, 1, 0))
+                    except (IndexError, TypeError, ValueError):
+                        rgb = (1.0, 0.0, 1.0)
+                    width = max(1.0, float(getattr(obj, 'linewidth', 2.0)))
+                    features.append(("%s:%s" % (layer, key), points,
+                                     rgb, width))
+        features.sort(key=lambda feature: feature[0])
+        self.map.set_kml(features)
+        self.kml_change_state = self._kml_state(kml_mod)
+
     def idle_task(self):
         if self.map is None:
             return
@@ -226,6 +268,9 @@ class Map3DModule(mp_module.MPModule):
                 self.map3d_settings.fpvfov = fpvfov
             elif event[0] == 'follow':
                 self.follow = bool(event[1])
+        kml_mod = self.module('kmlread')
+        if self._kml_state(kml_mod) != self.kml_change_state:
+            self.send_kml(kml_mod)
         # poll change times like the 2D map / cesium modules
         try:
             wp_change = self.module('wp').wploader.last_change

--- a/MAVProxy/modules/mavproxy_map3d/__init__.py
+++ b/MAVProxy/modules/mavproxy_map3d/__init__.py
@@ -233,10 +233,11 @@ class Map3DModule(mp_module.MPModule):
                 resolved = sample_terrain(lat, lon) is not None
             except Exception:
                 resolved = False
+            # drop it either way: a success is cached from here on, and a
+            # failure must stay retryable rather than blocking the point forever
+            with self.terrain_lock:
+                self.terrain_requested.discard((lat, lon))
             if resolved:
-                # terrain is reachable, so let points that failed earlier retry
-                with self.terrain_lock:
-                    self.terrain_requested.clear()
                 self.terrain_resolved = True
 
     def send_mission(self):

--- a/MAVProxy/modules/mavproxy_map3d/camera.py
+++ b/MAVProxy/modules/mavproxy_map3d/camera.py
@@ -1,0 +1,115 @@
+'''
+Cesium-like camera and interactor for the 3D map.
+
+The camera keeps the horizon level at all times (no roll/flip): only yaw (about
+world up) and pitch (look-down angle, clamped). Default mouse drag pans; Ctrl+drag
+rotates (left-right = yaw, forward-back = pitch); wheel zooms.
+'''
+
+import math
+
+import vtk
+
+
+class TerrainCamera:
+    def __init__(self, cam, focal, dist, yaw=0.0, pitch=45.0):
+        self.cam = cam
+        self.focal = list(focal)
+        self.dist = dist
+        self.yaw = yaw
+        self.pitch = pitch
+        self.pos = (0.0, 0.0, 0.0)
+        self.apply()
+
+    def apply(self):
+        y = math.radians(self.yaw)
+        p = math.radians(self.pitch)
+        vd = (math.sin(y) * math.cos(p), math.cos(y) * math.cos(p), -math.sin(p))
+        pos = (self.focal[0] - self.dist * vd[0],
+               self.focal[1] - self.dist * vd[1],
+               self.focal[2] - self.dist * vd[2])
+        self.pos = pos
+        self.cam.SetFocalPoint(*self.focal)
+        self.cam.SetPosition(*pos)
+        self.cam.SetViewUp(0, 0, 1)
+        self.cam.SetClippingRange(max(1.0, self.dist * 0.005), self.dist * 60.0)
+
+    def pan(self, dx, dy):
+        y = math.radians(self.yaw)
+        right = (math.cos(y), -math.sin(y), 0.0)
+        fwd = (math.sin(y), math.cos(y), 0.0)
+        s = self.dist * 0.0015
+        self.focal[0] -= (right[0] * dx + fwd[0] * dy) * s
+        self.focal[1] -= (right[1] * dx + fwd[1] * dy) * s
+        self.apply()
+
+    def rotate(self, dx, dy):
+        self.yaw += dx * 0.3
+        self.pitch = min(89.0, max(5.0, self.pitch - dy * 0.3))
+        self.apply()
+
+    def zoom(self, factor):
+        self.dist = max(20.0, self.dist * factor)
+        self.apply()
+
+    def look_at(self, focal, dist=None, yaw=None, pitch=None):
+        self.focal = list(focal)
+        if dist is not None:
+            self.dist = dist
+        if yaw is not None:
+            self.yaw = yaw
+        if pitch is not None:
+            self.pitch = pitch
+        self.apply()
+
+
+class TerrainStyle(vtk.vtkInteractorStyleUser):
+    '''default drag = pan, Ctrl+drag = yaw/pitch, wheel = zoom'''
+    def __init__(self, tc, on_change=None):
+        self.tc = tc
+        self.on_change = on_change
+        self.last = None
+        self.moved = False
+        self.AddObserver("LeftButtonPressEvent", self._down)
+        self.AddObserver("LeftButtonReleaseEvent", self._up)
+        self.AddObserver("MouseMoveEvent", self._move)
+        self.AddObserver("MouseWheelForwardEvent", self._wf)
+        self.AddObserver("MouseWheelBackwardEvent", self._wb)
+
+    def _render(self):
+        self.GetInteractor().GetRenderWindow().Render()
+
+    def _down(self, o, e):
+        self.last = self.GetInteractor().GetEventPosition()
+        self.moved = False
+
+    def _up(self, o, e):
+        self.last = None
+        if self.moved and self.on_change:
+            self.on_change()
+
+    def _move(self, o, e):
+        if self.last is None:
+            return
+        it = self.GetInteractor()
+        x, y = it.GetEventPosition()
+        dx, dy = x - self.last[0], y - self.last[1]
+        self.last = (x, y)
+        self.moved = True
+        if it.GetControlKey():
+            self.tc.rotate(dx, dy)
+        else:
+            self.tc.pan(dx, dy)
+        self._render()
+
+    def _wf(self, o, e):
+        self.tc.zoom(1.0 / 1.2)
+        if self.on_change:
+            self.on_change()
+        self._render()
+
+    def _wb(self, o, e):
+        self.tc.zoom(1.2)
+        if self.on_change:
+            self.on_change()
+        self._render()

--- a/MAVProxy/modules/mavproxy_map3d/camera.py
+++ b/MAVProxy/modules/mavproxy_map3d/camera.py
@@ -62,6 +62,27 @@ class TerrainCamera:
             self.pitch = pitch
         self.apply()
 
+    def set_fpv(self, position, yaw, pitch, lookahead=5000.0):
+        '''Place the camera at the vehicle and look along its yaw/pitch.
+
+        yaw and pitch are radians from MAVLink. Roll is deliberately omitted;
+        world-up remains camera-up so the FPV horizon is always level.
+        '''
+        pitch = min(math.radians(85.0), max(math.radians(-85.0), pitch))
+        cp = math.cos(pitch)
+        direction = (math.sin(yaw) * cp,
+                     math.cos(yaw) * cp,
+                     math.sin(pitch))
+        self.pos = tuple(position)
+        self.focal = [position[i] + lookahead * direction[i] for i in range(3)]
+        self.dist = lookahead
+        self.yaw = math.degrees(yaw)
+        self.pitch = math.degrees(pitch)
+        self.cam.SetPosition(*self.pos)
+        self.cam.SetFocalPoint(*self.focal)
+        self.cam.SetViewUp(0, 0, 1)
+        self.cam.SetClippingRange(0.5, lookahead * 100.0)
+
 
 class TerrainStyle(vtk.vtkInteractorStyleUser):
     '''default drag = pan, Ctrl+drag = yaw/pitch, wheel = zoom'''
@@ -70,6 +91,9 @@ class TerrainStyle(vtk.vtkInteractorStyleUser):
         self.on_change = on_change
         self.last = None
         self.moved = False
+        # Do not call this "enabled": vtkInteractorStyle exposes an enabled
+        # property that attempts to enable the style immediately.
+        self.interaction_enabled = True
         self.AddObserver("LeftButtonPressEvent", self._down)
         self.AddObserver("LeftButtonReleaseEvent", self._up)
         self.AddObserver("MouseMoveEvent", self._move)
@@ -80,16 +104,20 @@ class TerrainStyle(vtk.vtkInteractorStyleUser):
         self.GetInteractor().GetRenderWindow().Render()
 
     def _down(self, o, e):
+        if not self.interaction_enabled:
+            return
         self.last = self.GetInteractor().GetEventPosition()
         self.moved = False
 
     def _up(self, o, e):
         self.last = None
+        if not self.interaction_enabled:
+            return
         if self.moved and self.on_change:
             self.on_change()
 
     def _move(self, o, e):
-        if self.last is None:
+        if not self.interaction_enabled or self.last is None:
             return
         it = self.GetInteractor()
         x, y = it.GetEventPosition()
@@ -103,12 +131,16 @@ class TerrainStyle(vtk.vtkInteractorStyleUser):
         self._render()
 
     def _wf(self, o, e):
+        if not self.interaction_enabled:
+            return
         self.tc.zoom(1.0 / 1.2)
         if self.on_change:
             self.on_change()
         self._render()
 
     def _wb(self, o, e):
+        if not self.interaction_enabled:
+            return
         self.tc.zoom(1.2)
         if self.on_change:
             self.on_change()

--- a/MAVProxy/modules/mavproxy_map3d/elements.py
+++ b/MAVProxy/modules/mavproxy_map3d/elements.py
@@ -1,0 +1,162 @@
+'''
+VTK actors for the map elements drawn over the 3D terrain: flight path / trail,
+mission, fence, rally points and the vehicle. All positions are converted to the
+same local ENU frame used by the terrain (origin lat0,lon0, up = AMSL * zexag).
+'''
+
+import math
+
+import vtk
+
+from MAVProxy.modules.mavproxy_map3d.terrain import enu
+
+# MAV_FRAME altitude conventions
+FRAME_GLOBAL = (0, 5)            # AMSL
+FRAME_RELATIVE = (3, 6)          # relative to home
+FRAME_TERRAIN = (10, 11)         # above terrain
+
+
+def _polyline(points_enu, colour, width, dashed=False):
+    vpts = vtk.vtkPoints()
+    line = vtk.vtkPolyLine()
+    line.GetPointIds().SetNumberOfIds(len(points_enu))
+    for i, p in enumerate(points_enu):
+        vpts.InsertNextPoint(*p)
+        line.GetPointIds().SetId(i, i)
+    cells = vtk.vtkCellArray()
+    cells.InsertNextCell(line)
+    poly = vtk.vtkPolyData()
+    poly.SetPoints(vpts)
+    poly.SetLines(cells)
+    mapper = vtk.vtkPolyDataMapper()
+    mapper.SetInputData(poly)
+    actor = vtk.vtkActor()
+    actor.SetMapper(mapper)
+    actor.GetProperty().SetColor(*colour)
+    actor.GetProperty().SetLineWidth(width)
+    actor.GetProperty().SetLighting(False)
+    if dashed:
+        actor.GetProperty().SetLineStipplePattern(0xF0F0)
+    return actor
+
+
+def _points(points_enu, colour, size):
+    vpts = vtk.vtkPoints()
+    verts = vtk.vtkCellArray()
+    for i, p in enumerate(points_enu):
+        vpts.InsertNextPoint(*p)
+        verts.InsertNextCell(1, [i])
+    poly = vtk.vtkPolyData()
+    poly.SetPoints(vpts)
+    poly.SetVerts(verts)
+    mapper = vtk.vtkPolyDataMapper()
+    mapper.SetInputData(poly)
+    actor = vtk.vtkActor()
+    actor.SetMapper(mapper)
+    actor.GetProperty().SetColor(*colour)
+    actor.GetProperty().SetPointSize(size)
+    actor.GetProperty().SetLighting(False)
+    return actor
+
+
+class ElementManager:
+    def __init__(self, renderer, lat0, lon0, zexag):
+        self.ren = renderer
+        self.lat0 = lat0
+        self.lon0 = lon0
+        self.zexag = zexag
+        self.home_amsl = 0.0
+        self.actors = {}            # key -> list of actors
+        self.trail = []             # accumulated live positions (enu)
+        self.vehicle = None
+
+    def _enu(self, lat, lon, amsl):
+        e, n, u = enu(lat, lon, amsl, self.lat0, self.lon0)
+        return (e, n, u * self.zexag)
+
+    def _resolve_amsl(self, alt, frame):
+        if frame in FRAME_GLOBAL:
+            return alt
+        # relative-to-home and terrain both referenced to home AMSL in v1
+        return self.home_amsl + alt
+
+    def _replace(self, key, actors):
+        for a in self.actors.get(key, []):
+            self.ren.RemoveActor(a)
+        for a in actors:
+            self.ren.AddActor(a)
+        self.actors[key] = actors
+
+    def set_home(self, amsl):
+        self.home_amsl = amsl
+
+    def set_path(self, path):
+        '''path: list of (lat,lon,amsl)'''
+        if not path:
+            return
+        pts = [self._enu(lat, lon, a + 2.0) for (lat, lon, a) in path]
+        self._replace('path', [_polyline(pts, (1.0, 0.0, 0.7), 2.5)])
+
+    def add_trail_point(self, lat, lon, amsl):
+        self.trail.append(self._enu(lat, lon, amsl))
+        if len(self.trail) > 5000:
+            self.trail = self.trail[-5000:]
+        if len(self.trail) >= 2:
+            self._replace('trail', [_polyline(self.trail, (1.0, 1.0, 0.0), 2.0)])
+
+    def set_mission(self, items):
+        '''items: list of (lat,lon,z,frame,command,seq)'''
+        line = []
+        markers = []
+        for (lat, lon, z, frame, command, seq) in items:
+            if lat == 0 and lon == 0:
+                continue
+            amsl = self._resolve_amsl(z, frame)
+            p = self._enu(lat, lon, amsl)
+            line.append(p)
+            markers.append(p)
+        actors = []
+        if len(line) >= 2:
+            actors.append(_polyline(line, (1.0, 1.0, 1.0), 2.0, dashed=True))
+        if markers:
+            actors.append(_points(markers, (1.0, 1.0, 1.0), 9))
+        self._replace('mission', actors)
+
+    def set_fence(self, pts):
+        '''pts: list of (lat,lon) polygon (drawn near ground)'''
+        if len(pts) < 2:
+            self._replace('fence', [])
+            return
+        ring = [self._enu(lat, lon, self.home_amsl + 1.0) for (lat, lon) in pts]
+        ring.append(ring[0])
+        self._replace('fence', [_polyline(ring, (0.0, 1.0, 0.0), 2.0)])
+
+    def set_rally(self, pts):
+        '''pts: list of (lat,lon,alt_rel)'''
+        if not pts:
+            self._replace('rally', [])
+            return
+        markers = [self._enu(lat, lon, self.home_amsl + alt) for (lat, lon, alt) in pts]
+        self._replace('rally', [_points(markers, (0.4, 0.8, 1.0), 12)])
+
+    def set_vehicle(self, lat, lon, amsl, roll, pitch, yaw):
+        if self.vehicle is None:
+            cone = vtk.vtkConeSource()
+            cone.SetHeight(40.0)
+            cone.SetRadius(14.0)
+            cone.SetResolution(16)
+            cone.SetDirection(0, 1, 0)         # base orientation: north
+            mapper = vtk.vtkPolyDataMapper()
+            mapper.SetInputConnection(cone.GetOutputPort())
+            self.vehicle = vtk.vtkActor()
+            self.vehicle.SetMapper(mapper)
+            self.vehicle.GetProperty().SetColor(1.0, 0.2, 0.0)
+            self.ren.AddActor(self.vehicle)
+        e, n, u = self._enu(lat, lon, amsl)
+        self.vehicle.SetPosition(e, n, u)
+        # yaw about Z (heading), then pitch/roll best-effort
+        self.vehicle.SetOrientation(0, 0, 0)
+        self.vehicle.RotateZ(-math.degrees(yaw))
+        self.vehicle.RotateX(math.degrees(pitch))
+        self.vehicle.RotateY(math.degrees(roll))
+        return (e, n, u)

--- a/MAVProxy/modules/mavproxy_map3d/elements.py
+++ b/MAVProxy/modules/mavproxy_map3d/elements.py
@@ -1,7 +1,8 @@
 '''
 VTK actors for the map elements drawn over the 3D terrain: flight path / trail,
-mission, fence, rally points and the vehicle. All positions are converted to the
-same local ENU frame used by the terrain (origin lat0,lon0, up = AMSL * zexag).
+mission, fence, KML, rally points and the vehicle. All positions are converted
+to the same local ENU frame used by the terrain (origin lat0,lon0, up = AMSL *
+zexag).
 '''
 
 import math
@@ -119,6 +120,9 @@ class ElementManager:
         self.terrain_height = None
         self.fence = []
         self.fence_ring = None
+        self.kml_features = []
+        self.kml_geometry = None
+        self.kml_height_cache = {}
 
     def _enu(self, lat, lon, amsl):
         e, n, u = enu(lat, lon, amsl, self.lat0, self.lon0)
@@ -141,6 +145,8 @@ class ElementManager:
         self.home_amsl = amsl
         if self.fence:
             self.refresh_fence()
+        if self.kml_features:
+            self.refresh_kml()
 
     def set_terrain_height(self, terrain_height):
         self.terrain_height = terrain_height
@@ -182,13 +188,15 @@ class ElementManager:
             actors.append(_points(markers, (1.0, 1.0, 1.0), 9))
         self._replace('mission', actors)
 
-    def _fence_samples(self):
-        '''Yield a closed, densified fence ring so it follows terrain ridges.'''
-        fence = self.fence
-        if len(fence) > 2 and fence[0] == fence[-1]:
-            fence = fence[:-1]
-        for i, (lat1, lon1) in enumerate(fence):
-            lat2, lon2 = fence[(i + 1) % len(fence)]
+    def _terrain_samples(self, points, closed):
+        '''Densify a lat/lon polyline so it follows terrain between vertices.'''
+        points = list(points)
+        if closed and len(points) > 2 and points[0] == points[-1]:
+            points = points[:-1]
+        segment_count = len(points) if closed else len(points) - 1
+        for i in range(max(0, segment_count)):
+            lat1, lon1 = points[i]
+            lat2, lon2 = points[(i + 1) % len(points)]
             e1, n1, _ = enu(lat1, lon1, 0.0, self.lat0, self.lon0)
             e2, n2, _ = enu(lat2, lon2, 0.0, self.lat0, self.lon0)
             distance = math.hypot(e2 - e1, n2 - n1)
@@ -198,6 +206,26 @@ class ElementManager:
                 t = float(j) / count
                 yield (lat1 + (lat2 - lat1) * t,
                        lon1 + (lon2 - lon1) * t)
+        if points:
+            yield points[0] if closed else points[-1]
+
+    def _terrain_draped_line(self, points, closed, height_cache=None):
+        fallback = self.home_amsl * self.zexag
+        clearance = FENCE_CLEARANCE * self.zexag
+        line = []
+        for lat, lon in self._terrain_samples(points, closed):
+            e, n, _ = enu(lat, lon, 0.0, self.lat0, self.lon0)
+            cache_key = (lat, lon)
+            ground = (height_cache.get(cache_key)
+                      if height_cache is not None else None)
+            if ground is None and self.terrain_height is not None:
+                ground = self.terrain_height(lat, lon)
+                if ground is not None and height_cache is not None:
+                    height_cache[cache_key] = ground
+            if ground is None:
+                ground = fallback
+            line.append((e, n, ground + clearance))
+        return line
 
     def refresh_fence(self, terrain_height=None):
         '''Rebuild the fence just above the currently loaded terrain.
@@ -213,18 +241,7 @@ class ElementManager:
             self.fence_ring = None
             return
 
-        ring = []
-        fallback = self.home_amsl * self.zexag
-        clearance = FENCE_CLEARANCE * self.zexag
-        for lat, lon in self._fence_samples():
-            e, n, _ = enu(lat, lon, 0.0, self.lat0, self.lon0)
-            ground = None
-            if self.terrain_height is not None:
-                ground = self.terrain_height(lat, lon)
-            if ground is None:
-                ground = fallback
-            ring.append((e, n, ground + clearance))
-        ring.append(ring[0])
+        ring = self._terrain_draped_line(self.fence, closed=True)
 
         if ring == self.fence_ring:
             return
@@ -237,6 +254,37 @@ class ElementManager:
         if terrain_height is not None:
             self.set_terrain_height(terrain_height)
         self.refresh_fence()
+
+    def refresh_kml(self, terrain_height=None):
+        '''Rebuild visible KML lines just above the loaded terrain.'''
+        if terrain_height is not None:
+            self.set_terrain_height(terrain_height)
+        geometry = []
+        for key, points, colour, width in self.kml_features:
+            closed = len(points) > 2 and points[0] == points[-1]
+            line = self._terrain_draped_line(
+                points, closed, self.kml_height_cache)
+            if len(line) >= 2:
+                geometry.append((key, line, colour, width))
+        if geometry == self.kml_geometry:
+            return
+        self.kml_geometry = geometry
+        actors = [_polyline(line, colour, width)
+                  for _key, line, colour, width in geometry]
+        self._replace('kml', actors)
+
+    def set_kml(self, features, terrain_height=None, refresh=True):
+        '''features: visible (key, [(lat,lon)], RGB colour, line width).'''
+        self.kml_features = list(features)
+        if terrain_height is not None:
+            self.set_terrain_height(terrain_height)
+        self.kml_geometry = None
+        if not self.kml_features:
+            self.kml_height_cache = {}
+            self.kml_geometry = []
+            self._replace('kml', [])
+        elif refresh:
+            self.refresh_kml()
 
     def set_rally(self, pts):
         '''pts: list of (lat,lon,alt_rel)'''

--- a/MAVProxy/modules/mavproxy_map3d/elements.py
+++ b/MAVProxy/modules/mavproxy_map3d/elements.py
@@ -9,7 +9,7 @@ import math
 
 import vtk
 
-from MAVProxy.modules.mavproxy_map3d.terrain import enu
+from MAVProxy.modules.mavproxy_map3d.terrain import enu, R
 
 # MAV_FRAME altitude conventions
 FRAME_GLOBAL = (0, 5)            # AMSL
@@ -18,6 +18,21 @@ FRAME_TERRAIN = (10, 11)         # above terrain
 FENCE_CLEARANCE = 3.0
 FENCE_SAMPLE_SPACING = 20.0
 FENCE_MAX_SAMPLES_PER_EDGE = 1000
+FENCE_CIRCLE_SEGMENTS = 64
+
+
+def circle_latlon(centre, radius, segments=FENCE_CIRCLE_SEGMENTS):
+    '''lat/lon ring approximating a circle of radius metres about centre'''
+    (lat, lon) = centre
+    dlat = math.degrees(max(0.0, float(radius)) / R)
+    coslat = math.cos(math.radians(lat))
+    dlon = dlat / coslat if abs(coslat) > 1.0e-9 else 0.0
+    points = []
+    for i in range(segments):
+        angle = 2.0 * math.pi * i / segments
+        points.append((lat + dlat * math.cos(angle),
+                       lon + dlon * math.sin(angle)))
+    return points
 
 
 def _polyline(points_enu, colour, width, dashed=False):
@@ -119,7 +134,7 @@ class ElementManager:
         self.vehicle_visible = True
         self.terrain_height = None
         self.fence = []
-        self.fence_ring = None
+        self.fence_geometry = None
         self.kml_features = []
         self.kml_geometry = None
         self.kml_height_cache = {}
@@ -228,7 +243,7 @@ class ElementManager:
         return line
 
     def refresh_fence(self, terrain_height=None):
-        '''Rebuild the fence just above the currently loaded terrain.
+        '''Rebuild the fence shapes just above the currently loaded terrain.
 
         terrain_height returns rendered world Z for a lat/lon, or None where
         terrain has not arrived yet. In that case home AMSL is a safe temporary
@@ -236,21 +251,29 @@ class ElementManager:
         '''
         if terrain_height is not None:
             self.set_terrain_height(terrain_height)
-        if len(self.fence) < 2:
-            self._replace('fence', [])
-            self.fence_ring = None
+        geometry = []
+        for shape in self.fence:
+            if shape[0] == 'circle':
+                (_, centre, radius, colour) = shape
+                points = circle_latlon(centre, radius)
+            else:
+                (_, points, colour) = shape
+            if len(points) < 2:
+                continue
+            ring = self._terrain_draped_line(points, closed=True)
+            if len(ring) >= 2:
+                geometry.append((ring, colour))
+
+        if geometry == self.fence_geometry:
             return
+        self.fence_geometry = geometry
+        self._replace('fence', [_polyline(ring, colour, 2.0)
+                                for (ring, colour) in geometry])
 
-        ring = self._terrain_draped_line(self.fence, closed=True)
-
-        if ring == self.fence_ring:
-            return
-        self.fence_ring = ring
-        self._replace('fence', [_polyline(ring, (0.0, 1.0, 0.0), 2.0)])
-
-    def set_fence(self, pts, terrain_height=None):
-        '''pts: list of (lat,lon) polygon, clamped above loaded terrain'''
-        self.fence = [(lat, lon) for lat, lon in pts]
+    def set_fence(self, shapes, terrain_height=None):
+        '''shapes: list of ('polygon', [(lat,lon), ...], rgb) or
+        ('circle', (lat,lon), radius_m, rgb), each clamped above loaded terrain'''
+        self.fence = list(shapes)
         if terrain_height is not None:
             self.set_terrain_height(terrain_height)
         self.refresh_fence()

--- a/MAVProxy/modules/mavproxy_map3d/elements.py
+++ b/MAVProxy/modules/mavproxy_map3d/elements.py
@@ -14,6 +14,9 @@ from MAVProxy.modules.mavproxy_map3d.terrain import enu
 FRAME_GLOBAL = (0, 5)            # AMSL
 FRAME_RELATIVE = (3, 6)          # relative to home
 FRAME_TERRAIN = (10, 11)         # above terrain
+FENCE_CLEARANCE = 3.0
+FENCE_SAMPLE_SPACING = 20.0
+FENCE_MAX_SAMPLES_PER_EDGE = 1000
 
 
 def _polyline(points_enu, colour, width, dashed=False):
@@ -30,6 +33,8 @@ def _polyline(points_enu, colour, width, dashed=False):
     poly.SetLines(cells)
     mapper = vtk.vtkPolyDataMapper()
     mapper.SetInputData(poly)
+    mapper.SetResolveCoincidentTopologyToPolygonOffset()
+    mapper.SetRelativeCoincidentTopologyLineOffsetParameters(-1.0, -1.0)
     actor = vtk.vtkActor()
     actor.SetMapper(mapper)
     actor.GetProperty().SetColor(*colour)
@@ -37,6 +42,46 @@ def _polyline(points_enu, colour, width, dashed=False):
     actor.GetProperty().SetLighting(False)
     if dashed:
         actor.GetProperty().SetLineStipplePattern(0xF0F0)
+    return actor
+
+
+def _vehicle_icon():
+    '''Return an opaque aircraft glyph in the local horizontal plane.
+
+    Using native geometry avoids platform-dependent PNG alpha/texture issues.
+    The outline coordinates describe a unit aircraft pointing towards +Y.
+    '''
+    outline = [
+        (0.00, 0.50), (-0.07, 0.24), (-0.48, 0.02), (-0.48, -0.07),
+        (-0.08, 0.00), (-0.07, -0.30), (-0.22, -0.43), (-0.22, -0.50),
+        (0.00, -0.42), (0.22, -0.50), (0.22, -0.43), (0.07, -0.30),
+        (0.08, 0.00), (0.48, -0.07), (0.48, 0.02), (0.07, 0.24),
+    ]
+    points = vtk.vtkPoints()
+    polygon = vtk.vtkPolygon()
+    polygon.GetPointIds().SetNumberOfIds(len(outline))
+    for i, (x, y) in enumerate(outline):
+        points.InsertNextPoint(x, y, 0.0)
+        polygon.GetPointIds().SetId(i, i)
+    cells = vtk.vtkCellArray()
+    cells.InsertNextCell(polygon)
+    poly = vtk.vtkPolyData()
+    poly.SetPoints(points)
+    poly.SetPolys(cells)
+    triangles = vtk.vtkTriangleFilter()
+    triangles.SetInputData(poly)
+    mapper = vtk.vtkPolyDataMapper()
+    mapper.SetInputConnection(triangles.GetOutputPort())
+    actor = vtk.vtkActor()
+    actor.SetMapper(mapper)
+    actor.GetProperty().SetLighting(False)
+    actor.GetProperty().SetAmbient(1.0)
+    actor.GetProperty().SetDiffuse(0.0)
+    actor.GetProperty().SetColor(1.0, 0.05, 0.0)
+    actor.ForceOpaqueOn()
+
+    # Keep the pipeline alive for the lifetime of the actor.
+    actor._map3d_triangles = triangles
     return actor
 
 
@@ -69,6 +114,11 @@ class ElementManager:
         self.actors = {}            # key -> list of actors
         self.trail = []             # accumulated live positions (enu)
         self.vehicle = None
+        self.vehicle_pose = None
+        self.vehicle_visible = True
+        self.terrain_height = None
+        self.fence = []
+        self.fence_ring = None
 
     def _enu(self, lat, lon, amsl):
         e, n, u = enu(lat, lon, amsl, self.lat0, self.lon0)
@@ -89,6 +139,16 @@ class ElementManager:
 
     def set_home(self, amsl):
         self.home_amsl = amsl
+        if self.fence:
+            self.refresh_fence()
+
+    def set_terrain_height(self, terrain_height):
+        self.terrain_height = terrain_height
+
+    def set_vehicle_visible(self, visible):
+        self.vehicle_visible = bool(visible)
+        if self.vehicle is not None:
+            self.vehicle.SetVisibility(self.vehicle_visible)
 
     def set_path(self, path):
         '''path: list of (lat,lon,amsl)'''
@@ -122,14 +182,61 @@ class ElementManager:
             actors.append(_points(markers, (1.0, 1.0, 1.0), 9))
         self._replace('mission', actors)
 
-    def set_fence(self, pts):
-        '''pts: list of (lat,lon) polygon (drawn near ground)'''
-        if len(pts) < 2:
+    def _fence_samples(self):
+        '''Yield a closed, densified fence ring so it follows terrain ridges.'''
+        fence = self.fence
+        if len(fence) > 2 and fence[0] == fence[-1]:
+            fence = fence[:-1]
+        for i, (lat1, lon1) in enumerate(fence):
+            lat2, lon2 = fence[(i + 1) % len(fence)]
+            e1, n1, _ = enu(lat1, lon1, 0.0, self.lat0, self.lon0)
+            e2, n2, _ = enu(lat2, lon2, 0.0, self.lat0, self.lon0)
+            distance = math.hypot(e2 - e1, n2 - n1)
+            count = max(1, int(math.ceil(distance / FENCE_SAMPLE_SPACING)))
+            count = min(count, FENCE_MAX_SAMPLES_PER_EDGE)
+            for j in range(count):
+                t = float(j) / count
+                yield (lat1 + (lat2 - lat1) * t,
+                       lon1 + (lon2 - lon1) * t)
+
+    def refresh_fence(self, terrain_height=None):
+        '''Rebuild the fence just above the currently loaded terrain.
+
+        terrain_height returns rendered world Z for a lat/lon, or None where
+        terrain has not arrived yet. In that case home AMSL is a safe temporary
+        fallback; the UI calls this again whenever terrain tiles arrive.
+        '''
+        if terrain_height is not None:
+            self.set_terrain_height(terrain_height)
+        if len(self.fence) < 2:
             self._replace('fence', [])
+            self.fence_ring = None
             return
-        ring = [self._enu(lat, lon, self.home_amsl + 1.0) for (lat, lon) in pts]
+
+        ring = []
+        fallback = self.home_amsl * self.zexag
+        clearance = FENCE_CLEARANCE * self.zexag
+        for lat, lon in self._fence_samples():
+            e, n, _ = enu(lat, lon, 0.0, self.lat0, self.lon0)
+            ground = None
+            if self.terrain_height is not None:
+                ground = self.terrain_height(lat, lon)
+            if ground is None:
+                ground = fallback
+            ring.append((e, n, ground + clearance))
         ring.append(ring[0])
+
+        if ring == self.fence_ring:
+            return
+        self.fence_ring = ring
         self._replace('fence', [_polyline(ring, (0.0, 1.0, 0.0), 2.0)])
+
+    def set_fence(self, pts, terrain_height=None):
+        '''pts: list of (lat,lon) polygon, clamped above loaded terrain'''
+        self.fence = [(lat, lon) for lat, lon in pts]
+        if terrain_height is not None:
+            self.set_terrain_height(terrain_height)
+        self.refresh_fence()
 
     def set_rally(self, pts):
         '''pts: list of (lat,lon,alt_rel)'''
@@ -139,24 +246,36 @@ class ElementManager:
         markers = [self._enu(lat, lon, self.home_amsl + alt) for (lat, lon, alt) in pts]
         self._replace('rally', [_points(markers, (0.4, 0.8, 1.0), 12)])
 
-    def set_vehicle(self, lat, lon, amsl, roll, pitch, yaw):
+    def refresh_vehicle(self):
+        if self.vehicle_pose is None:
+            return None
+        lat, lon, amsl, roll, pitch, yaw = self.vehicle_pose
         if self.vehicle is None:
-            cone = vtk.vtkConeSource()
-            cone.SetHeight(40.0)
-            cone.SetRadius(14.0)
-            cone.SetResolution(16)
-            cone.SetDirection(0, 1, 0)         # base orientation: north
-            mapper = vtk.vtkPolyDataMapper()
-            mapper.SetInputConnection(cone.GetOutputPort())
-            self.vehicle = vtk.vtkActor()
-            self.vehicle.SetMapper(mapper)
-            self.vehicle.GetProperty().SetColor(1.0, 0.2, 0.0)
+            self.vehicle = _vehicle_icon()
+            self.vehicle.SetVisibility(self.vehicle_visible)
             self.ren.AddActor(self.vehicle)
         e, n, u = self._enu(lat, lon, amsl)
+        if self.terrain_height is not None:
+            ground = self.terrain_height(lat, lon)
+            if ground is not None:
+                u = max(u, ground + 5.0 * self.zexag)
         self.vehicle.SetPosition(e, n, u)
-        # yaw about Z (heading), then pitch/roll best-effort
-        self.vehicle.SetOrientation(0, 0, 0)
+        camera = self.ren.GetActiveCamera()
+        cx, cy, cz = camera.GetPosition()
+        distance = math.sqrt((cx - e) ** 2 + (cy - n) ** 2 + (cz - u) ** 2)
+        # Scale with camera distance for a stable screen size. These values are
+        # half the original marker size.
+        display_size = max(22.5, distance * 0.03)
+        self.vehicle.SetScale(display_size)
+        # The glyph starts level, pointing north (+Y). Apply the aircraft
+        # attitude in the local east/north/up frame so a level aircraft remains
+        # parallel to the terrain rather than facing the camera.
+        self.vehicle.SetOrientation(0.0, 0.0, 0.0)
         self.vehicle.RotateZ(-math.degrees(yaw))
         self.vehicle.RotateX(math.degrees(pitch))
         self.vehicle.RotateY(math.degrees(roll))
         return (e, n, u)
+
+    def set_vehicle(self, lat, lon, amsl, roll, pitch, yaw):
+        self.vehicle_pose = (lat, lon, amsl, roll, pitch, yaw)
+        return self.refresh_vehicle()

--- a/MAVProxy/modules/mavproxy_map3d/elements.py
+++ b/MAVProxy/modules/mavproxy_map3d/elements.py
@@ -22,16 +22,32 @@ FENCE_CIRCLE_SEGMENTS = 64
 
 
 def circle_latlon(centre, radius, segments=FENCE_CIRCLE_SEGMENTS):
-    '''lat/lon ring approximating a circle of radius metres about centre'''
+    '''lat/lon ring approximating a circle of radius metres about centre.
+
+    Great-circle destination points, so the ring stays a circle at high latitude
+    instead of blowing up as a flat-earth 1/cos(lat) would. Longitudes are left
+    unwrapped (centre longitude plus an offset) so the ring stays continuous for
+    the ENU projection rather than jumping at the 180th meridian.
+    '''
     (lat, lon) = centre
-    dlat = math.degrees(max(0.0, float(radius)) / R)
-    coslat = math.cos(math.radians(lat))
-    dlon = dlat / coslat if abs(coslat) > 1.0e-9 else 0.0
+    delta = max(0.0, float(radius)) / R
+    lat1 = math.radians(lat)
+    (sin_lat1, cos_lat1) = (math.sin(lat1), math.cos(lat1))
+    (sin_d, cos_d) = (math.sin(delta), math.cos(delta))
+    if abs(cos_lat1) < 1.0e-12:
+        # exactly on a pole the bearing terms cancel, so sweep longitude instead
+        polar_lat = math.degrees(math.copysign(math.pi / 2 - delta, lat1))
+        return [(polar_lat, lon - 180.0 + 360.0 * i / segments)
+                for i in range(segments)]
     points = []
     for i in range(segments):
-        angle = 2.0 * math.pi * i / segments
-        points.append((lat + dlat * math.cos(angle),
-                       lon + dlon * math.sin(angle)))
+        bearing = 2.0 * math.pi * i / segments
+        sin_lat2 = min(1.0, max(-1.0, sin_lat1 * cos_d +
+                                cos_lat1 * sin_d * math.cos(bearing)))
+        lat2 = math.asin(sin_lat2)
+        dlon = math.atan2(math.sin(bearing) * sin_d * cos_lat1,
+                          cos_d - sin_lat1 * sin_lat2)
+        points.append((math.degrees(lat2), lon + math.degrees(dlon)))
     return points
 
 

--- a/MAVProxy/modules/mavproxy_map3d/map3d.py
+++ b/MAVProxy/modules/mavproxy_map3d/map3d.py
@@ -1,0 +1,94 @@
+'''
+Parent-side handle for the 3D map. Spawns the VTK/wx viewer in a child process
+(mirrors mp_slipmap) and pushes element/camera updates over a queue.
+'''
+
+import time
+
+from MAVProxy.modules.lib import multiproc
+
+
+class Map3D:
+    def __init__(self, title="3D Map", service="MicrosoftSat", zexag=1.0,
+                 width=1100, height=800, debug=False):
+        self.title = title
+        self.service = service
+        self.zexag = zexag
+        self.width = width
+        self.height = height
+        self.debug = debug
+
+        self.object_queue = multiproc.Queue()
+        self.event_queue = multiproc.Queue()
+        self.app_ready = multiproc.Event()
+        self.close_window = multiproc.Semaphore()
+        self.close_window.acquire()
+        self.child = multiproc.Process(target=self.child_task)
+        self.child.start()
+        self._origin_set = False
+
+    def child_task(self):
+        from MAVProxy.modules.lib import mp_util
+        mp_util.child_close_fds()
+        from MAVProxy.modules.lib import wx_processguard  # noqa: F401
+        from MAVProxy.modules.lib.wx_loader import wx
+        from MAVProxy.modules.mavproxy_map3d.map3d_ui import Map3DFrame
+
+        app = wx.App(False)
+        app.SetExitOnFrameDelete(True)
+        frame = Map3DFrame(self)
+        frame.Show()
+        self.app_ready.set()
+        app.MainLoop()
+
+    def is_alive(self):
+        return self.child.is_alive()
+
+    def _put(self, msg):
+        if self.child.is_alive():
+            self.object_queue.put(msg)
+
+    # ------------------------------------------------------------- push helpers
+    def set_origin(self, lat, lon, amsl_ref):
+        self._origin_set = True
+        self._put(('origin', lat, lon, amsl_ref))
+
+    def origin_set(self):
+        return self._origin_set
+
+    def set_home(self, amsl):
+        self._put(('home', amsl))
+
+    def set_vehicle(self, lat, lon, amsl, roll=0.0, pitch=0.0, yaw=0.0):
+        self._put(('vehicle', lat, lon, amsl, roll, pitch, yaw))
+
+    def set_path(self, path):
+        self._put(('path', list(path)))
+
+    def set_mission(self, items):
+        self._put(('mission', list(items)))
+
+    def set_fence(self, pts):
+        self._put(('fence', list(pts)))
+
+    def set_rally(self, pts):
+        self._put(('rally', list(pts)))
+
+    def set_follow(self, enable):
+        self._put(('follow', bool(enable)))
+
+    def center_on_vehicle(self):
+        self._put(('center', None))
+
+    def look_at(self, lat, lon, amsl, dist=None):
+        self._put(('lookat', lat, lon, amsl, dist))
+
+    def close(self):
+        self.close_window.release()
+        count = 0
+        while self.child.is_alive() and count < 20:
+            time.sleep(0.1)
+            count += 1
+        if self.child.is_alive():
+            self.child.terminate()
+        self.child.join()

--- a/MAVProxy/modules/mavproxy_map3d/map3d.py
+++ b/MAVProxy/modules/mavproxy_map3d/map3d.py
@@ -4,19 +4,27 @@ Parent-side handle for the 3D map. Spawns the VTK/wx viewer in a child process
 '''
 
 import time
+import queue
 
 from MAVProxy.modules.lib import multiproc
 
 
 class Map3D:
     def __init__(self, title="3D Map", service="MicrosoftSat", zexag=1.0,
-                 width=1100, height=800, debug=False):
+                 width=1100, height=800, debug=False, fpvfov=90.0,
+                 terrain_brightness=1.25, terrain_shading=True,
+                 terrain_wireframe=False, follow=True):
         self.title = title
         self.service = service
         self.zexag = zexag
         self.width = width
         self.height = height
         self.debug = debug
+        self.fpvfov = fpvfov
+        self.terrain_brightness = terrain_brightness
+        self.terrain_shading = terrain_shading
+        self.terrain_wireframe = terrain_wireframe
+        self.follow = bool(follow)
 
         self.object_queue = multiproc.Queue()
         self.event_queue = multiproc.Queue()
@@ -76,6 +84,21 @@ class Map3D:
 
     def set_follow(self, enable):
         self._put(('follow', bool(enable)))
+
+    def set_fpv_fov(self, fov):
+        self._put(('fpvfov', float(fov)))
+
+    def set_render_settings(self, brightness, shading, wireframe):
+        self._put(('render_settings', float(brightness), bool(shading),
+                   bool(wireframe)))
+
+    def check_events(self):
+        events = []
+        while True:
+            try:
+                events.append(self.event_queue.get_nowait())
+            except queue.Empty:
+                return events
 
     def center_on_vehicle(self):
         self._put(('center', None))

--- a/MAVProxy/modules/mavproxy_map3d/map3d.py
+++ b/MAVProxy/modules/mavproxy_map3d/map3d.py
@@ -79,6 +79,9 @@ class Map3D:
     def set_fence(self, pts):
         self._put(('fence', list(pts)))
 
+    def set_kml(self, features):
+        self._put(('kml', list(features)))
+
     def set_rally(self, pts):
         self._put(('rally', list(pts)))
 

--- a/MAVProxy/modules/mavproxy_map3d/map3d.py
+++ b/MAVProxy/modules/mavproxy_map3d/map3d.py
@@ -76,8 +76,9 @@ class Map3D:
     def set_mission(self, items):
         self._put(('mission', list(items)))
 
-    def set_fence(self, pts):
-        self._put(('fence', list(pts)))
+    def set_fence(self, shapes):
+        '''shapes: ('polygon', [(lat,lon), ...], rgb) / ('circle', (lat,lon), radius_m, rgb)'''
+        self._put(('fence', list(shapes)))
 
     def set_kml(self, features):
         self._put(('kml', list(features)))

--- a/MAVProxy/modules/mavproxy_map3d/map3d_test.py
+++ b/MAVProxy/modules/mavproxy_map3d/map3d_test.py
@@ -1,0 +1,131 @@
+'''
+Standalone test/verify harness for the 3D map rendering core.
+
+Exercises terrain.py + elements.py + camera.py directly (in-process) and renders
+to a PNG offscreen, or opens the real multiprocess viewer with --gui.
+
+  PYTHONPATH=$PWD python3 -m MAVProxy.modules.mavproxy_map3d.map3d_test \
+      --log example_logs/V95_56.bin --out /tmp/map3d_module.png
+'''
+
+import argparse
+import math
+import time
+
+import vtk
+
+from pymavlink import mavutil
+from MAVProxy.modules.mavproxy_map import mp_tile
+from MAVProxy.modules.mavproxy_map3d.terrain import TerrainManager, R
+from MAVProxy.modules.mavproxy_map3d.elements import ElementManager
+from MAVProxy.modules.mavproxy_map3d.camera import TerrainCamera
+
+
+def load_log(path):
+    m = mavutil.mavlink_connection(path)
+    pts = []
+    mission = []
+    while True:
+        msg = m.recv_match(type=['POS', 'CMD'], blocking=False)
+        if msg is None:
+            break
+        if msg.get_type() == 'POS':
+            pts.append((msg.Lat, msg.Lng, msg.Alt))
+        elif msg.get_type() == 'CMD':
+            if msg.Lat != 0 or msg.Lng != 0:
+                mission.append((msg.Lat, msg.Lng, msg.Alt, getattr(msg, 'Frame', 3),
+                                msg.CId, msg.CNum))
+    return pts, mission
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--log", default="example_logs/V95_56.bin")
+    ap.add_argument("--service", default="MicrosoftSat")
+    ap.add_argument("--zexag", type=float, default=1.0)
+    ap.add_argument("--pitch", type=float, default=28.0)
+    ap.add_argument("--width", type=int, default=1100)
+    ap.add_argument("--height", type=int, default=800)
+    ap.add_argument("--settle", type=float, default=40.0, help="seconds to wait for tiles")
+    ap.add_argument("--out", default="/tmp/map3d_module.png")
+    ap.add_argument("--gui", action="store_true")
+    args = ap.parse_args()
+
+    pts, mission = load_log(args.log)
+    if not pts:
+        print("no POS in", args.log)
+        return
+    lat0 = sum(p[0] for p in pts) / len(pts)
+    lon0 = sum(p[1] for p in pts) / len(pts)
+    ground0 = min(p[2] for p in pts)
+    minlat, maxlat = min(p[0] for p in pts), max(p[0] for p in pts)
+    minlon, maxlon = min(p[1] for p in pts), max(p[1] for p in pts)
+    spanlon = math.radians(maxlon - minlon) * R * math.cos(math.radians(lat0))
+    spanlat = math.radians(maxlat - minlat) * R
+    span = max(spanlon, spanlat, 1000.0)
+    print("path=%d mission=%d centroid=(%.5f,%.5f) span=%.0fm" %
+          (len(pts), len(mission), lat0, lon0, span))
+
+    if args.gui:
+        from MAVProxy.modules.mavproxy_map3d.map3d import Map3D
+        m = Map3D(title="map3d test", service=args.service, zexag=args.zexag,
+                  width=args.width, height=args.height)
+        time.sleep(1.0)
+        m.set_origin(lat0, lon0, ground0)
+        m.set_home(ground0)
+        m.set_path(pts)
+        m.set_mission(mission)
+        m.look_at(lat0, lon0, ground0, dist=1.6 * span)
+        try:
+            while m.is_alive():
+                time.sleep(0.5)
+        except KeyboardInterrupt:
+            m.close()
+        return
+
+    # offscreen: drive the core directly
+    ren = vtk.vtkRenderer()
+    ren.SetBackground(0.45, 0.62, 0.85)
+    mt = mp_tile.MPTile(service=args.service, tile_delay=0.02)
+    terrain = TerrainManager(ren, mt, lat0, lon0, zexag=args.zexag,
+                             fine_radius=3, screen_h=args.height)
+    elements = ElementManager(ren, lat0, lon0, args.zexag)
+    elements.set_home(ground0)
+    elements.set_path(pts)
+    elements.set_mission(mission)
+
+    tc = TerrainCamera(ren.GetActiveCamera(),
+                       focal=(0.0, 0.0, ground0 * args.zexag),
+                       dist=1.6 * span, yaw=0.0, pitch=args.pitch)
+    terrain.update(tc)
+
+    deadline = time.time() + args.settle
+    last_change = time.time()
+    while time.time() < deadline:
+        if terrain.process(tc):
+            last_change = time.time()
+        settled = (not terrain.inflight and mt.tiles_pending() == 0)
+        if settled and time.time() - last_change > 2.0:
+            break
+        time.sleep(0.1)
+    print("tiles=%d inflight=%d pending=%d" %
+          (len(terrain.tiles), len(terrain.inflight), mt.tiles_pending()))
+
+    rw = vtk.vtkRenderWindow()
+    rw.SetOffScreenRendering(1)
+    rw.SetSize(args.width, args.height)
+    rw.AddRenderer(ren)
+    rw.Render()
+    w2i = vtk.vtkWindowToImageFilter()
+    w2i.SetInput(rw)
+    w2i.Update()
+    wr = vtk.vtkPNGWriter()
+    wr.SetFileName(args.out)
+    wr.SetInputConnection(w2i.GetOutputPort())
+    wr.Write()
+    terrain.shutdown()
+    print("wrote", args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/MAVProxy/modules/mavproxy_map3d/map3d_ui.py
+++ b/MAVProxy/modules/mavproxy_map3d/map3d_ui.py
@@ -1,0 +1,138 @@
+'''
+Child-process GUI for the 3D map: a wx frame hosting a VTK render window. A timer
+drains the parent's object queue (element/camera updates) and the terrain
+manager's async results, then renders.
+'''
+
+import math
+import queue
+
+from MAVProxy.modules.lib.wx_loader import wx
+from vtk.wx.wxVTKRenderWindowInteractor import wxVTKRenderWindowInteractor
+
+from MAVProxy.modules.mavproxy_map import mp_tile
+from MAVProxy.modules.mavproxy_map3d.camera import TerrainCamera, TerrainStyle
+from MAVProxy.modules.mavproxy_map3d.terrain import TerrainManager, R
+from MAVProxy.modules.mavproxy_map3d.elements import ElementManager
+
+import vtk
+
+
+class Map3DFrame(wx.Frame):
+    def __init__(self, state):
+        wx.Frame.__init__(self, None, -1, state.title,
+                          size=(state.width, state.height))
+        self.state = state
+        self.terrain = None
+        self.elements = None
+        self.tc = None
+        self.mt = None
+        self.follow = False
+        self.last_vehicle = None
+
+        self.widget = wxVTKRenderWindowInteractor(self, -1)
+        self.widget.Enable(1)
+        self.ren = vtk.vtkRenderer()
+        self.ren.SetBackground(0.45, 0.62, 0.85)
+        self.widget.GetRenderWindow().AddRenderer(self.ren)
+
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        sizer.Add(self.widget, 1, wx.EXPAND)
+        self.SetSizer(sizer)
+
+        self.timer = wx.Timer(self)
+        self.Bind(wx.EVT_TIMER, self.on_timer, self.timer)
+        self.timer.Start(100)
+        self.Bind(wx.EVT_CLOSE, self.on_close)
+
+    # ----------------------------------------------------------------- scene
+    def init_scene(self, lat0, lon0, amsl_ref):
+        self.mt = mp_tile.MPTile(service=self.state.service, tile_delay=0.02)
+        self.terrain = TerrainManager(self.ren, self.mt, lat0, lon0,
+                                      zexag=self.state.zexag,
+                                      screen_h=self.GetClientSize()[1] or self.state.height)
+        self.elements = ElementManager(self.ren, lat0, lon0, self.state.zexag)
+        self.elements.set_home(amsl_ref)
+        span = 4000.0
+        self.tc = TerrainCamera(self.ren.GetActiveCamera(),
+                                focal=(0.0, 0.0, amsl_ref * self.state.zexag),
+                                dist=1.6 * span, yaw=0.0, pitch=30.0)
+        style = TerrainStyle(self.tc, on_change=self.on_camera_change)
+        self.widget.SetInteractorStyle(style)
+        self.terrain.update(self.tc)
+
+    def on_camera_change(self):
+        if self.terrain:
+            self.terrain.update(self.tc)
+        self.render()
+
+    def render(self):
+        self.widget.GetRenderWindow().Render()
+
+    def look_at_latlon(self, lat, lon, amsl, dist=None):
+        e = math.radians(lon - self.terrain.lon0) * R * math.cos(math.radians(self.terrain.lat0))
+        n = math.radians(lat - self.terrain.lat0) * R
+        u = amsl * self.state.zexag
+        self.tc.look_at((e, n, u), dist=dist)
+        self.on_camera_change()
+
+    # --------------------------------------------------------------- messages
+    def handle(self, msg):
+        kind = msg[0]
+        if kind == 'origin':
+            if self.terrain is None:
+                self.init_scene(msg[1], msg[2], msg[3])
+        if self.terrain is None:
+            return
+        if kind == 'home':
+            self.elements.set_home(msg[1])
+        elif kind == 'vehicle':
+            (_, lat, lon, amsl, roll, pitch, yaw) = msg
+            enu = self.elements.set_vehicle(lat, lon, amsl, roll, pitch, yaw)
+            self.elements.add_trail_point(lat, lon, amsl)
+            self.last_vehicle = (lat, lon, amsl)
+            if self.follow:
+                self.tc.look_at((enu[0], enu[1], enu[2]))
+                self.terrain.update(self.tc)
+        elif kind == 'path':
+            self.elements.set_path(msg[1])
+        elif kind == 'mission':
+            self.elements.set_mission(msg[1])
+        elif kind == 'fence':
+            self.elements.set_fence(msg[1])
+        elif kind == 'rally':
+            self.elements.set_rally(msg[1])
+        elif kind == 'lookat':
+            (_, lat, lon, amsl, dist) = msg
+            self.look_at_latlon(lat, lon, amsl, dist)
+        elif kind == 'follow':
+            self.follow = msg[1]
+        elif kind == 'center':
+            if self.last_vehicle:
+                self.look_at_latlon(*self.last_vehicle)
+
+    def on_timer(self, event):
+        # drain parent messages
+        drained = False
+        for _ in range(200):
+            try:
+                msg = self.state.object_queue.get_nowait()
+            except queue.Empty:
+                break
+            self.handle(msg)
+            drained = True
+        # drain terrain worker results
+        if self.terrain is not None:
+            if self.terrain.process(self.tc):
+                drained = True
+        if drained:
+            self.render()
+        # close request from parent
+        if self.state.close_window.acquire(False):
+            self.timer.Stop()
+            self.Close()
+
+    def on_close(self, event):
+        if self.terrain is not None:
+            self.terrain.shutdown()
+        self.Destroy()

--- a/MAVProxy/modules/mavproxy_map3d/map3d_ui.py
+++ b/MAVProxy/modules/mavproxy_map3d/map3d_ui.py
@@ -6,6 +6,7 @@ manager's async results, then renders.
 
 import math
 import queue
+import time
 
 from MAVProxy.modules.lib.wx_loader import wx
 from vtk.wx.wxVTKRenderWindowInteractor import wxVTKRenderWindowInteractor
@@ -16,6 +17,8 @@ from MAVProxy.modules.mavproxy_map3d.terrain import TerrainManager, R
 from MAVProxy.modules.mavproxy_map3d.elements import ElementManager
 
 import vtk
+
+KML_REFRESH_DELAY = 0.5
 
 
 class RenderSettingsDialog(wx.Dialog):
@@ -87,6 +90,9 @@ class Map3DFrame(wx.Frame):
         self.follow = bool(state.follow)
         self.last_vehicle = None
         self.last_vehicle_pose = None
+        self.kml_features = []
+        self.kml_refresh_due = None
+        self.overlay_mesh_revision = -1
         self.fpv_enabled = False
         self.fpv_fov = min(150.0, max(20.0, float(state.fpvfov)))
         self.terrain_brightness = min(
@@ -148,6 +154,10 @@ class Map3DFrame(wx.Frame):
         self.elements = ElementManager(self.ren, lat0, lon0, self.state.zexag)
         self.elements.set_terrain_height(self.terrain.height_at)
         self.elements.set_home(amsl_ref)
+        self.elements.set_kml(self.kml_features, self.terrain.height_at,
+                              refresh=False)
+        self.overlay_mesh_revision = self.terrain.mesh_revision
+        self.schedule_kml_refresh()
         span = 4000.0
         self.tc = TerrainCamera(self.ren.GetActiveCamera(),
                                 focal=(0.0, 0.0, amsl_ref * self.state.zexag),
@@ -169,6 +179,12 @@ class Map3DFrame(wx.Frame):
 
     def on_follow_toggle(self, event):
         self.set_follow_enabled(self.follow_button.GetValue(), notify=True)
+
+    def schedule_kml_refresh(self):
+        if self.elements is None or not self.kml_features:
+            self.kml_refresh_due = None
+            return
+        self.kml_refresh_due = time.monotonic() + KML_REFRESH_DELAY
 
     def render_settings(self):
         return (self.terrain_brightness, self.terrain_shading,
@@ -229,18 +245,41 @@ class Map3DFrame(wx.Frame):
                 self.tc.look_at(focal, dist=dist, yaw=yaw, pitch=pitch)
                 camera.SetViewAngle(fov)
                 self.saved_map_view = None
-            if self.follow and self.last_vehicle is not None:
-                self.look_at_latlon(*self.last_vehicle)
-            else:
-                self.on_camera_change()
+            if self.follow and self.elements is not None:
+                self.follow_vehicle(self.elements.refresh_vehicle())
+            self.on_camera_change()
 
     def set_follow_enabled(self, enable, notify=False):
         self.follow = bool(enable)
         self.follow_button.SetValue(self.follow)
-        if self.follow and not self.fpv_enabled and self.last_vehicle is not None:
-            self.look_at_latlon(*self.last_vehicle)
+        if self.follow and not self.fpv_enabled and self.elements is not None:
+            if self.follow_vehicle(self.elements.refresh_vehicle()):
+                self.on_camera_change()
         if notify:
             self.state.event_queue.put(('follow', self.follow))
+
+    def vehicle_in_follow_region(self, vehicle_enu):
+        '''Match the 2D map follow dead zone: the middle half of the view.'''
+        if vehicle_enu is None:
+            return False
+        width, height = self.ren.GetSize()
+        if width <= 0 or height <= 0:
+            return False
+        self.ren.SetWorldPoint(*vehicle_enu, 1.0)
+        self.ren.WorldToDisplay()
+        px, py, depth = self.ren.GetDisplayPoint()
+        ratio = 0.25
+        return (0.0 <= depth <= 1.0 and
+                ratio * width < px < (1.0 - ratio) * width and
+                ratio * height < py < (1.0 - ratio) * height)
+
+    def follow_vehicle(self, vehicle_enu):
+        '''Recenter only after the vehicle leaves the central follow region.'''
+        if (not self.follow or self.fpv_enabled or vehicle_enu is None or
+                self.vehicle_in_follow_region(vehicle_enu)):
+            return False
+        self.tc.look_at(vehicle_enu)
+        return True
 
     def set_fpv_fov(self, fov):
         self.fpv_fov = min(150.0, max(20.0, float(fov)))
@@ -285,6 +324,13 @@ class Map3DFrame(wx.Frame):
         if kind == 'follow':
             self.set_follow_enabled(msg[1])
             return
+        if kind == 'kml':
+            self.kml_features = list(msg[1])
+            if self.elements is not None:
+                self.elements.set_kml(self.kml_features,
+                                      self.terrain.height_at, refresh=False)
+                self.schedule_kml_refresh()
+            return
         if kind == 'origin':
             if self.terrain is None:
                 self.init_scene(msg[1], msg[2], msg[3])
@@ -300,8 +346,7 @@ class Map3DFrame(wx.Frame):
             self.last_vehicle_pose = (lat, lon, amsl, roll, pitch, yaw)
             if self.fpv_enabled:
                 self.update_fpv_camera(enu)
-            elif self.follow:
-                self.tc.look_at((enu[0], enu[1], enu[2]))
+            elif self.follow_vehicle(enu):
                 self.terrain.update(self.tc)
         elif kind == 'path':
             self.elements.set_path(msg[1])
@@ -332,14 +377,24 @@ class Map3DFrame(wx.Frame):
             drained = True
         # drain terrain worker results
         if self.terrain is not None:
-            if self.terrain.process(self.tc):
+            terrain_changed = self.terrain.process(self.tc)
+            if self.terrain.mesh_revision != self.overlay_mesh_revision:
+                self.overlay_mesh_revision = self.terrain.mesh_revision
                 self.elements.refresh_fence(self.terrain.height_at)
+                self.schedule_kml_refresh()
+                drained = True
+            if terrain_changed:
                 vehicle_enu = self.elements.refresh_vehicle()
                 if self.fpv_enabled:
                     self.update_fpv_camera(vehicle_enu)
                 if self.status_actor is not None and self.terrain.tiles:
                     self.ren.RemoveActor2D(self.status_actor)
                     self.status_actor = None
+                drained = True
+            if (self.kml_refresh_due is not None and
+                    time.monotonic() >= self.kml_refresh_due):
+                self.kml_refresh_due = None
+                self.elements.refresh_kml(self.terrain.height_at)
                 drained = True
         if drained:
             self.render()

--- a/MAVProxy/modules/mavproxy_map3d/map3d_ui.py
+++ b/MAVProxy/modules/mavproxy_map3d/map3d_ui.py
@@ -18,6 +18,63 @@ from MAVProxy.modules.mavproxy_map3d.elements import ElementManager
 import vtk
 
 
+class RenderSettingsDialog(wx.Dialog):
+    def __init__(self, parent, values, on_preview):
+        wx.Dialog.__init__(self, parent, title="3D Render Settings")
+        self.on_preview = on_preview
+        brightness, shading, wireframe, fpvfov = values
+
+        self.brightness = wx.Slider(
+            self, -1, int(round(brightness * 100.0)), 25, 200,
+            style=wx.SL_HORIZONTAL | wx.SL_LABELS)
+        self.shading = wx.CheckBox(self, -1, "Enable terrain lighting")
+        self.shading.SetValue(shading)
+        self.wireframe = wx.CheckBox(self, -1, "Render terrain as wireframe")
+        self.wireframe.SetValue(wireframe)
+        self.fpvfov = wx.SpinCtrlDouble(self, -1, min=20.0, max=150.0,
+                                        inc=5.0)
+        self.fpvfov.SetDigits(1)
+        self.fpvfov.SetValue(fpvfov)
+
+        grid = wx.FlexGridSizer(4, 2, 8, 12)
+        grid.Add(wx.StaticText(self, -1, "Terrain brightness"), 0,
+                 wx.ALIGN_CENTER_VERTICAL)
+        grid.Add(self.brightness, 1, wx.EXPAND)
+        grid.Add(wx.StaticText(self, -1, "Terrain shading"), 0,
+                 wx.ALIGN_CENTER_VERTICAL)
+        grid.Add(self.shading, 0, wx.ALIGN_CENTER_VERTICAL)
+        grid.Add(wx.StaticText(self, -1, "Terrain geometry"), 0,
+                 wx.ALIGN_CENTER_VERTICAL)
+        grid.Add(self.wireframe, 0, wx.ALIGN_CENTER_VERTICAL)
+        grid.Add(wx.StaticText(self, -1, "FPV field of view (degrees)"), 0,
+                 wx.ALIGN_CENTER_VERTICAL)
+        grid.Add(self.fpvfov, 0, wx.EXPAND)
+        grid.AddGrowableCol(1, 1)
+
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        sizer.Add(grid, 1, wx.ALL | wx.EXPAND, 12)
+        sizer.Add(self.CreateButtonSizer(wx.OK | wx.CANCEL), 0,
+                  wx.ALL | wx.ALIGN_RIGHT, 8)
+        self.SetSizerAndFit(sizer)
+        self.SetMinSize((480, self.GetSize()[1]))
+        self.CentreOnParent()
+
+        self.Bind(wx.EVT_SLIDER, self.on_control, self.brightness)
+        self.Bind(wx.EVT_CHECKBOX, self.on_control, self.shading)
+        self.Bind(wx.EVT_CHECKBOX, self.on_control, self.wireframe)
+        self.Bind(wx.EVT_SPINCTRLDOUBLE, self.on_control, self.fpvfov)
+
+    def values(self):
+        return (self.brightness.GetValue() / 100.0,
+                self.shading.GetValue(),
+                self.wireframe.GetValue(),
+                self.fpvfov.GetValue())
+
+    def on_control(self, event):
+        self.on_preview(self.values())
+        event.Skip()
+
+
 class Map3DFrame(wx.Frame):
     def __init__(self, state):
         wx.Frame.__init__(self, None, -1, state.title,
@@ -27,16 +84,49 @@ class Map3DFrame(wx.Frame):
         self.elements = None
         self.tc = None
         self.mt = None
-        self.follow = False
+        self.follow = bool(state.follow)
         self.last_vehicle = None
+        self.last_vehicle_pose = None
+        self.fpv_enabled = False
+        self.fpv_fov = min(150.0, max(20.0, float(state.fpvfov)))
+        self.terrain_brightness = min(
+            2.0, max(0.25, float(state.terrain_brightness)))
+        self.terrain_shading = bool(state.terrain_shading)
+        self.terrain_wireframe = bool(state.terrain_wireframe)
+        self.saved_map_view = None
 
         self.widget = wxVTKRenderWindowInteractor(self, -1)
         self.widget.Enable(1)
         self.ren = vtk.vtkRenderer()
         self.ren.SetBackground(0.45, 0.62, 0.85)
         self.widget.GetRenderWindow().AddRenderer(self.ren)
+        self.status_actor = vtk.vtkTextActor()
+        self.status_actor.SetInput("Waiting for vehicle position...")
+        self.status_actor.SetPosition(20, 20)
+        self.status_actor.GetTextProperty().SetFontSize(18)
+        self.status_actor.GetTextProperty().SetColor(1.0, 1.0, 1.0)
+        self.ren.AddActor2D(self.status_actor)
+        self.initial_render = True
 
         sizer = wx.BoxSizer(wx.VERTICAL)
+        controls = wx.BoxSizer(wx.HORIZONTAL)
+        self.follow_button = wx.ToggleButton(self, -1, "Follow")
+        self.follow_button.SetValue(self.follow)
+        self.follow_button.SetToolTip("Keep the normal 3D view on the aircraft")
+        self.Bind(wx.EVT_TOGGLEBUTTON, self.on_follow_toggle,
+                  self.follow_button)
+        controls.Add(self.follow_button, 0, wx.ALL, 4)
+        self.fpv_button = wx.ToggleButton(self, -1, "FPV View")
+        self.fpv_button.SetToolTip("Toggle level-horizon first-person view")
+        self.Bind(wx.EVT_TOGGLEBUTTON, self.on_fpv_toggle, self.fpv_button)
+        controls.Add(self.fpv_button, 0, wx.ALL, 4)
+        gear = wx.ArtProvider.GetBitmap(wx.ART_HELP_SETTINGS, wx.ART_BUTTON,
+                                        (16, 16))
+        self.settings_button = wx.BitmapButton(self, -1, gear)
+        self.settings_button.SetToolTip("3D render settings")
+        self.Bind(wx.EVT_BUTTON, self.on_settings, self.settings_button)
+        controls.Add(self.settings_button, 0, wx.ALL, 4)
+        sizer.Add(controls, 0, wx.EXPAND)
         sizer.Add(self.widget, 1, wx.EXPAND)
         self.SetSizer(sizer)
 
@@ -47,19 +137,129 @@ class Map3DFrame(wx.Frame):
 
     # ----------------------------------------------------------------- scene
     def init_scene(self, lat0, lon0, amsl_ref):
+        self.status_actor.SetInput("Loading terrain...")
         self.mt = mp_tile.MPTile(service=self.state.service, tile_delay=0.02)
         self.terrain = TerrainManager(self.ren, self.mt, lat0, lon0,
                                       zexag=self.state.zexag,
-                                      screen_h=self.GetClientSize()[1] or self.state.height)
+                                      screen_h=self.GetClientSize()[1] or self.state.height,
+                                      brightness=self.terrain_brightness,
+                                      shading=self.terrain_shading,
+                                      wireframe=self.terrain_wireframe)
         self.elements = ElementManager(self.ren, lat0, lon0, self.state.zexag)
+        self.elements.set_terrain_height(self.terrain.height_at)
         self.elements.set_home(amsl_ref)
         span = 4000.0
         self.tc = TerrainCamera(self.ren.GetActiveCamera(),
                                 focal=(0.0, 0.0, amsl_ref * self.state.zexag),
                                 dist=1.6 * span, yaw=0.0, pitch=30.0)
-        style = TerrainStyle(self.tc, on_change=self.on_camera_change)
-        self.widget.SetInteractorStyle(style)
+        self.style = TerrainStyle(self.tc, on_change=self.on_camera_change)
+        self.widget.SetInteractorStyle(self.style)
+        if self.fpv_enabled:
+            camera = self.ren.GetActiveCamera()
+            self.saved_map_view = (list(self.tc.focal), self.tc.dist,
+                                   self.tc.yaw, self.tc.pitch,
+                                   camera.GetViewAngle())
+            self.style.interaction_enabled = False
+            self.elements.set_vehicle_visible(False)
+            camera.SetViewAngle(self.fpv_fov)
         self.terrain.update(self.tc)
+
+    def on_fpv_toggle(self, event):
+        self.set_fpv_enabled(self.fpv_button.GetValue())
+
+    def on_follow_toggle(self, event):
+        self.set_follow_enabled(self.follow_button.GetValue(), notify=True)
+
+    def render_settings(self):
+        return (self.terrain_brightness, self.terrain_shading,
+                self.terrain_wireframe, self.fpv_fov)
+
+    def apply_render_settings(self, values, notify=False):
+        brightness, shading, wireframe, fpvfov = values
+        self.terrain_brightness = min(2.0, max(0.25, float(brightness)))
+        self.terrain_shading = bool(shading)
+        self.terrain_wireframe = bool(wireframe)
+        self.set_fpv_fov(fpvfov)
+        if self.terrain is not None:
+            self.terrain.set_render_settings(
+                self.terrain_brightness, self.terrain_shading,
+                self.terrain_wireframe)
+            self.render()
+        if notify:
+            self.state.event_queue.put(
+                ('render_settings', self.terrain_brightness,
+                 self.terrain_shading, self.terrain_wireframe, self.fpv_fov))
+
+    def on_settings(self, event):
+        original = self.render_settings()
+        dialog = RenderSettingsDialog(
+            self, original,
+            lambda values: self.apply_render_settings(values, notify=False))
+        result = dialog.ShowModal()
+        if result == wx.ID_OK:
+            self.apply_render_settings(dialog.values(), notify=True)
+        else:
+            self.apply_render_settings(original, notify=False)
+        dialog.Destroy()
+
+    def set_fpv_enabled(self, enable):
+        enable = bool(enable)
+        if enable == self.fpv_enabled:
+            return
+        self.fpv_enabled = enable
+        self.fpv_button.SetValue(enable)
+        self.follow_button.Enable(not enable)
+        if self.elements is not None:
+            self.elements.set_vehicle_visible(not enable)
+        if self.tc is None:
+            return
+
+        camera = self.ren.GetActiveCamera()
+        if enable:
+            self.saved_map_view = (list(self.tc.focal), self.tc.dist,
+                                   self.tc.yaw, self.tc.pitch,
+                                   camera.GetViewAngle())
+            self.style.interaction_enabled = False
+            camera.SetViewAngle(self.fpv_fov)
+            self.update_fpv_camera()
+        else:
+            self.style.interaction_enabled = True
+            if self.saved_map_view is not None:
+                focal, dist, yaw, pitch, fov = self.saved_map_view
+                self.tc.look_at(focal, dist=dist, yaw=yaw, pitch=pitch)
+                camera.SetViewAngle(fov)
+                self.saved_map_view = None
+            if self.follow and self.last_vehicle is not None:
+                self.look_at_latlon(*self.last_vehicle)
+            else:
+                self.on_camera_change()
+
+    def set_follow_enabled(self, enable, notify=False):
+        self.follow = bool(enable)
+        self.follow_button.SetValue(self.follow)
+        if self.follow and not self.fpv_enabled and self.last_vehicle is not None:
+            self.look_at_latlon(*self.last_vehicle)
+        if notify:
+            self.state.event_queue.put(('follow', self.follow))
+
+    def set_fpv_fov(self, fov):
+        self.fpv_fov = min(150.0, max(20.0, float(fov)))
+        if self.fpv_enabled and self.tc is not None:
+            self.ren.GetActiveCamera().SetViewAngle(self.fpv_fov)
+            self.render()
+
+    def update_fpv_camera(self, vehicle_enu=None):
+        if not self.fpv_enabled or self.tc is None or self.last_vehicle_pose is None:
+            return
+        if vehicle_enu is None:
+            vehicle_enu = self.elements.refresh_vehicle()
+        if vehicle_enu is None:
+            return
+        (_, _, _, _roll, pitch, yaw) = self.last_vehicle_pose
+        self.tc.set_fpv(vehicle_enu, yaw, pitch)
+        self.ren.GetActiveCamera().SetViewAngle(self.fpv_fov)
+        self.terrain.update(self.tc)
+        self.render()
 
     def on_camera_change(self):
         if self.terrain:
@@ -79,6 +279,12 @@ class Map3DFrame(wx.Frame):
     # --------------------------------------------------------------- messages
     def handle(self, msg):
         kind = msg[0]
+        if kind == 'fpvfov':
+            self.set_fpv_fov(msg[1])
+            return
+        if kind == 'follow':
+            self.set_follow_enabled(msg[1])
+            return
         if kind == 'origin':
             if self.terrain is None:
                 self.init_scene(msg[1], msg[2], msg[3])
@@ -91,7 +297,10 @@ class Map3DFrame(wx.Frame):
             enu = self.elements.set_vehicle(lat, lon, amsl, roll, pitch, yaw)
             self.elements.add_trail_point(lat, lon, amsl)
             self.last_vehicle = (lat, lon, amsl)
-            if self.follow:
+            self.last_vehicle_pose = (lat, lon, amsl, roll, pitch, yaw)
+            if self.fpv_enabled:
+                self.update_fpv_camera(enu)
+            elif self.follow:
                 self.tc.look_at((enu[0], enu[1], enu[2]))
                 self.terrain.update(self.tc)
         elif kind == 'path':
@@ -99,21 +308,21 @@ class Map3DFrame(wx.Frame):
         elif kind == 'mission':
             self.elements.set_mission(msg[1])
         elif kind == 'fence':
-            self.elements.set_fence(msg[1])
+            self.elements.set_fence(msg[1], self.terrain.height_at)
         elif kind == 'rally':
             self.elements.set_rally(msg[1])
         elif kind == 'lookat':
             (_, lat, lon, amsl, dist) = msg
-            self.look_at_latlon(lat, lon, amsl, dist)
-        elif kind == 'follow':
-            self.follow = msg[1]
+            if not self.fpv_enabled:
+                self.look_at_latlon(lat, lon, amsl, dist)
         elif kind == 'center':
             if self.last_vehicle:
                 self.look_at_latlon(*self.last_vehicle)
 
     def on_timer(self, event):
         # drain parent messages
-        drained = False
+        drained = self.initial_render
+        self.initial_render = False
         for _ in range(200):
             try:
                 msg = self.state.object_queue.get_nowait()
@@ -124,6 +333,13 @@ class Map3DFrame(wx.Frame):
         # drain terrain worker results
         if self.terrain is not None:
             if self.terrain.process(self.tc):
+                self.elements.refresh_fence(self.terrain.height_at)
+                vehicle_enu = self.elements.refresh_vehicle()
+                if self.fpv_enabled:
+                    self.update_fpv_camera(vehicle_enu)
+                if self.status_actor is not None and self.terrain.tiles:
+                    self.ren.RemoveActor2D(self.status_actor)
+                    self.status_actor = None
                 drained = True
         if drained:
             self.render()

--- a/MAVProxy/modules/mavproxy_map3d/requirements.txt
+++ b/MAVProxy/modules/mavproxy_map3d/requirements.txt
@@ -1,0 +1,4 @@
+# Optional dependencies for the 3D map module (mavproxy_map3d).
+# Install with:  pip install vtk quantized-mesh-tile
+vtk>=9.2
+quantized-mesh-tile>=0.7.0

--- a/MAVProxy/modules/mavproxy_map3d/terrain.py
+++ b/MAVProxy/modules/mavproxy_map3d/terrain.py
@@ -1,0 +1,374 @@
+'''
+Async terrain manager for the 3D map.
+
+Fetches ArduPilot quantized-mesh terrain tiles, decodes them, and drapes
+satellite imagery (via mp_tile) over them with view-dependent texture LOD.
+Network + decode + imagery happen on a background worker thread; VTK object
+creation happens on the main GUI thread (drained via process()).
+'''
+
+import math
+import os
+import queue
+import threading
+import urllib.request
+
+import numpy as np
+import vtk
+from vtk.util import numpy_support
+
+from quantized_mesh_tile import decode as qmt_decode
+from quantized_mesh_tile.global_geodetic import GlobalGeodetic
+
+from MAVProxy.modules.mavproxy_map import mp_tile
+
+R = 6378137.0
+QUANTIZED_BASE = "https://plot.ardupilot.org/quantized"
+CACHE_DIR = os.path.join(os.environ.get("HOME", "."), ".tilecache", "quantized")
+
+
+def enu(lat, lon, h, lat0, lon0):
+    e = math.radians(lon - lon0) * R * math.cos(math.radians(lat0))
+    n = math.radians(lat - lat0) * R
+    return e, n, h
+
+
+def np_rgb_to_texture(img):
+    h, w = img.shape[:2]
+    flat = np.ascontiguousarray(img[::-1])    # vtkImageData origin is bottom-left
+    vimg = vtk.vtkImageData()
+    vimg.SetDimensions(w, h, 1)
+    arr = numpy_support.numpy_to_vtk(flat.reshape(-1, 3), deep=1,
+                                     array_type=vtk.VTK_UNSIGNED_CHAR)
+    arr.SetNumberOfComponents(3)
+    vimg.GetPointData().SetScalars(arr)
+    tex = vtk.vtkTexture()
+    tex.SetInputData(vimg)
+    tex.InterpolateOn()
+    tex.EdgeClampOn()
+    return tex
+
+
+def fetch_terrain_tile(z, x, y):
+    path = os.path.join(CACHE_DIR, str(z), str(x), "%d.terrain" % y)
+    if not os.path.exists(path):
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        url = "%s/%d/%d/%d.terrain" % (QUANTIZED_BASE, z, x, y)
+        req = urllib.request.Request(url, headers={"Accept": "application/octet-stream"})
+        data = urllib.request.urlopen(req, timeout=30).read()
+        with open(path, "wb") as f:
+            f.write(data)
+    with open(path, "rb") as f:
+        gz = f.read(2) == b"\x1f\x8b"
+    return path, gz
+
+
+def decode_terrain(z, x, y):
+    '''worker-safe: return dict(bbox, verts, idx) using numpy only'''
+    g = GlobalGeodetic(True)
+    bbox = g.TileBounds(x, y, z)
+    path, gz = fetch_terrain_tile(z, x, y)
+    tile = qmt_decode(path, bbox, gzipped=gz)
+    verts = np.array(tile.getVerticesCoordinates())
+    nv = len(verts)
+    mask = 0xFFFF if nv <= 0x10000 else 0xFFFFFFFF
+    idx = (np.array(tile.indices) & mask).astype(np.int64).reshape(-1, 3)
+    return {"bbox": bbox, "verts": verts, "idx": idx}
+
+
+_sample_cache = {}
+
+
+def sample_terrain(lat, lon, zoom=12):
+    '''return terrain elevation (m AMSL) at lat/lon from the quantized mesh
+    (same source we render), or None. Decoded tiles are cached. Assumes the
+    regular grid mesh ArduPilot publishes; falls back to the tile mean for a
+    non-grid tile.'''
+    g = GlobalGeodetic(True)
+    x, y = g.LonLatToTile(lon, lat, zoom)
+    key = (zoom, x, y)
+    dec = _sample_cache.get(key)
+    if dec is None:
+        try:
+            dec = decode_terrain(zoom, x, y)
+        except Exception:
+            return None
+        _sample_cache[key] = dec
+    (W, S, E, N) = dec["bbox"]
+    verts = dec["verts"]
+    n = int(round(len(verts) ** 0.5))
+    if n * n != len(verts) or E == W or N == S:
+        return float(np.mean(verts[:, 2]))
+    # vertex grid is row-major, row 0 = north edge, col 0 = west edge
+    fx = min(n - 1, max(0.0, (lon - W) / (E - W) * (n - 1)))
+    fy = min(n - 1, max(0.0, (N - lat) / (N - S) * (n - 1)))
+    x0, y0 = int(fx), int(fy)
+    x1, y1 = min(n - 1, x0 + 1), min(n - 1, y0 + 1)
+    tx, ty = fx - x0, fy - y0
+    h = verts[:, 2]
+    top = h[y0 * n + x0] * (1 - tx) + h[y0 * n + x1] * tx
+    bot = h[y1 * n + x0] * (1 - tx) + h[y1 * n + x1] * tx
+    return float(top * (1 - ty) + bot * ty)
+
+
+def lod_tile_set(g, z_fine, fx0, fx1, fy0, fy1, z_min, ring):
+    '''nested quadtree LOD: fine tiles, then coarser rings. Returns set of (z,x,y)'''
+    out = set((z_fine, x, y)
+              for x in range(fx0, fx1 + 1) for y in range(fy0, fy1 + 1))
+    hx0, hx1, hy0, hy1 = fx0, fx1, fy0, fy1
+    z = z_fine
+    while z - 1 >= z_min:
+        z -= 1
+        skx0, skx1 = (hx0 + 1) // 2, (hx1 - 1) // 2
+        sky0, sky1 = (hy0 + 1) // 2, (hy1 - 1) // 2
+        ox0, ox1 = hx0 // 2 - ring, hx1 // 2 + ring
+        oy0, oy1 = hy0 // 2 - ring, hy1 // 2 + ring
+        for x in range(ox0, ox1 + 1):
+            for y in range(oy0, oy1 + 1):
+                if skx0 <= x <= skx1 and sky0 <= y <= sky1:
+                    continue
+                out.add((z, x, y))
+        hx0, hx1, hy0, hy1 = ox0, ox1, oy0, oy1
+    return out
+
+
+class Tile:
+    '''one terrain tile (main-thread VTK objects + view-dependent drape)'''
+    def __init__(self, decoded, lat0, lon0, zexag, z_offset):
+        self.bbox = decoded["bbox"]                 # (W,S,E,N)
+        self.verts = decoded["verts"]
+        idx = decoded["idx"]
+        self.zoff = z_offset
+        nv = len(self.verts)
+
+        pts = vtk.vtkPoints()
+        pts.SetNumberOfPoints(nv)
+        for i in range(nv):
+            lon, lat, h = self.verts[i]
+            e, n, u = enu(lat, lon, h, lat0, lon0)
+            pts.SetPoint(i, e, n, u * zexag + z_offset)
+        cells = vtk.vtkCellArray()
+        for tri in idx:
+            cells.InsertNextCell(3, [int(tri[0]), int(tri[1]), int(tri[2])])
+        clat = 0.5 * (self.bbox[1] + self.bbox[3])
+        clon = 0.5 * (self.bbox[0] + self.bbox[2])
+        ce, cn, cu = enu(clat, clon, float(np.mean(self.verts[:, 2])), lat0, lon0)
+        self.center = (ce, cn, cu * zexag + z_offset)
+
+        poly = vtk.vtkPolyData()
+        poly.SetPoints(pts)
+        poly.SetPolys(cells)
+        normals = vtk.vtkPolyDataNormals()
+        normals.SetInputData(poly)
+        normals.SplittingOff()
+        normals.Update()
+        self.geo = normals.GetOutput()
+        self.tcoords = vtk.vtkFloatArray()
+        self.tcoords.SetNumberOfComponents(2)
+        self.tcoords.SetNumberOfTuples(nv)
+        self.geo.GetPointData().SetTCoords(self.tcoords)
+        mapper = vtk.vtkPolyDataMapper()
+        mapper.SetInputData(self.geo)
+        self.actor = vtk.vtkActor()
+        self.actor.SetMapper(mapper)
+        self.actor.GetProperty().SetAmbient(0.35)
+        self.actor.GetProperty().SetDiffuse(0.8)
+        self.actor.GetProperty().SetColor(0.55, 0.6, 0.5)   # muted land until textured
+        self.tex_key = None     # currently applied drape key
+        self.want_key = None    # most recently requested drape key
+
+    def texture_request(self, campos, foclat, foclon, ext_m, screen_h, mt, fov_deg=30.0):
+        '''compute the desired drape (cheap, main thread). Returns (key, params)
+        or None if unchanged.'''
+        W, S, E, N = self.bbox
+        ext_lat = math.degrees(ext_m / R)
+        ext_lon = math.degrees(ext_m / (R * math.cos(math.radians(foclat))))
+        vw, ve = max(W, foclon - ext_lon), min(E, foclon + ext_lon)
+        vs, vn = max(S, foclat - ext_lat), min(N, foclat + ext_lat)
+        if ve <= vw or vn <= vs:
+            vw, ve, vs, vn = W, E, S, N
+        mid = 0.5 * (vn + vs)
+        dist = math.sqrt(sum((campos[i] - self.center[i]) ** 2 for i in range(3)))
+        gsd = max(0.3, dist * 2.0 * math.tan(math.radians(fov_deg) / 2.0) / screen_h)
+        img_zoom = int(round(math.log2(
+            2 * math.pi * R * math.cos(math.radians(mid)) / (gsd * 256))))
+        img_zoom = max(mt.min_zoom, min(mt.max_zoom, img_zoom))
+        sub_w_m = math.radians(ve - vw) * R * math.cos(math.radians(mid))
+        tex_w = min(1024, max(256, int(sub_w_m / gsd)))
+        key = (round(vw, 4), round(vs, 4), round(ve, 4), round(vn, 4), img_zoom, tex_w)
+        if key == self.tex_key:
+            return None
+        return key, (vw, vs, ve, vn, img_zoom, tex_w)
+
+    def apply_texture(self, img, vw, vs, ve, vn, tex_w, key):
+        '''main thread: attach the draped image and recompute UVs'''
+        dlon = math.radians(ve - vw)
+        C = tex_w / dlon
+        tex_h = img.shape[0]
+        myn = mp_tile.mercator_y(vn)
+        for i in range(len(self.verts)):
+            lon, lat, _ = self.verts[i]
+            x = C * math.radians(lon - vw)
+            y = C * (myn - mp_tile.mercator_y(lat))
+            u = min(1.0, max(0.0, x / tex_w))
+            v = min(1.0, max(0.0, 1.0 - y / tex_h))
+            self.tcoords.SetTuple2(i, u, v)
+        self.tcoords.Modified()
+        self.actor.SetTexture(np_rgb_to_texture(img))
+        self.tex_key = key
+
+
+def build_texture_image(mt, lock, vw, vs, ve, vn, img_zoom, tex_w):
+    '''worker thread: assemble the draped Mercator image for a sub-rect. Does NOT
+    block on downloads (mp_tile fetches imagery on its own thread); missing
+    imagery comes back as placeholders and is refreshed once downloads settle.'''
+    dlon = math.radians(ve - vw)
+    C = tex_w / dlon
+    tex_h = max(1, int(round(C * (mp_tile.mercator_y(vn) - mp_tile.mercator_y(vs)))))
+    gw = R * math.cos(math.radians(vn)) * dlon
+    with lock:   # mp_tile's in-memory cache is not thread-safe
+        img = mt.area_to_image(vn, vw, tex_w, tex_h, gw, zoom=img_zoom)
+    return img
+
+
+class TerrainManager:
+    def __init__(self, renderer, mt, lat0, lon0, zexag=1.0,
+                 zoom_fine=12, lod_min=8, ring=1, fine_radius=2, screen_h=800):
+        self.ren = renderer
+        self.mt = mt
+        self.lat0 = lat0
+        self.lon0 = lon0
+        self.zexag = zexag
+        self.zoom_fine = zoom_fine
+        self.lod_min = lod_min
+        self.ring = ring
+        self.fine_radius = fine_radius
+        self.screen_h = screen_h
+        self.g = GlobalGeodetic(True)
+        self.tiles = {}                 # (z,x,y) -> Tile
+        self.inflight = set()           # jobs queued/running
+        self.jobs = queue.Queue()
+        self.results = queue.Queue()
+        self.tex_lock = threading.Lock()
+        self.prev_pending = 0
+        self.last_tc = None
+        self.stop = False
+        self.workers = [threading.Thread(target=self._worker, daemon=True)
+                        for _ in range(6)]
+        for w in self.workers:
+            w.start()
+
+    def _worker(self):
+        while not self.stop:
+            try:
+                kind, jid, payload = self.jobs.get(timeout=0.2)
+            except queue.Empty:
+                continue
+            try:
+                if kind == "decode":
+                    (z, x, y) = payload
+                    self.results.put(("decode", jid, decode_terrain(z, x, y)))
+                elif kind == "texture":
+                    (_tilekey, _tkey, params) = payload
+                    (vw, vs, ve, vn, img_zoom, tex_w) = params
+                    img = build_texture_image(self.mt, self.tex_lock,
+                                              vw, vs, ve, vn, img_zoom, tex_w)
+                    self.results.put(("texture", jid, (img, payload)))
+            except Exception as e:
+                self.results.put(("error", jid, e))
+
+    def focal_latlon(self, tc):
+        foclat = self.lat0 + math.degrees(tc.focal[1] / R)
+        foclon = self.lon0 + math.degrees(tc.focal[0] / (R * math.cos(math.radians(self.lat0))))
+        return foclat, foclon
+
+    def desired_set(self, foclat, foclon):
+        fx, fy = self.g.LonLatToTile(foclon, foclat, self.zoom_fine)
+        r = self.fine_radius
+        z_min = self.lod_min if self.ring > 0 else self.zoom_fine
+        raw = lod_tile_set(self.g, self.zoom_fine, fx - r, fx + r, fy - r, fy + r,
+                           z_min, self.ring)
+        # clamp/wrap to the valid EPSG:4326 TMS tile range (y bounded, x wraps)
+        out = set()
+        for (z, x, y) in raw:
+            ny = self.g.GetNumberOfYTilesAtZoom(z)
+            nx = self.g.GetNumberOfXTilesAtZoom(z)
+            if y < 0 or y >= ny:
+                continue
+            out.add((z, x % nx, y))
+        return out
+
+    def update(self, tc):
+        '''called on camera settle: page in/out terrain + request textures'''
+        foclat, foclon = self.focal_latlon(tc)
+        want = self.desired_set(foclat, foclon)
+        # page in missing terrain
+        for (z, x, y) in want:
+            jid = ("D", z, x, y)
+            if (z, x, y) not in self.tiles and jid not in self.inflight:
+                self.inflight.add(jid)
+                self.jobs.put(("decode", jid, (z, x, y)))
+        # page out far tiles
+        for key in list(self.tiles.keys()):
+            if key not in want:
+                self.ren.RemoveActor(self.tiles[key].actor)
+                del self.tiles[key]
+        # request textures for present tiles (at most one outstanding per tile)
+        ext_m = tc.dist * 0.8
+        for key, tile in self.tiles.items():
+            req = tile.texture_request(tc.pos, foclat, foclon, ext_m, self.screen_h, self.mt)
+            if req is None:
+                continue
+            tkey, params = req
+            jid = ("T", key)
+            if jid in self.inflight:
+                continue
+            tile.want_key = tkey
+            self.inflight.add(jid)
+            self.jobs.put(("texture", jid, (key, tkey, params)))
+
+    def process(self, tc):
+        '''main thread: drain worker results, build/update VTK. Returns True if
+        anything changed (caller should render).'''
+        self.last_tc = tc
+        changed = False
+        # once imagery downloads settle, re-drape so placeholder tiles sharpen
+        pend = self.mt.tiles_pending()
+        if self.prev_pending > 0 and pend == 0:
+            for t in self.tiles.values():
+                t.tex_key = None
+            self.update(tc)
+        self.prev_pending = pend
+        want = self.desired_set(*self.focal_latlon(tc)) if tc is not None else None
+        for _ in range(64):
+            try:
+                kind, jid, payload = self.results.get_nowait()
+            except queue.Empty:
+                break
+            self.inflight.discard(jid)
+            if kind == "decode":
+                (z, x, y) = jid[1:]
+                if want is not None and (z, x, y) not in want:
+                    continue   # camera moved on; don't build a tile we'll drop
+                zoff = -(self.zoom_fine - z) * 3.0
+                try:
+                    tile = Tile(payload, self.lat0, self.lon0, self.zexag, zoff)
+                except Exception:
+                    continue
+                self.tiles[(z, x, y)] = tile
+                self.ren.AddActor(tile.actor)
+                changed = True
+            elif kind == "texture":
+                img, (tilekey, tkey, params) = payload
+                (vw, vs, ve, vn, img_zoom, tex_w) = params
+                tile = self.tiles.get(tilekey)
+                if tile is not None and tkey == tile.want_key:
+                    tile.apply_texture(img, vw, vs, ve, vn, tex_w, tkey)
+                    changed = True
+        # after building new tiles, request their textures next update
+        if changed and tc is not None:
+            self.update(tc)
+        return changed
+
+    def shutdown(self):
+        self.stop = True

--- a/MAVProxy/modules/mavproxy_map3d/terrain.py
+++ b/MAVProxy/modules/mavproxy_map3d/terrain.py
@@ -292,6 +292,7 @@ class TerrainManager:
         self.brightness = brightness
         self.shading = shading
         self.wireframe = wireframe
+        self.mesh_revision = 0
         self.g = GlobalGeodetic(True)
         self.tiles = {}                 # (z,x,y) -> Tile
         self.inflight = set()           # jobs queued/running
@@ -387,10 +388,14 @@ class TerrainManager:
                 self.inflight.add(jid)
                 self.jobs.put(("decode", jid, (z, x, y)))
         # page out far tiles
+        removed_tile = False
         for key in list(self.tiles.keys()):
             if key not in want:
                 self.ren.RemoveActor(self.tiles[key].actor)
                 del self.tiles[key]
+                removed_tile = True
+        if removed_tile:
+            self.mesh_revision += 1
         # request textures for present tiles (at most one outstanding per tile)
         fov_deg = tc.cam.GetViewAngle()
         for key, tile in self.tiles.items():
@@ -436,6 +441,7 @@ class TerrainManager:
                     continue
                 self.tiles[(z, x, y)] = tile
                 self.ren.AddActor(tile.actor)
+                self.mesh_revision += 1
                 changed = True
             elif kind == "texture":
                 img, (tilekey, tkey, params) = payload

--- a/MAVProxy/modules/mavproxy_map3d/terrain.py
+++ b/MAVProxy/modules/mavproxy_map3d/terrain.py
@@ -65,8 +65,12 @@ def fetch_terrain_tile(z, x, y):
         url = "%s/%d/%d/%d.terrain" % (QUANTIZED_BASE, z, x, y)
         req = urllib.request.Request(url, headers={"Accept": "application/octet-stream"})
         data = urllib.request.urlopen(req, timeout=30).read()
-        with open(path, "wb") as f:
+        # publish atomically under a unique name: the viewer child process and
+        # the module share this cache, so a reader must never see a partial tile
+        tmppath = "%s.tmp.%u.%u" % (path, os.getpid(), threading.get_ident())
+        with open(tmppath, "wb") as f:
             f.write(data)
+        os.replace(tmppath, path)
     with open(path, "rb") as f:
         gz = f.read(2) == b"\x1f\x8b"
     return path, gz

--- a/MAVProxy/modules/mavproxy_map3d/terrain.py
+++ b/MAVProxy/modules/mavproxy_map3d/terrain.py
@@ -88,16 +88,21 @@ def decode_terrain(z, x, y):
 _sample_cache = {}
 
 
-def sample_terrain(lat, lon, zoom=12):
+def sample_terrain(lat, lon, zoom=12, cache_only=False):
     '''return terrain elevation (m AMSL) at lat/lon from the quantized mesh
     (same source we render), or None. Decoded tiles are cached. Assumes the
     regular grid mesh ArduPilot publishes; falls back to the tile mean for a
-    non-grid tile.'''
+    non-grid tile.
+
+    cache_only returns None rather than fetching/decoding a missing tile, so
+    callers on a latency-sensitive thread can defer the work.'''
     g = GlobalGeodetic(True)
     x, y = g.LonLatToTile(lon, lat, zoom)
     key = (zoom, x, y)
     dec = _sample_cache.get(key)
     if dec is None:
+        if cache_only:
+            return None
         try:
             dec = decode_terrain(zoom, x, y)
         except Exception:

--- a/MAVProxy/modules/mavproxy_map3d/terrain.py
+++ b/MAVProxy/modules/mavproxy_map3d/terrain.py
@@ -12,6 +12,7 @@ import os
 import queue
 import threading
 import urllib.request
+import warnings
 
 import numpy as np
 import vtk
@@ -25,6 +26,14 @@ from MAVProxy.modules.mavproxy_map import mp_tile
 R = 6378137.0
 QUANTIZED_BASE = "https://plot.ardupilot.org/quantized"
 CACHE_DIR = os.path.join(os.environ.get("HOME", "."), ".tilecache", "quantized")
+
+# ArduPilot tiles include the optional lighting extension. This decoder warns
+# when it skips that extension, but map3d computes its own VTK normals anyway.
+warnings.filterwarnings(
+    "ignore",
+    message=r"Skipping unsupported terrain tile extension \(id=1, length=\d+ bytes\).*",
+    category=UserWarning,
+    module=r"quantized_mesh_tile\.terrain")
 
 
 def enu(lat, lon, h, lat0, lon0):
@@ -134,7 +143,8 @@ def lod_tile_set(g, z_fine, fx0, fx1, fy0, fy1, z_min, ring):
 
 class Tile:
     '''one terrain tile (main-thread VTK objects + view-dependent drape)'''
-    def __init__(self, decoded, lat0, lon0, zexag, z_offset):
+    def __init__(self, decoded, lat0, lon0, zexag, z_offset,
+                 brightness=1.25, shading=True, wireframe=False):
         self.bbox = decoded["bbox"]                 # (W,S,E,N)
         self.verts = decoded["verts"]
         idx = decoded["idx"]
@@ -163,6 +173,10 @@ class Tile:
         normals.SplittingOff()
         normals.Update()
         self.geo = normals.GetOutput()
+        self.locator = None
+        bounds = self.geo.GetBounds()
+        self.z_min = bounds[4]
+        self.z_max = bounds[5]
         self.tcoords = vtk.vtkFloatArray()
         self.tcoords.SetNumberOfComponents(2)
         self.tcoords.SetNumberOfTuples(nv)
@@ -171,34 +185,64 @@ class Tile:
         mapper.SetInputData(self.geo)
         self.actor = vtk.vtkActor()
         self.actor.SetMapper(mapper)
-        self.actor.GetProperty().SetAmbient(0.35)
-        self.actor.GetProperty().SetDiffuse(0.8)
-        self.actor.GetProperty().SetColor(0.55, 0.6, 0.5)   # muted land until textured
+        self.apply_render_settings(brightness, shading, wireframe)
         self.tex_key = None     # currently applied drape key
         self.want_key = None    # most recently requested drape key
 
-    def texture_request(self, campos, foclat, foclon, ext_m, screen_h, mt, fov_deg=30.0):
-        '''compute the desired drape (cheap, main thread). Returns (key, params)
-        or None if unchanged.'''
+    def apply_render_settings(self, brightness, shading, wireframe):
+        prop = self.actor.GetProperty()
+        brightness = min(2.0, max(0.25, float(brightness)))
+        prop.SetAmbient(min(1.0, 0.35 * brightness))
+        prop.SetDiffuse(min(1.0, 0.8 * brightness))
+        prop.SetColor(*(min(1.0, c * brightness)
+                        for c in (0.55, 0.6, 0.5)))
+        prop.SetLighting(bool(shading))
+        if shading:
+            prop.SetInterpolationToPhong()
+        if wireframe:
+            prop.SetRepresentationToWireframe()
+        else:
+            prop.SetRepresentationToSurface()
+
+    def height_at(self, e, n):
+        '''Return the rendered world Z at an east/north point, or None.'''
+        if self.locator is None:
+            self.locator = vtk.vtkStaticCellLocator()
+            self.locator.SetDataSet(self.geo)
+            self.locator.BuildLocator()
+        intersections = vtk.vtkPoints()
+        cell_ids = vtk.vtkIdList()
+        margin = max(1000.0, self.z_max - self.z_min)
+        found = self.locator.IntersectWithLine(
+            (e, n, self.z_max + margin),
+            (e, n, self.z_min - margin),
+            1.0e-6, intersections, cell_ids)
+        if not found or intersections.GetNumberOfPoints() == 0:
+            return None
+        return max(intersections.GetPoint(i)[2]
+                   for i in range(intersections.GetNumberOfPoints()))
+
+    def texture_request(self, campos, screen_h, mt, fov_deg=30.0):
+        '''Compute the desired full-tile drape (cheap, main thread).
+
+        A texture must cover the complete mesh tile. Applying imagery for only
+        the camera-visible subsection makes VTK clamp the texture coordinates
+        of the remaining vertices to an edge pixel, producing long stretched
+        streaks in low-angle and FPV views.
+        '''
         W, S, E, N = self.bbox
-        ext_lat = math.degrees(ext_m / R)
-        ext_lon = math.degrees(ext_m / (R * math.cos(math.radians(foclat))))
-        vw, ve = max(W, foclon - ext_lon), min(E, foclon + ext_lon)
-        vs, vn = max(S, foclat - ext_lat), min(N, foclat + ext_lat)
-        if ve <= vw or vn <= vs:
-            vw, ve, vs, vn = W, E, S, N
-        mid = 0.5 * (vn + vs)
+        mid = 0.5 * (N + S)
         dist = math.sqrt(sum((campos[i] - self.center[i]) ** 2 for i in range(3)))
         gsd = max(0.3, dist * 2.0 * math.tan(math.radians(fov_deg) / 2.0) / screen_h)
         img_zoom = int(round(math.log2(
             2 * math.pi * R * math.cos(math.radians(mid)) / (gsd * 256))))
         img_zoom = max(mt.min_zoom, min(mt.max_zoom, img_zoom))
-        sub_w_m = math.radians(ve - vw) * R * math.cos(math.radians(mid))
-        tex_w = min(1024, max(256, int(sub_w_m / gsd)))
-        key = (round(vw, 4), round(vs, 4), round(ve, 4), round(vn, 4), img_zoom, tex_w)
+        tile_w_m = math.radians(E - W) * R * math.cos(math.radians(mid))
+        tex_w = min(1024, max(256, int(tile_w_m / gsd)))
+        key = (img_zoom, tex_w)
         if key == self.tex_key:
             return None
-        return key, (vw, vs, ve, vn, img_zoom, tex_w)
+        return key, (W, S, E, N, img_zoom, tex_w)
 
     def apply_texture(self, img, vw, vs, ve, vn, tex_w, key):
         '''main thread: attach the draped image and recompute UVs'''
@@ -219,7 +263,7 @@ class Tile:
 
 
 def build_texture_image(mt, lock, vw, vs, ve, vn, img_zoom, tex_w):
-    '''worker thread: assemble the draped Mercator image for a sub-rect. Does NOT
+    '''worker thread: assemble the draped Mercator image for a tile. Does NOT
     block on downloads (mp_tile fetches imagery on its own thread); missing
     imagery comes back as placeholders and is refreshed once downloads settle.'''
     dlon = math.radians(ve - vw)
@@ -233,7 +277,8 @@ def build_texture_image(mt, lock, vw, vs, ve, vn, img_zoom, tex_w):
 
 class TerrainManager:
     def __init__(self, renderer, mt, lat0, lon0, zexag=1.0,
-                 zoom_fine=12, lod_min=8, ring=1, fine_radius=2, screen_h=800):
+                 zoom_fine=12, lod_min=8, ring=1, fine_radius=2, screen_h=800,
+                 brightness=1.25, shading=True, wireframe=False):
         self.ren = renderer
         self.mt = mt
         self.lat0 = lat0
@@ -244,6 +289,9 @@ class TerrainManager:
         self.ring = ring
         self.fine_radius = fine_radius
         self.screen_h = screen_h
+        self.brightness = brightness
+        self.shading = shading
+        self.wireframe = wireframe
         self.g = GlobalGeodetic(True)
         self.tiles = {}                 # (z,x,y) -> Tile
         self.inflight = set()           # jobs queued/running
@@ -257,6 +305,14 @@ class TerrainManager:
                         for _ in range(6)]
         for w in self.workers:
             w.start()
+
+    def set_render_settings(self, brightness, shading, wireframe):
+        self.brightness = min(2.0, max(0.25, float(brightness)))
+        self.shading = bool(shading)
+        self.wireframe = bool(wireframe)
+        for tile in self.tiles.values():
+            tile.apply_render_settings(self.brightness, self.shading,
+                                       self.wireframe)
 
     def _worker(self):
         while not self.stop:
@@ -298,12 +354,34 @@ class TerrainManager:
             out.add((z, x % nx, y))
         return out
 
+    def height_at(self, lat, lon):
+        '''Return rendered terrain world Z at lat/lon, preferring fine tiles.'''
+        e, n, _ = enu(lat, lon, 0.0, self.lat0, self.lon0)
+        for key, tile in sorted(self.tiles.items(), reverse=True):
+            west, south, east, north = tile.bbox
+            if not (west <= lon <= east and south <= lat <= north):
+                continue
+            height = tile.height_at(e, n)
+            if height is not None:
+                return height
+        return None
+
     def update(self, tc):
         '''called on camera settle: page in/out terrain + request textures'''
         foclat, foclon = self.focal_latlon(tc)
         want = self.desired_set(foclat, foclon)
         # page in missing terrain
-        for (z, x, y) in want:
+
+        def tile_priority(key):
+            z, x, y = key
+            west, south, east, north = self.g.TileBounds(x, y, z)
+            clat = 0.5 * (south + north)
+            clon = 0.5 * (west + east)
+            dlat = clat - foclat
+            dlon = (clon - foclon) * math.cos(math.radians(foclat))
+            return (-z, dlat * dlat + dlon * dlon)
+
+        for (z, x, y) in sorted(want, key=tile_priority):
             jid = ("D", z, x, y)
             if (z, x, y) not in self.tiles and jid not in self.inflight:
                 self.inflight.add(jid)
@@ -314,9 +392,9 @@ class TerrainManager:
                 self.ren.RemoveActor(self.tiles[key].actor)
                 del self.tiles[key]
         # request textures for present tiles (at most one outstanding per tile)
-        ext_m = tc.dist * 0.8
+        fov_deg = tc.cam.GetViewAngle()
         for key, tile in self.tiles.items():
-            req = tile.texture_request(tc.pos, foclat, foclon, ext_m, self.screen_h, self.mt)
+            req = tile.texture_request(tc.pos, self.screen_h, self.mt, fov_deg)
             if req is None:
                 continue
             tkey, params = req
@@ -352,7 +430,8 @@ class TerrainManager:
                     continue   # camera moved on; don't build a tile we'll drop
                 zoff = -(self.zoom_fine - z) * 3.0
                 try:
-                    tile = Tile(payload, self.lat0, self.lon0, self.zexag, zoff)
+                    tile = Tile(payload, self.lat0, self.lon0, self.zexag, zoff,
+                                self.brightness, self.shading, self.wireframe)
                 except Exception:
                     continue
                 self.tiles[(z, x, y)] = tile

--- a/MAVProxy/tools/MAVExplorer.py
+++ b/MAVProxy/tools/MAVExplorer.py
@@ -133,6 +133,7 @@ class MEState(object):
             "graphs"    : ['(PREDEFINED_GRAPH)'],
             "dump"      : ['(MESSAGETYPE)', '--verbose (MESSAGETYPE)'],
             "map"       : ['(VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE) (VARIABLE)'],
+            "map3d"     : [],
             "param"     : ['download', 'check', 'help (PARAMETER)', 'save', 'savechanged', 'diff', 'show', 'check'],
             "logmessage": ['download', 'help (MESSAGETYPE)'],
             "locationAnalysis"  : [],
@@ -654,6 +655,104 @@ def cmd_map(args):
             pass
     child.start()
     mestate.mlog.rewind()
+
+map3d_views = []
+
+def cmd_map3d(args):
+    '''show a 3D map view: draped satellite imagery over terrain'''
+    try:
+        from MAVProxy.modules.mavproxy_map3d.map3d import Map3D
+    except ImportError as ex:
+        print("map3d needs extra packages: pip install vtk quantized-mesh-tile (%s)" % ex)
+        return
+
+    mlog = mestate.mlog
+    path = []
+    mission = []
+    while True:
+        m = mlog.recv_match(type=['POS', 'CMD'], condition=mestate.settings.condition)
+        if m is None:
+            break
+        mtype = m.get_type()
+        if mtype == 'POS':
+            path.append((m.Lat, m.Lng, m.Alt))
+        elif mtype == 'CMD' and (m.Lat != 0 or m.Lng != 0):
+            mission.append((m.Lat, m.Lng, m.Alt, getattr(m, 'Frame', 3), m.CId, m.CNum))
+    mlog.rewind()
+
+    if len(path) == 0:
+        print("No POS messages found for 3D map")
+        return
+
+    # note: sum/min/max are shadowed in this namespace (mavextra import *), so
+    # accumulate explicitly
+    sumlat = sumlon = 0.0
+    minlat = maxlat = path[0][0]
+    minlon = maxlon = path[0][1]
+    ground0 = path[0][2]
+    for (la, lo, al) in path:
+        sumlat += la
+        sumlon += lo
+        if al < ground0:
+            ground0 = al
+        minlat = la if la < minlat else minlat
+        maxlat = la if la > maxlat else maxlat
+        minlon = lo if lo < minlon else minlon
+        maxlon = lo if lo > maxlon else maxlon
+    lat0 = sumlat / len(path)
+    lon0 = sumlon / len(path)
+    span_ns = mp_util.gps_distance(minlat, minlon, maxlat, minlon)
+    span_ew = mp_util.gps_distance(minlat, minlon, minlat, maxlon)
+    span = span_ns if span_ns > span_ew else span_ew
+    if span < 1000.0:
+        span = 1000.0
+
+    # resolve mission item altitudes to AMSL before sending. Terrain-frame
+    # waypoints (MAV_FRAME_GLOBAL_TERRAIN_ALT = 10/11) are "z above terrain", so
+    # they need the terrain elevation at the waypoint, not home + z.
+    if mission:
+        mission = resolve_mission_amsl(mission, ground0)
+
+    m3d = Map3D(title="MAVExplorer 3D Map")
+    map3d_views.append(m3d)
+    m3d.set_origin(lat0, lon0, ground0)
+    m3d.set_home(ground0)
+    m3d.set_path(path)
+    if mission:
+        m3d.set_mission(mission)
+    m3d.look_at(lat0, lon0, ground0, dist=1.6 * span)
+
+def resolve_mission_amsl(mission, ground0):
+    '''convert mission items to AMSL. mission items are
+    (lat, lon, z, frame, cmd, seq); returns items with frame 0 (AMSL).
+
+    Terrain-frame waypoints are resolved using the quantized terrain mesh (the
+    same source rendered in the 3D view), which is fetched per 1-degree tile and
+    cached, so it never stalls the command thread per waypoint.'''
+    # home AMSL: the home item (seq 0) altitude, else takeoff ground
+    home_amsl = ground0
+    for (la, lo, z, frame, cid, seq) in mission:
+        if seq == 0:
+            home_amsl = z
+            break
+    sampler = None
+    if any(frame in (10, 11) for (_, _, _, frame, _, _) in mission):
+        try:
+            from MAVProxy.modules.mavproxy_map3d.terrain import sample_terrain
+            sampler = sample_terrain
+        except Exception as ex:
+            print("map3d: terrain elevation unavailable (%s)" % ex)
+    out = []
+    for (la, lo, z, frame, cid, seq) in mission:
+        if frame in (0, 5):
+            amsl = z
+        elif frame in (10, 11):
+            terr = sampler(la, lo) if sampler is not None else None
+            amsl = (terr if terr is not None else home_amsl) + z
+        else:
+            amsl = home_amsl + z
+        out.append((la, lo, amsl, 0, cid, seq))
+    return out
 
 def cmd_set(args):
     '''control MAVExporer options'''
@@ -1764,6 +1863,7 @@ command_map = {
     'messages'   : (cmd_messages,  'show messages'),
     'devid'      : (cmd_devid,     'show device IDs'),
     'map'        : (cmd_map,       'show map view'),
+    'map3d'      : (cmd_map3d,     'show 3D map view'),
     'fft'        : (cmd_fft,       'show a FFT (if available)'),
     'loadLog'    : (cmd_loadfile,  'load a log file'),
     'stats'      : (cmd_stats,     'show statistics on the log'),

--- a/MAVProxy/tools/MAVExplorer.py
+++ b/MAVProxy/tools/MAVExplorer.py
@@ -713,6 +713,11 @@ def cmd_map3d(args):
     if mission:
         mission = resolve_mission_amsl(mission, ground0)
 
+    # drop views the user has already closed, so their child processes are reaped
+    for old in [v for v in map3d_views if not v.is_alive()]:
+        old.close()
+        map3d_views.remove(old)
+
     m3d = Map3D(title="MAVExplorer 3D Map")
     map3d_views.append(m3d)
     m3d.set_origin(lat0, lon0, ground0)

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ on how to use MAVProxy.''',
                 'MAVProxy.modules.mavproxy_anufireproject',
                 'MAVProxy.modules.mavproxy_fieldcheck',
                 'MAVProxy.modules.mavproxy_map',
+                'MAVProxy.modules.mavproxy_map3d',
                 'MAVProxy.modules.mavproxy_mmap',
                 'MAVProxy.modules.mavproxy_misseditor',
                 'MAVProxy.modules.mavproxy_paramedit',
@@ -97,6 +98,8 @@ on how to use MAVProxy.''',
       install_requires=requirements,
       extras_require={
         'cesium': ['tornado'],
+        # map3d module (native 3D terrain map)
+        'map3d': ['vtk', 'quantized-mesh-tile'],
         # restserver module
         'server': ['flask'],
         'recommended': ['flask', 'PyYAML', 'lxml', 'wxpython',


### PR DESCRIPTION
Add a 3D map that drapes satellite imagery over ArduPilot quantized-mesh terrain (https://plot.ardupilot.org/quantized/) rendered with VTK, showing the same elements as the 2D map (flight path, mission, fence, rally, vehicle) for both live telemetry and log review.

- terrain.py: background worker pool fetches/decodes quantized-mesh tiles and assembles draped imagery via mp_tile; VTK objects are built on the GUI thread. Nested quadtree LOD with distance-based, view-dependent texture zoom so detail sharpens as you zoom in; tiles re-drape once imagery downloads settle. sample_terrain() interpolates the mesh for terrain-relative altitudes.
- camera.py: Cesium-like camera/interactor with a permanently level horizon (yaw+pitch only, no roll), drag to pan, Ctrl+drag to rotate, wheel to zoom.
- elements.py: flight path, live trail, mission, fence, rally and vehicle actors in a shared local ENU frame, with altitude-frame handling.
- map3d.py / map3d_ui.py: parent handle + child wx/VTK viewer process, mirroring the mp_slipmap multiprocess pattern.
- __init__.py: Map3DModule with the 'map3d' command and a live MAVLink feed (vehicle pose/attitude, mission/fence/rally on change).
- map3d_test.py: standalone offscreen/GUI verification harness.

MAVExplorer gains a 'map3d' command for 3D log review, extracting the flight path (POS, with altitude) and mission (CMD) from the log; terrain-frame waypoints are resolved to AMSL via the quantized mesh.

Requires the optional packages vtk and quantized-mesh-tile (extras: map3d).