### PR TITLE
fix map3d on macOS

### DIFF
--- a/MAVProxy/modules/mavproxy_map3d/camera.py
+++ b/MAVProxy/modules/mavproxy_map3d/camera.py
@@ -92,15 +92,16 @@ class TerrainStyle(vtk.vtkInteractorStyleUser):
         self.last = None
         self.moved = False
         self.rotating = False
+        self.active_button = None
         # Do not call this "enabled": vtkInteractorStyle exposes an enabled
         # property that attempts to enable the style immediately.
         self.interaction_enabled = True
-        self.AddObserver("LeftButtonPressEvent", self._down)
-        self.AddObserver("LeftButtonReleaseEvent", self._up)
+        self.AddObserver("LeftButtonPressEvent", self._down_pan)
+        self.AddObserver("LeftButtonReleaseEvent", self._up_left)
         # macOS turns Ctrl+left into a right click, so the Ctrl+drag above
         # never reaches us there; rotate on a right drag as well
         self.AddObserver("RightButtonPressEvent", self._down_rotate)
-        self.AddObserver("RightButtonReleaseEvent", self._up)
+        self.AddObserver("RightButtonReleaseEvent", self._up_right)
         self.AddObserver("MouseMoveEvent", self._move)
         self.AddObserver("MouseWheelForwardEvent", self._wf)
         self.AddObserver("MouseWheelBackwardEvent", self._wb)
@@ -108,27 +109,45 @@ class TerrainStyle(vtk.vtkInteractorStyleUser):
     def _render(self):
         self.GetInteractor().GetRenderWindow().Render()
 
-    def _down(self, o, e):
-        if not self.interaction_enabled:
-            return
-        self.last = self.GetInteractor().GetEventPosition()
+    def cancel_drag(self):
+        '''forget any drag in progress. Without this a drag left unfinished
+        (interaction disabled part way through, or a release we never saw)
+        would keep moving the camera on plain mouse motion'''
+        self.last = None
         self.moved = False
         self.rotating = False
+        self.active_button = None
+
+    def _begin(self, button, rotating):
+        # one button owns the drag: a second press must not switch pan/rotate
+        # under the first, and its release must not end the first drag
+        if not self.interaction_enabled or self.active_button is not None:
+            return
+        self.active_button = button
+        self.rotating = rotating
+        self.last = self.GetInteractor().GetEventPosition()
+        self.moved = False
+
+    def _end(self, button):
+        if self.active_button != button:
+            return
+        moved = self.moved
+        enabled = self.interaction_enabled
+        self.cancel_drag()
+        if enabled and moved and self.on_change:
+            self.on_change()
+
+    def _down_pan(self, o, e):
+        self._begin('left', False)
 
     def _down_rotate(self, o, e):
-        if not self.interaction_enabled:
-            return
-        self.last = self.GetInteractor().GetEventPosition()
-        self.moved = False
-        self.rotating = True
+        self._begin('right', True)
 
-    def _up(self, o, e):
-        self.last = None
-        self.rotating = False
-        if not self.interaction_enabled:
-            return
-        if self.moved and self.on_change:
-            self.on_change()
+    def _up_left(self, o, e):
+        self._end('left')
+
+    def _up_right(self, o, e):
+        self._end('right')
 
     def _move(self, o, e):
         if not self.interaction_enabled or self.last is None:

--- a/MAVProxy/modules/mavproxy_map3d/camera.py
+++ b/MAVProxy/modules/mavproxy_map3d/camera.py
@@ -3,7 +3,7 @@ Cesium-like camera and interactor for the 3D map.
 
 The camera keeps the horizon level at all times (no roll/flip): only yaw (about
 world up) and pitch (look-down angle, clamped). Default mouse drag pans; Ctrl+drag
-rotates (left-right = yaw, forward-back = pitch); wheel zooms.
+or a right drag rotates (left-right = yaw, forward-back = pitch); wheel zooms.
 '''
 
 import math
@@ -85,17 +85,22 @@ class TerrainCamera:
 
 
 class TerrainStyle(vtk.vtkInteractorStyleUser):
-    '''default drag = pan, Ctrl+drag = yaw/pitch, wheel = zoom'''
+    '''default drag = pan, Ctrl+drag or right drag = yaw/pitch, wheel = zoom'''
     def __init__(self, tc, on_change=None):
         self.tc = tc
         self.on_change = on_change
         self.last = None
         self.moved = False
+        self.rotating = False
         # Do not call this "enabled": vtkInteractorStyle exposes an enabled
         # property that attempts to enable the style immediately.
         self.interaction_enabled = True
         self.AddObserver("LeftButtonPressEvent", self._down)
         self.AddObserver("LeftButtonReleaseEvent", self._up)
+        # macOS turns Ctrl+left into a right click, so the Ctrl+drag above
+        # never reaches us there; rotate on a right drag as well
+        self.AddObserver("RightButtonPressEvent", self._down_rotate)
+        self.AddObserver("RightButtonReleaseEvent", self._up)
         self.AddObserver("MouseMoveEvent", self._move)
         self.AddObserver("MouseWheelForwardEvent", self._wf)
         self.AddObserver("MouseWheelBackwardEvent", self._wb)
@@ -108,9 +113,18 @@ class TerrainStyle(vtk.vtkInteractorStyleUser):
             return
         self.last = self.GetInteractor().GetEventPosition()
         self.moved = False
+        self.rotating = False
+
+    def _down_rotate(self, o, e):
+        if not self.interaction_enabled:
+            return
+        self.last = self.GetInteractor().GetEventPosition()
+        self.moved = False
+        self.rotating = True
 
     def _up(self, o, e):
         self.last = None
+        self.rotating = False
         if not self.interaction_enabled:
             return
         if self.moved and self.on_change:
@@ -124,7 +138,7 @@ class TerrainStyle(vtk.vtkInteractorStyleUser):
         dx, dy = x - self.last[0], y - self.last[1]
         self.last = (x, y)
         self.moved = True
-        if it.GetControlKey():
+        if self.rotating or it.GetControlKey():
             self.tc.rotate(dx, dy)
         else:
             self.tc.pan(dx, dy)

--- a/MAVProxy/modules/mavproxy_map3d/map3d_ui.py
+++ b/MAVProxy/modules/mavproxy_map3d/map3d_ui.py
@@ -135,6 +135,9 @@ class Map3DFrame(wx.Frame):
         sizer.Add(controls, 0, wx.EXPAND)
         sizer.Add(self.widget, 1, wx.EXPAND)
         self.SetSizer(sizer)
+        # without this the children keep their default position and the VTK
+        # canvas sits over the controls. Only MSW lays out on its own.
+        self.Layout()
 
         self.timer = wx.Timer(self)
         self.Bind(wx.EVT_TIMER, self.on_timer, self.timer)

--- a/MAVProxy/modules/mavproxy_map3d/map3d_ui.py
+++ b/MAVProxy/modules/mavproxy_map3d/map3d_ui.py
@@ -173,6 +173,7 @@ class Map3DFrame(wx.Frame):
                                    self.tc.yaw, self.tc.pitch,
                                    camera.GetViewAngle())
             self.style.interaction_enabled = False
+            self.style.cancel_drag()
             self.elements.set_vehicle_visible(False)
             camera.SetViewAngle(self.fpv_fov)
         self.terrain.update(self.tc)
@@ -239,6 +240,7 @@ class Map3DFrame(wx.Frame):
                                    self.tc.yaw, self.tc.pitch,
                                    camera.GetViewAngle())
             self.style.interaction_enabled = False
+            self.style.cancel_drag()
             camera.SetViewAngle(self.fpv_fov)
             self.update_fpv_camera()
         else:


### PR DESCRIPTION
Two macOS bugs in the 3D map, plus a hardening fix that came out of review.

**Toolbar was unusable.** `Map3DFrame` called `SetSizer()` but never `Layout()`,
so every child stayed at wx's default `(-1,-1)` and the VTK canvas kept its own
default 1100x800, covering the controls. On macOS only fragments of the buttons
showed; on GTK with wx 4.0.7 the row had no height at all. Only MSW laid out on
its own, which is why Windows looked fine. `Layout()` is used rather than
`Fit()`/`SetSizerAndFit()` because those let the canvas's best size change the
caller's requested frame size.

**Rotate did not work.** `TerrainStyle` began a drag only on
`LeftButtonPressEvent` and required `GetControlKey()`. macOS Cocoa converts
Ctrl+left-click into a right click, so that press never arrived and only panning
worked. A right drag now rotates as well as Ctrl+drag.

**Drag ownership.** Adding the right button exposed that either release ended
whichever drag was running, and a second press could switch pan/rotate under the
first. A drag left unfinished - interaction disabled part way through for FPV, or
a release never seen - also kept moving the camera on plain mouse motion. Each
drag now has one owning button, with `cancel_drag()` called where interaction is
disabled.

Tested on macOS 26.3 arm64 (Python 3.14, wxPython 4.3.1 osx-cocoa, VTK 9.6.2,
spawn start method) against live SITL telemetry, with pan and rotate confirmed by
hand. Layout geometry checked on macOS, GTK and Windows; drag state transitions
covered by synthetic VTK events.
