### PR TITLE
mavproxy: allow 32 bit MAVLink system IDs

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -279,9 +279,9 @@ class MPState(object):
             MPSetting('rally_breakalt', int, 40, 'Default Rally Break Altitude', range=(0, 10000), increment=1),
             MPSetting('rally_flags', int, 0, 'Default Rally Flags', range=(0, 10000), increment=1),
 
-            MPSetting('source_system', int, 255, 'MAVLink Source system', range=(0, 255), increment=1, tab='MAVLink'),
+            MPSetting('source_system', int, 255, 'MAVLink Source system', range=(0, 0xFFFFFFFF), increment=1, tab='MAVLink'),
             MPSetting('source_component', int, 230, 'MAVLink Source component', range=(0, 255), increment=1),
-            MPSetting('target_system', int, 0, 'MAVLink target system', range=(0, 255), increment=1),
+            MPSetting('target_system', int, 0, 'MAVLink target system', range=(0, 0xFFFFFFFF), increment=1),
             MPSetting('target_component', int, 0, 'MAVLink target component', range=(0, 255), increment=1),
             MPSetting('state_basedir', str, None, 'base directory for logs and aircraft directories'),
             MPSetting('allow_unsigned', bool, True, 'whether unsigned packets will be accepted'),

--- a/MAVProxy/modules/lib/mission_item_protocol.py
+++ b/MAVProxy/modules/lib/mission_item_protocol.py
@@ -1113,7 +1113,12 @@ on'''
             w = self.wp_to_mission_item_int(w)
             tlist = []
             for field in mavmsg.ordered_fieldnames:
-                tlist.append(getattr(w, field))
+                value = getattr(w, field)
+                if field == 'target_system' and value > 255:
+                    # the mission file has an 8 bit target_system field,
+                    # which the autopilot ignores on upload
+                    value = 0
+                tlist.append(value)
             tlist = tuple(tlist)
             buf = mavmsg.unpacker.pack(*tlist)
             fh.write(buf)

--- a/MAVProxy/modules/mavproxy_chat/assistant_setup/send_mavlink_command_int.json
+++ b/MAVProxy/modules/mavproxy_chat/assistant_setup/send_mavlink_command_int.json
@@ -6,7 +6,7 @@
     "parameters": {
       "type": "object",
       "properties": {
-          "target_system": {"type": "integer", "minimum":0, "maximum":255, "description": "vehicle autopilot System ID.  can be omitted"},
+          "target_system": {"type": "integer", "minimum":0, "maximum":4294967295, "description": "vehicle autopilot System ID.  can be omitted"},
           "target_component": {"type": "integer",  "minimum":0, "maximum":255, "description": "vehicle autopilot Component ID.  can be omitted"},
           "frame": {"type": "integer", "minimum":0, "maximum":21, "description": "altitude type.  see MAV_FRAME.  0 for altitude above sea level, 3 for altitude above home, 10 for altitude above terrain"},
           "command": {"type": "integer",  "minimum":0, "maximum":65535, "description": "MAVLink command id.  See MAV_CMD for a full list of available commands"},

--- a/MAVProxy/modules/mavproxy_chat/assistant_setup/send_mavlink_set_position_target_global_int.json
+++ b/MAVProxy/modules/mavproxy_chat/assistant_setup/send_mavlink_set_position_target_global_int.json
@@ -7,7 +7,7 @@
       "type": "object",
       "properties": {
           "time_boot_ms": {"type": "integer", "description": "system timestamp.  can be left as 0"},
-          "target_system": {"type": "integer", "minimum":0, "maximum":255, "description": "vehicle autopilot System ID.  can be omitted"},
+          "target_system": {"type": "integer", "minimum":0, "maximum":4294967295, "description": "vehicle autopilot System ID.  can be omitted"},
           "target_component": {"type": "integer",  "minimum":0, "maximum":255, "description": "vehicle autopilot Component ID.  can be omitted"},
           "coordinate_frame": {"type": "integer", "minimum":0, "maximum":21, "description": "altitude type.  see MAV_FRAME.  5 for altitude above sea level, 6 for altitude above home, 11 for altitude above terrain"},
           "type_mask": {"type": "integer", "minimum":0, "maximum":65535, "description": "Bitmap to indicate which dimensions should be ignored by the vehicle.  see POSITION_TARGET_TYPEMASK.  If only location (e.g. lat_int, lon_int and alt) is sent use 3576.  If location and yaw are sent use 2552.  If only velocity (e.g. vx, vy, vz) is sent use 2552. if velocity and yaw are sent use 2503.  If only yaw is sent use 2559"},

--- a/MAVProxy/modules/mavproxy_oldwp.py
+++ b/MAVProxy/modules/mavproxy_oldwp.py
@@ -1004,7 +1004,12 @@ class WPModule(mp_module.MPModule):
             w = self.wp_to_mission_item_int(w)
             tlist = []
             for field in mavmsg.ordered_fieldnames:
-                tlist.append(getattr(w, field))
+                value = getattr(w, field)
+                if field == 'target_system' and value > 255:
+                    # the mission file has an 8 bit target_system field,
+                    # which the autopilot ignores on upload
+                    value = 0
+                tlist.append(value)
             tlist = tuple(tlist)
             buf = mavmsg.unpacker.pack(*tlist)
             fh.write(buf)


### PR DESCRIPTION
Lift the source_system and target_system setting ranges for MAVLink2.1 32 bit system IDs. The wire handling comes from pymavlink; targets in the extended TARGETTED header are overlaid onto decoded messages by pymavlink so vehicle switching and forwarding work unchanged.

Requires https://github.com/ArduPilot/pymavlink/pull/1229
