### PR TITLE
tools: MAVExplorer: add Attitude and Altitude tracking error graphs

### DIFF
--- a/MAVProxy/tools/graphs/mavgraphs.xml
+++ b/MAVProxy/tools/graphs/mavgraphs.xml
@@ -54,6 +54,26 @@
     <expression>sqrt(((ATT.Roll-ATT.DesRoll)**2)+((ATT.Pitch-ATT.DesPitch)**2))</expression>
   </graph>
 
+  <graph name='Attitude/Tracking Error/Roll Tracking Error'>
+  <description>Difference between desired and actual roll angle</description>
+    <expression>ATT.DesRoll-ATT.Roll</expression>
+  </graph>
+
+  <graph name='Attitude/Tracking Error/Pitch Tracking Error'>
+  <description>Difference between desired and actual pitch angle</description>
+    <expression>ATT.DesPitch-ATT.Pitch</expression>
+  </graph>
+
+  <graph name='Attitude/Tracking Error/Yaw Tracking Error'>
+  <description>Difference between desired and actual yaw angle</description>
+    <expression>ATT.DesYaw-ATT.Yaw</expression>
+  </graph>
+
+  <graph name='Altitude/Tracking Error/Altitude Tracking Error'>
+  <description>Difference between demanded altitude and barometric altitude</description>
+    <expression>CTUN.DAlt-CTUN.BAlt</expression>
+  </graph>
+
   <graph name='Sensors/Accelerometer/Accelerometers'>
     <description>Accelerometer Output</description>
     <expression>RAW_IMU.xacc*9.81*0.001 RAW_IMU.yacc*9.81*0.001 RAW_IMU.zacc*9.81*0.001 gravity(RAW_IMU)</expression>


### PR DESCRIPTION
Adds four new preset tracking error graphs to `mavgraphs.xml` under the `Attitude` and `Altitude` menu hierarchies. These compute the delta between commanded and actual states directly from `ATT` and `CTUN` log messages.

**Motivation:**
Engineers currently overlay Desired vs. Actual traces manually to assess controller performance (settling time, overshoot, steady-state error) during aggressive or transition flight phases. These graphs surface the tracking delta as a single expression, removing the need for manual visual comparison.

**Changes:**
* `Attitude/Tracking Error/Roll`: `ATT.DesRoll - ATT.Roll`
* `Attitude/Tracking Error/Pitch`: `ATT.DesPitch - ATT.Pitch`
* `Attitude/Tracking Error/Yaw`: `ATT.DesYaw - ATT.Yaw`
* `Altitude/Tracking Error`: `CTUN.DAlt - CTUN.BAlt`

Verified expressions evaluate correctly against sample logs in MAVExplorer without requiring changes to the expression parser.

AI assistance disclosure: This contribution was developed with the assistance of Claude (Anthropic). I reviewed and tested the results as described above and understand the change.