### PR TITLE
Convert strings to unicode before passing to pymavlink

### DIFF
--- a/MAVProxy/modules/mavproxy_example.py
+++ b/MAVProxy/modules/mavproxy_example.py
@@ -79,7 +79,7 @@ class example(mp_module.MPModule):
             self.say("%s: %s" % (self.name,message))
             # See if whatever we're connected to would like to play:
             self.master.mav.statustext_send(mavutil.mavlink.MAV_SEVERITY_NOTICE,
-                                            message)
+                                            message.encode('utf8'))
 
     def mavlink_packet(self, m):
         '''handle mavlink packets'''

--- a/MAVProxy/modules/mavproxy_message.py
+++ b/MAVProxy/modules/mavproxy_message.py
@@ -7,6 +7,8 @@ Peter Barker, September 2017
 
 import time
 
+from pymavlink import mavutil
+
 from MAVProxy.modules.lib import mp_module
 from MAVProxy.modules.lib import mp_settings
 
@@ -43,6 +45,18 @@ class message(mp_module.MPModule):
             except AttributeError:
                 print("Unable to find %s" % methodname)
                 return
+            # pymavlink requires bytes for char-array fields; encode
+            # any str supplied for one of those:
+            msg_class = getattr(
+                mavutil.mavlink,
+                "MAVLink_%s_message" % packettype.lower(),
+                None)
+            if msg_class is not None:
+                for i, fieldtype in enumerate(msg_class.fieldtypes):
+                    if (fieldtype == "char" and
+                            i < len(transformed) and
+                            isinstance(transformed[i], str)):
+                        transformed[i] = transformed[i].encode("utf8")
             method(*transformed)
 
 


### PR DESCRIPTION
Avoid the need to specify the encoding of a string when using the `message` command by simply converting any passed-in-string to bytes before passing to pymavlink

This fixes the same problem as in https://github.com/ArduPilot/pymavlink/issues/1225

This is basically, "give pymavlink what it wants", which is unicode.
