### PR TITLE
tools: MAVExplorer: add EKF3 variance, innovation, and sensor consistency graphs

### DIFF
--- a/MAVProxy/tools/graphs/mavgraphs.xml
+++ b/MAVProxy/tools/graphs/mavgraphs.xml
@@ -749,5 +749,129 @@
   <expression>RATE.Y RATE.YDes ATT.Yaw:2 ATT.DesYaw:2</expression>
  </graph>
 
- 
+ <!-- ============================== EKF Diagnostics ============================== -->
+
+ <graph name="EKF/Variance/Velocity">
+    <expression>XKF4[0].SV</expression>
+    <expression>XKF4[1].SV</expression>
+    <expression>NKF4[0].SV</expression>
+    <expression>NKF4[1].SV</expression>
+    <expression>1.0+0*XKF4[0].SV</expression>
+ </graph>
+
+ <graph name="EKF/Variance/Position">
+    <expression>XKF4[0].SP</expression>
+    <expression>XKF4[1].SP</expression>
+    <expression>NKF4[0].SP</expression>
+    <expression>NKF4[1].SP</expression>
+    <expression>1.0+0*XKF4[0].SP</expression>
+ </graph>
+
+ <graph name="EKF/Variance/Height">
+    <expression>XKF4[0].SH</expression>
+    <expression>XKF4[1].SH</expression>
+    <expression>NKF4[0].SH</expression>
+    <expression>NKF4[1].SH</expression>
+    <expression>1.0+0*XKF4[0].SH</expression>
+ </graph>
+
+ <graph name="EKF/Variance/Magnetometer">
+    <expression>XKF4[0].SM</expression>
+    <expression>XKF4[1].SM</expression>
+    <expression>NKF4[0].SM</expression>
+    <expression>NKF4[1].SM</expression>
+    <expression>1.0+0*XKF4[0].SM</expression>
+ </graph>
+
+ <graph name="EKF/Variance/Terrain">
+    <expression>XKF4[0].SVT</expression>
+    <expression>XKF4[1].SVT</expression>
+    <expression>NKF4[0].SVT</expression>
+    <expression>NKF4[1].SVT</expression>
+    <expression>1.0+0*XKF4[0].SVT</expression>
+ </graph>
+
+ <graph name="EKF/Variance/Overview">
+    <expression>XKF4[0].SV</expression>
+    <expression>XKF4[0].SP</expression>
+    <expression>XKF4[0].SH</expression>
+    <expression>XKF4[0].SM</expression>
+    <expression>1.0+0*XKF4[0].SV</expression>
+ </graph>
+
+ <graph name="EKF/Innovations/Velocity">
+    <expression>XKF3[0].IVN</expression>
+    <expression>XKF3[0].IVE</expression>
+    <expression>XKF3[0].IVD</expression>
+    <expression>NKF3[0].IVN</expression>
+    <expression>NKF3[0].IVE</expression>
+    <expression>NKF3[0].IVD</expression>
+ </graph>
+
+ <graph name="EKF/Innovations/Position">
+    <expression>XKF3[0].IPN</expression>
+    <expression>XKF3[0].IPE</expression>
+    <expression>XKF3[0].IPD</expression>
+    <expression>NKF3[0].IPN</expression>
+    <expression>NKF3[0].IPE</expression>
+    <expression>NKF3[0].IPD</expression>
+ </graph>
+
+ <graph name="EKF/Innovations/Magnetometer">
+    <expression>XKF3[0].IMX</expression>
+    <expression>XKF3[0].IMY</expression>
+    <expression>XKF3[0].IMZ</expression>
+    <expression>NKF3[0].IMX</expression>
+    <expression>NKF3[0].IMY</expression>
+    <expression>NKF3[0].IMZ</expression>
+ </graph>
+
+ <graph name="EKF/Innovations/Yaw">
+    <expression>XKF3[0].IYAW</expression>
+    <expression>NKF3[0].IYAW</expression>
+ </graph>
+
+ <graph name="EKF/Status/Flags">
+    <expression>XKF4[0].SS</expression>
+    <expression>XKF4[1].SS</expression>
+    <expression>NKF4[0].SS</expression>
+ </graph>
+
+ <graph name="EKF/Status/AttitudeError">
+    <expression>degrees(XKF4[0].errRP)</expression>
+    <expression>degrees(XKF4[1].errRP)</expression>
+    <expression>degrees(NKF4[0].errRP)</expression>
+ </graph>
+
+ <graph name="Sensors/IMU/Accel-Consistency">
+    <expression>IMU[0].AccX-IMU[1].AccX</expression>
+    <expression>IMU[0].AccY-IMU[1].AccY</expression>
+    <expression>IMU[0].AccZ-IMU[1].AccZ</expression>
+ </graph>
+
+ <graph name="Sensors/IMU/Gyro-Consistency">
+    <expression>degrees(IMU[0].GyrX-IMU[1].GyrX)</expression>
+    <expression>degrees(IMU[0].GyrY-IMU[1].GyrY)</expression>
+    <expression>degrees(IMU[0].GyrZ-IMU[1].GyrZ)</expression>
+ </graph>
+
+ <graph name="Sensors/GPS/Position-Offset">
+    <expression>(GPS[0].Lat-GPS[1].Lat)*1.0e7</expression>
+    <expression>(GPS[0].Lng-GPS[1].Lng)*1.0e7</expression>
+    <expression>GPS[0].Alt-GPS[1].Alt</expression>
+ </graph>
+
+ <graph name="Sensors/GPS/Quality">
+    <expression>GPS[0].HDop</expression>
+    <expression>GPS[1].HDop</expression>
+    <expression>GPS[0].NSats</expression>
+    <expression>GPS[1].NSats</expression>
+ </graph>
+
+ <graph name="Sensors/Compass/Field-Consistency">
+    <expression>sqrt(MAG[0].MagX**2+MAG[0].MagY**2+MAG[0].MagZ**2)</expression>
+    <expression>sqrt(MAG[1].MagX**2+MAG[1].MagY**2+MAG[1].MagZ**2)</expression>
+    <expression>sqrt(MAG[2].MagX**2+MAG[2].MagY**2+MAG[2].MagZ**2)</expression>
+ </graph>
+
 </graphs>

--- a/MAVProxy/tools/graphs/mavgraphs.xml
+++ b/MAVProxy/tools/graphs/mavgraphs.xml
@@ -751,7 +751,7 @@
 
  <!-- ============================== EKF Diagnostics ============================== -->
 
- <graph name="EKF/Variance/Velocity">
+ <graph name="EKF3/Variance/Velocity">
     <expression>XKF4[0].SV</expression>
     <expression>XKF4[1].SV</expression>
     <expression>NKF4[0].SV</expression>
@@ -759,7 +759,7 @@
     <expression>1.0+0*XKF4[0].SV</expression>
  </graph>
 
- <graph name="EKF/Variance/Position">
+ <graph name="EKF3/Variance/Position">
     <expression>XKF4[0].SP</expression>
     <expression>XKF4[1].SP</expression>
     <expression>NKF4[0].SP</expression>
@@ -767,7 +767,7 @@
     <expression>1.0+0*XKF4[0].SP</expression>
  </graph>
 
- <graph name="EKF/Variance/Height">
+ <graph name="EKF3/Variance/Height">
     <expression>XKF4[0].SH</expression>
     <expression>XKF4[1].SH</expression>
     <expression>NKF4[0].SH</expression>
@@ -775,7 +775,7 @@
     <expression>1.0+0*XKF4[0].SH</expression>
  </graph>
 
- <graph name="EKF/Variance/Magnetometer">
+ <graph name="EKF3/Variance/Magnetometer">
     <expression>XKF4[0].SM</expression>
     <expression>XKF4[1].SM</expression>
     <expression>NKF4[0].SM</expression>
@@ -783,7 +783,7 @@
     <expression>1.0+0*XKF4[0].SM</expression>
  </graph>
 
- <graph name="EKF/Variance/Terrain">
+ <graph name="EKF3/Variance/Terrain">
     <expression>XKF4[0].SVT</expression>
     <expression>XKF4[1].SVT</expression>
     <expression>NKF4[0].SVT</expression>
@@ -791,7 +791,7 @@
     <expression>1.0+0*XKF4[0].SVT</expression>
  </graph>
 
- <graph name="EKF/Variance/Overview">
+ <graph name="EKF3/Variance/Overview">
     <expression>XKF4[0].SV</expression>
     <expression>XKF4[0].SP</expression>
     <expression>XKF4[0].SH</expression>
@@ -799,7 +799,7 @@
     <expression>1.0+0*XKF4[0].SV</expression>
  </graph>
 
- <graph name="EKF/Innovations/Velocity">
+ <graph name="EKF3/Innovations/Velocity">
     <expression>XKF3[0].IVN</expression>
     <expression>XKF3[0].IVE</expression>
     <expression>XKF3[0].IVD</expression>
@@ -808,7 +808,7 @@
     <expression>NKF3[0].IVD</expression>
  </graph>
 
- <graph name="EKF/Innovations/Position">
+ <graph name="EKF3/Innovations/Position">
     <expression>XKF3[0].IPN</expression>
     <expression>XKF3[0].IPE</expression>
     <expression>XKF3[0].IPD</expression>
@@ -817,7 +817,7 @@
     <expression>NKF3[0].IPD</expression>
  </graph>
 
- <graph name="EKF/Innovations/Magnetometer">
+ <graph name="EKF3/Innovations/Magnetometer">
     <expression>XKF3[0].IMX</expression>
     <expression>XKF3[0].IMY</expression>
     <expression>XKF3[0].IMZ</expression>
@@ -826,18 +826,18 @@
     <expression>NKF3[0].IMZ</expression>
  </graph>
 
- <graph name="EKF/Innovations/Yaw">
+ <graph name="EKF3/Innovations/Yaw">
     <expression>XKF3[0].IYAW</expression>
     <expression>NKF3[0].IYAW</expression>
  </graph>
 
- <graph name="EKF/Status/Flags">
+ <graph name="EKF3/Status/Flags">
     <expression>XKF4[0].SS</expression>
     <expression>XKF4[1].SS</expression>
     <expression>NKF4[0].SS</expression>
  </graph>
 
- <graph name="EKF/Status/AttitudeError">
+ <graph name="EKF3/Status/AttitudeError">
     <expression>degrees(XKF4[0].errRP)</expression>
     <expression>degrees(XKF4[1].errRP)</expression>
     <expression>degrees(NKF4[0].errRP)</expression>


### PR DESCRIPTION
Adds comprehensive EKF and multi-sensor diagnostic preset graphs to `mavgraphs.xml`.

Closes #1595

## Motivation

Evaluating EKF health, lane switching, and pre-filter sensor inconsistencies
currently requires manual plotting of multiple `XKF*`, `NKF*`, and raw sensor
messages. These presets allow immediate, one-click analysis of filter health
and hardware consistency directly from the MAVExplorer menu, and directly
address the gap reported in #1595 (no monitoring tool for EKF3 affinity and
lane switching).

## Changes

- **EKF3/Variance**: Plots normalized innovation variances (`SV`, `SP`, `SH`,
  `SM`, `SVT`). A `1.0` threshold line is included
  (`1.0+0*XKF4[0].*`) — this is not an arbitrary reference: it is
  ArduPilot's actual innovation-rejection gate (see "Verification" below).
- **EKF3/Innovations**: Plots raw innovation (residual) values for Velocity,
  Position, Mag, and Yaw.
- **EKF3/Status**: Plots solution status flags (`SS`) and estimated attitude
  errors (`errRP`).
- **Sensors**: Adds pre-EKF hardware consistency checks, to help distinguish
  a genuine EKF/algorithm problem from an underlying sensor problem when a
  Variance or Innovation graph above shows something unhealthy:
  - IMU Accel/Gyro deltas between core 0 and 1.
  - GPS Position offsets (scaled by `1.0e7`) and quality metrics (`HDop`,
    `NSats`).
  - Compass magnetic field magnitude consistency across instances.

## Technical Details

- Supports both modern EKF3 (`XKF3`/`XKF4`) and legacy EKF2 (`NKF3`/`NKF4`)
  log messages within the same views, so the graphs remain useful across
  older logs as well as current ones.
- Evaluates multiple EKF lanes and sensor instances (`[0]`, `[1]`, `[2]`)
  to support redundant hardware setups (dual/triple IMU, GPS, compass).
- Uses `degrees()` for radian-to-degree conversions on Gyro and `errRP`
  data for readability.

## Verification: the 1.0 threshold is ArduPilot's real rejection gate

Traced through `AP_NavEKF3` source to confirm this isn't an arbitrary
reference line:

- `AP_NavEKF3_Outputs.cpp::getVariances()` returns `velVar = sqrtF(velTestRatio)`
  (and the equivalent for pos/hgt/mag/tas) — this is exactly what gets logged
  as `XKF4.SV`/`SP`/`SH`/`SM`/`SVT`.
- The filter's own health checks use the identical threshold, e.g.
  `AP_NavEKF3_PosVelFusion.cpp`: `if (velTestRatio < 1.0)`, and
  `AP_NavEKF3_MagFusion.cpp`: `magHealth = (magTestRatio[0] < 1.0f && ...)`.

So `SV`/`SP`/`SH`/`SM`/`SVT` crossing `1.0` in these graphs is the same
condition ArduPilot itself uses internally to start rejecting that
measurement — the graph is reading the filter's actual decision boundary,
not an approximation of it.

## Testing

Verified all 17 graph expressions evaluate without errors (no NameError /
eval exceptions) against a real dual-IMU, dual-core EKF3 log
(178,979 messages, ~35 min flight):

- All EKF3 (`XKF3`/`XKF4`) expressions returned full data (6,088 samples
  per field, both cores populated).
- All IMU-consistency and Compass-consistency expressions returned full
  data (146,103 / 2,435 samples).
- Rendered `EKF3/Variance/Velocity` to PNG to visually confirm the `1.0`
  threshold line sits correctly against real `SV` values, which stayed in
  the 0–0.03 range with one genuine spike to 0.28 — axis scaling and
  threshold placement both looked correct.
- Scanned 400 real dataflash logs on hand (home-directory-wide, filtered
  by dataflash magic bytes): the large majority contained `XKF3`/`XKF4`
  (EKF3), a small number of older logs contained `NKF3`/`NKF4` (EKF2, see
  below), none contained a second GPS instance.

EKF2 (`NKF3`/`NKF4`) was additionally verified against two logs:

- A real legacy log (ArduPlane V3.8.2-dev, ~2017/2018) found via a
  home-directory-wide scan.
- A SITL-generated modern EKF2 log (`EK2_ENABLE=1`, `EK3_ENABLE=0`,
  `AHRS_EKF_TYPE=2`), to check current-format behavior directly.

Result: `NKF3[0]`/`NKF4[0]` bracket-instance syntax returns full, correct
data on modern EKF2 logs (2,477 samples per field, both cores populated,
PNG-rendered and visually confirmed) — see the coverage limitation below
for the one gap this surfaced.

## Known test-coverage limitations

- **`NKF3[0]`/`NKF4[0]` instance syntax verified against two EKF2 logs**:
  a real legacy log (ArduPlane V3.8.2-dev, ~2017/2018) and a SITL-generated
  modern log (`EK2_ENABLE=1`/`EK3_ENABLE=0`). Result: the bracket-instance
  syntax works correctly on modern EKF2 logs, where `NKF3`/`NKF4` carry a
  core/lane field (`C`) — same as `XKF3`/`XKF4`. On pre-core-field EKF2 logs
  (roughly pre-2018, before multi-lane EKF2 existed), `NKF3[0]`/`NKF4[0]`
  silently returns empty data rather than raising an error, because there
  is no `C` field to index into. The plain (bracket-free) form — `NKF3.IVN`,
  `NKF4.SV`, etc. — does return data on these older logs.
  This is a narrow edge case (affects only genuinely old EKF2-only logs,
  not `XKF3`/`XKF4`, which have always had a core field), but worth knowing:
  a blank EKF2 graph on a very old log means "no core field," not
  "everything's fine."
- **`Sensors/GPS/Position-Offset` and `Sensors/GPS/Quality` render empty
  on any single-GPS setup** (i.e. most vehicles) — this is expected
  behavior (no `GPS[1]` data to plot), not a bug, but worth knowing before
  assuming the graph is broken on a normal log.
- These are preset diagnostic *views*, not automated lane-switch detectors —
  a lane switch event itself is not highlighted/annotated on the timeline;
  the graphs only make it visually apparent by eye.

## On the EKF3 vs Sensors split

These are kept in one PR because the `Sensors` graphs exist specifically
to help answer *why* a `Variance`/`Innovations` graph shows a problem
(e.g. a Mag Variance spike traced back to a Compass Field-Consistency
mismatch). Happy to split into two PRs if maintainers would prefer
independent review — flagging as an option, not proposing it.

AI assistance disclosure: This contribution was developed with the assistance of Claude (Anthropic). I reviewed and tested the results as described above and understand the change.