### PR TITLE
joystick: match Dual Action names reported by SDL >= 2.0.6

### DIFF
--- a/MAVProxy/modules/mavproxy_joystick/joysticks/logicool-f310.yml
+++ b/MAVProxy/modules/mavproxy_joystick/joysticks/logicool-f310.yml
@@ -2,6 +2,8 @@ description: >
   Support for the Logicool F310 joystick.
 match:
   - 'Logicool Logicool Dual Action'
+  # SDL >= 2.0.6 strips the duplicated vendor prefix from the name
+  - 'Logicool Dual Action'
 controls:
   - channel: 1
     type: axis

--- a/MAVProxy/modules/mavproxy_joystick/joysticks/logitech-dual-action.yml
+++ b/MAVProxy/modules/mavproxy_joystick/joysticks/logitech-dual-action.yml
@@ -2,6 +2,8 @@ description: >
   Support for the Logitech F310 joystick in "D" mode.
 match:
   - Logitech Logitech Dual Action
+  # SDL >= 2.0.6 strips the duplicated vendor prefix from the name
+  - Logitech Dual Action
 controls:
   - channel: 1
     type: axis


### PR DESCRIPTION
SDL 2.0.6 and later strip the duplicated vendor prefix from the device name, so the Logitech/Logicool F310 in DirectInput mode is reported as "Logicool Dual Action" / "Logitech Dual Action" and no longer matches the shipped definitions.  Add the new names alongside the old ones.