### PR TITLE
graphs: add Scheduler Health graph set to mavgraphs2.xml

### DIFF
--- a/MAVProxy/tools/graphs/mavgraphs2.xml
+++ b/MAVProxy/tools/graphs/mavgraphs2.xml
@@ -151,6 +151,59 @@
   <expression>PM.MaxT PM.NLon:2 PM.LogDrop:2</expression>
  </graph>
 
+ <graph name='PM/Scheduler Health/CPU Load Trend'>
+  <description>
+    CPU load as a percentage (PM.Load is logged at 10x the real percentage).
+    This is a filtered/averaged metric, so it shows the general load trend
+    rather than instantaneous spikes -- use it to spot slow drift towards
+    saturation, not single-loop overruns (see 'Loop Overrun' for that).
+  </description>
+  <expression>PM.Load*0.1</expression>
+ </graph>
+
+ <graph name='PM/Scheduler Health/Loop Overrun'>
+  <description>
+    PM.MaxT is the worst single loop time seen since the previous PM message
+    (PM is normally logged around 1Hz), so a high value here is a worst-case
+    sample, not proof of chronic overruns -- check the overrun ratio
+    (right axis) for how often it is actually happening.
+
+    The two flat reference lines are derived from the loop rate ArduPilot
+    itself measured for that PM period (PM.LR), not a hardcoded budget:
+    the lower line is the theoretical per-loop budget (1e6/LR us), the
+    upper line is ArduPilot's own 20%-over-budget threshold used to
+    increment PM.NLon. MaxT below the lower line is healthy, between the
+    two lines is within ArduPilot's accepted tolerance, above the upper
+    line is a genuine overrun.
+
+    The right-hand axis is the overrun ratio NLon/NL as a percentage --
+    the fraction of loops between PM messages that exceeded the 20%
+    threshold.
+
+    Note: motor arming commonly causes a MaxT spike (failsafe checks, EKF
+    alignment) -- this is expected and not by itself a scheduler problem.
+    Also note the scheduler only times the main loop; delays in other
+    ChibiOS threads (IO, DMA, logging) will not show up here.
+  </description>
+  <expression>PM.MaxT (1.0e6/PM.LR) (1.2e6/PM.LR) (PM.NLon/PM.NL)*100:2</expression>
+ </graph>
+
+ <graph name='PM/Scheduler Health/Overrun Root Cause'>
+  <description>
+    Overlays the loop overrun indicators (left axis) with I2C/SPI bus
+    activity counters (right axis) to help tell apart I/O-driven overruns
+    from compute-driven ones: if I2CI/I2CC/SPIC climb sharply at the same
+    time as MaxT/NLon spikes, bus contention is a likely contributor;
+    if the overrun happens with no matching bus activity increase, the
+    cause is more likely CPU-bound (e.g. EKF/attitude controller load).
+
+    These are cumulative counters, not rates, so look at the slope
+    (rate of increase) at the time of the overrun rather than the
+    absolute value.
+  </description>
+  <expression>PM.MaxT PM.NLon PM.I2CC:2 PM.I2CI:2 PM.SPIC:2</expression>
+ </graph>
+
  <graph name='Copter/Controller RMS'>
   <description></description>
   <expression>CTRL.RMSRoll CTRL.RMSPitch CTRL.RMSYaw</expression>


### PR DESCRIPTION
## What

Adds three new MAVExplorer graphs under `PM/Scheduler Health/`, built entirely from the existing `PM` (Performance Monitoring) log message. No firmware changes, no new log fields, no MAVExplorer/pymavlink code changes — graph definitions only (single file, `mavgraphs2.xml`).

1. **CPU Load Trend** — `PM.Load*0.1` (Load is logged at 10x the real percentage). A filtered/averaged metric, useful for spotting a slow drift toward CPU saturation over a flight rather than single spikes.

2. **Loop Overrun** — `PM.MaxT` plotted against two reference lines computed dynamically from the loop rate ArduPilot itself measured for that PM period (`PM.LR`), rather than a hardcoded budget:
   - theoretical per-loop budget: `1e6 / PM.LR` µs
   - ArduPilot's own "long loop" alarm threshold, 20% over budget: `1.2e6 / PM.LR` µs (matches the definition used to increment `PM.NLon`)

   The overrun ratio `NLon/NL` (%) is plotted on the secondary axis,
   so a single worst-case `MaxT` sample can be read alongside how
   often overruns are actually occurring in that interval.

3. **Overrun Root Cause** — overlays `MaxT`/`NLon` with the `I2CC`, `I2CI`, `SPIC` bus counters (secondary axis), to help separate I/O-driven overruns from compute-driven ones.

## Relationship to the existing PM/Perf graph

`PM/Perf` (`PM.MaxT PM.NLon:2`) already exists and remains useful as a quick raw view. This PR doesn't replace it — it adds a purpose-built diagnostic layer on top: dynamic budget/alarm reference lines (instead of eyeballing raw MaxT with no context), an overrun-frequency ratio, and a root-cause overlay. Happy to fold these into `PM/Perf` directly instead if maintainers prefer one graph over three — flagging this as an open design question.

## Why a dynamic threshold instead of a fixed budget line

ArduPilot's own scheduler treats 0-20% over budget as normal (that's literally the definition of when `PM.NLon` increments), so a single fixed "MaxT - budget" line would flag harmless variance as a problem. `PM.LR` — the filtered loop rate ArduPilot measured for that period — is already present on every `PM` message, so the two reference lines can be computed per-log with no parameter table lookups and no manual user input, and they stay correct even if the achieved loop rate drifts from the configured `SCHED_LOOP_RATE`.

(We initially explored reading `SCHED_LOOP_RATE` dynamically via the log's parameter table instead. `PM.LR` turned out to be a strictly simpler and more robust source for the same information — no cross-message lookup needed — so we went with that. Happy to discuss if there's a reason to prefer the parameter value in some case we haven't considered.)

## Known limitations (documented inline in the graph descriptions)

- `PM` is normally logged at ~1Hz, so `MaxT` is a single worst-case sample between messages, not proof of chronic overruns — the `NLon/NL` ratio is the better signal for frequency.
- The scheduler only times the main loop; delays in other ChibiOS threads (IO, DMA, logging) are invisible to these graphs.
- Motor arming commonly causes a `MaxT` spike (failsafe checks, EKF alignment) — expected, not itself a scheduler problem. Not auto-shaded in this version to keep the PR small; noted in the description instead.
- The I2C/SPI counters in "Overrun Root Cause" are cumulative, not rates — look at the slope at the time of the overrun, not the absolute value.

## Testing

Verified all three expressions evaluate without errors and render correctly against four real dataflash logs:
- Two quiet logs with `NLon=0` throughout — `MaxT` stays at/under the alarm line, overrun ratio flat at 0%.
- One log with a real `NLon=1` overrun — `MaxT` spikes to ~3x budget at boot/arm and the overrun-ratio axis spikes to ~7% at the same moment, then both settle under budget for the rest of the flight, consistent with the documented arm-spike behavior.

Only tested against Copter logs so far — the `PM` message and `LR` field are shared across vehicles via `AP_Scheduler`, but additional testing on Plane/Rover logs is welcome if anyone has some handy.

AI assistance disclosure: This contribution was developed with the assistance of Claude (Anthropic), as noted in the commit trailer. Claude helped analyze the PM log message fields and draft the graph expressions; I reviewed and tested the results against real dataflash logs as described above.