### PR TITLE
Make a clear command that clears the screen using a ANCI command

### DIFF
--- a/MAVProxy/modules/mavproxy_misc.py
+++ b/MAVProxy/modules/mavproxy_misc.py
@@ -120,6 +120,7 @@ class MiscModule(mp_module.MPModule):
 
         self.add_command('gear', self.cmd_landing_gear, "landing gear control")
 
+        self.add_command('clear', self.cmd_clear, "clears the terminal screen")
         self.repeats = []
 
         # support for changing altitude via command rather than mission item:
@@ -704,6 +705,16 @@ Alt: gear <extend|retract> [ID]'''
             DesiredState,
             0, 0, 0, 0, 0, 0
         )
+
+    def cmd_clear(self, args):
+        # https://stackoverflow.com/questions/2084508/clear-the-terminal-in-python
+        usage = "clear <|help>"
+        if len(args) != 0:
+            print(usage)
+            return
+        # This will only print if \033c breaks something this will make bug fixing easier
+        print("\033c") # this ANSI code will scroll up leaving the screen blank; history is kept
+        return
 
     def mavlink_packet(self, m):
         '''handle an incoming mavlink packet'''


### PR DESCRIPTION
I have made a clear command that will clear your screen by printing the ANCI escape sequence "\033c" to your screen with a print statement. I have also printed some debugging messages then cleared them so that the user can work out what went wrong.

I think that this feature is useful as I often reach for it and it doesn't exits but I understand that you may not want to maintain it so I understand that this may not get excepted.

# Tests
THIS SHOULD BE TESTED ON WINDOWS AND WSL
I have tested it on a mac in ghosty, and the mac os terminal and gnome-terminal
by running
MAV> clear
MAV> clear help
I also tested and confirms that auto complete works
% python scripts/run_flake8.py .  # this also passes

# Notes
This is one of my first commit to this project and so that I learn the code base I have used no AI in the whole process as this would have been trivial for claude to do.