### PR TITLE
map3d: fix slow imagery, takeoff altitude and vehicle icons

### DIFF
--- a/MAVProxy/modules/lib/mp_util.py
+++ b/MAVProxy/modules/lib/mp_util.py
@@ -587,6 +587,41 @@ def get_gps_time(tnow):
 
     
 
+_vehicle_type_names = None
+
+
+def vehicle_type_name(mav_type):
+    '''vehicle name for a MAV_TYPE, as used to pick a map icon, or None if we
+    have no icon for that type'''
+    global _vehicle_type_names
+    if _vehicle_type_names is None:
+        from pymavlink import mavutil
+        mavlink = mavutil.mavlink
+        groups = {
+            'plane': [mavlink.MAV_TYPE_FIXED_WING,
+                      mavlink.MAV_TYPE_VTOL_DUOROTOR,
+                      mavlink.MAV_TYPE_VTOL_QUADROTOR,
+                      mavlink.MAV_TYPE_VTOL_TILTROTOR],
+            'rover': [mavlink.MAV_TYPE_GROUND_ROVER],
+            'sub': [mavlink.MAV_TYPE_SUBMARINE],
+            'boat': [mavlink.MAV_TYPE_SURFACE_BOAT],
+            'copter': [mavlink.MAV_TYPE_QUADROTOR,
+                       mavlink.MAV_TYPE_HEXAROTOR,
+                       mavlink.MAV_TYPE_OCTOROTOR,
+                       mavlink.MAV_TYPE_TRICOPTER,
+                       mavlink.MAV_TYPE_DODECAROTOR,
+                       mavlink.MAV_TYPE_DECAROTOR],
+            'singlecopter': [mavlink.MAV_TYPE_COAXIAL],
+            'heli': [mavlink.MAV_TYPE_HELICOPTER],
+            'antenna': [mavlink.MAV_TYPE_ANTENNA_TRACKER],
+            'blimp': [mavlink.MAV_TYPE_AIRSHIP],
+        }
+        _vehicle_type_names = {t: name
+                               for name, types in groups.items()
+                               for t in types}
+    return _vehicle_type_names.get(mav_type)
+
+
 def natural_sort_key(s):
     '''a sort key for natural sorting, where embedded integers are sorted separately'''
     return [int(text) if text.isdigit() else text.lower()

--- a/MAVProxy/modules/mavproxy_map/__init__.py
+++ b/MAVProxy/modules/mavproxy_map/__init__.py
@@ -1181,34 +1181,8 @@ Usage: map circle <radius> <colour>
         sysid = m.get_srcSystem()
 
         if mtype == "HEARTBEAT" or mtype == "HIGH_LATENCY2":
-            vname = None
             vtype = self.vehicle_type_override.get(sysid, m.type)
-            if vtype in [mavutil.mavlink.MAV_TYPE_FIXED_WING,
-                         mavutil.mavlink.MAV_TYPE_VTOL_DUOROTOR,
-                         mavutil.mavlink.MAV_TYPE_VTOL_QUADROTOR,
-                         mavutil.mavlink.MAV_TYPE_VTOL_TILTROTOR]:
-                vname = 'plane'
-            elif vtype in [mavutil.mavlink.MAV_TYPE_GROUND_ROVER]:
-                vname = 'rover'
-            elif vtype in [mavutil.mavlink.MAV_TYPE_SUBMARINE]:
-                vname = 'sub'
-            elif vtype in [mavutil.mavlink.MAV_TYPE_SURFACE_BOAT]:
-                vname = 'boat'
-            elif vtype in [mavutil.mavlink.MAV_TYPE_QUADROTOR,
-                           mavutil.mavlink.MAV_TYPE_HEXAROTOR,
-                           mavutil.mavlink.MAV_TYPE_OCTOROTOR,
-                           mavutil.mavlink.MAV_TYPE_TRICOPTER,
-                           mavutil.mavlink.MAV_TYPE_DODECAROTOR,
-                           mavutil.mavlink.MAV_TYPE_DECAROTOR]:
-                vname = 'copter'
-            elif vtype in [mavutil.mavlink.MAV_TYPE_COAXIAL]:
-                vname = 'singlecopter'
-            elif vtype in [mavutil.mavlink.MAV_TYPE_HELICOPTER]:
-                vname = 'heli'
-            elif vtype in [mavutil.mavlink.MAV_TYPE_ANTENNA_TRACKER]:
-                vname = 'antenna'
-            elif vtype in [mavutil.mavlink.MAV_TYPE_AIRSHIP]:
-                vname = 'blimp'
+            vname = mp_util.vehicle_type_name(vtype)
             if vname is not None:
                 self.vehicle_type_by_sysid[sysid] = vname
 

--- a/MAVProxy/modules/mavproxy_map/mp_tile.py
+++ b/MAVProxy/modules/mavproxy_map/mp_tile.py
@@ -260,7 +260,7 @@ class MPTile:
         # with the downloader threads, so all access is under _download_lock
         self._download_pending = {}
         self._download_active = set()
-        self._download_threads = []
+        self._download_running = 0
         self._download_lock = threading.Lock()
         self._loading = mp_icon('loading.jpg')
         self._unavailable = mp_icon('unavailable.jpg')
@@ -325,7 +325,9 @@ class MPTile:
         '''claim the next tile to fetch, or None when there is nothing left.
 
         A claimed tile stays in _download_pending until its fetch finishes, so
-        tiles_pending() keeps counting it as outstanding.
+        tiles_pending() keeps counting it as outstanding. Returning None also
+        retires the calling thread, under the same lock queue_download() takes,
+        so a tile queued as a thread gives up cannot be left with no downloader.
         '''
         with self._download_lock:
             tile_info = None
@@ -336,7 +338,9 @@ class MPTile:
                 # choose by request_time, newest first
                 if tile_info is None or pending.request_time > tile_info.request_time:
                     tile_info = pending
-            if tile_info is not None:
+            if tile_info is None:
+                self._download_running -= 1
+            else:
                 self._download_active.add(tile_info.key())
             return tile_info
 
@@ -346,15 +350,23 @@ class MPTile:
             self._download_pending.pop(key, None)
 
     def downloader(self):
-        '''the download thread'''
-        while True:
-            tile_info = self._claim_download()
-            if tile_info is None:
-                break
-            try:
-                self.download_tile(tile_info)
-            finally:
-                self._release_download(tile_info.key())
+        '''a download thread: fetch tiles until there are none left to claim'''
+        retired = False
+        try:
+            while True:
+                tile_info = self._claim_download()
+                if tile_info is None:
+                    retired = True
+                    return
+                try:
+                    self.download_tile(tile_info)
+                finally:
+                    self._release_download(tile_info.key())
+        finally:
+            if not retired:
+                # died unexpectedly; give the slot back
+                with self._download_lock:
+                    self._download_running -= 1
 
     def download_tile(self, tile_info):
         '''fetch one tile into the cache directory'''
@@ -428,11 +440,10 @@ class MPTile:
     def start_download_thread(self):
         '''start the downloaders, up to download_threads of them'''
         with self._download_lock:
-            self._download_threads = [t for t in self._download_threads
-                                      if t.is_alive()]
+            wanted = self.download_threads - self._download_running
             starting = [threading.Thread(target=self.downloader)
-                        for _ in range(self.download_threads - len(self._download_threads))]
-            self._download_threads.extend(starting)
+                        for _ in range(max(0, wanted))]
+            self._download_running += len(starting)
         for t in starting:
             t.daemon = True
             t.start()

--- a/MAVProxy/modules/mavproxy_map/mp_tile.py
+++ b/MAVProxy/modules/mavproxy_map/mp_tile.py
@@ -234,7 +234,7 @@ class MPTile:
     '''map tile object'''
     def __init__(self, cache_path=None, download=True, cache_size=500,
                  service="MicrosoftSat", tile_delay=0.3, debug=False,
-                 max_zoom=19, refresh_age=30*24*60*60):
+                 max_zoom=19, refresh_age=30*24*60*60, download_threads=1):
 
         if cache_path is None:
             cache_path = default_cache_path()
@@ -251,13 +251,17 @@ class MPTile:
         self.service = service
         self.debug = debug
         self.refresh_age = refresh_age
+        self.download_threads = max(1, int(download_threads))
 
         if service not in TILE_SERVICES:
             raise TileException('unknown tile service %s' % service)
 
-        # _download_pending is a dictionary of TileInfo objects
+        # _download_pending is a dictionary of TileInfo objects. It is shared
+        # with the downloader threads, so all access is under _download_lock
         self._download_pending = {}
-        self._download_thread = None
+        self._download_active = set()
+        self._download_threads = []
+        self._download_lock = threading.Lock()
         self._loading = mp_icon('loading.jpg')
         self._unavailable = mp_icon('unavailable.jpg')
         self._tile_cache = collections.OrderedDict()
@@ -308,98 +312,130 @@ class MPTile:
         '''return number of tiles pending download'''
         return len(self._download_pending)
 
+    def queue_download(self, key, tile_info):
+        '''queue a tile for download, or bump its priority if already queued'''
+        with self._download_lock:
+            pending = self._download_pending.get(key)
+            if pending is not None:
+                pending.refresh_time()
+            else:
+                self._download_pending[key] = tile_info
+
+    def _claim_download(self):
+        '''claim the next tile to fetch, or None when there is nothing left.
+
+        A claimed tile stays in _download_pending until its fetch finishes, so
+        tiles_pending() keeps counting it as outstanding.
+        '''
+        with self._download_lock:
+            tile_info = None
+            for key in sorted(self._download_pending.keys()):
+                pending = self._download_pending[key]
+                if key in self._download_active:
+                    continue
+                # choose by request_time, newest first
+                if tile_info is None or pending.request_time > tile_info.request_time:
+                    tile_info = pending
+            if tile_info is not None:
+                self._download_active.add(tile_info.key())
+            return tile_info
+
+    def _release_download(self, key):
+        with self._download_lock:
+            self._download_active.discard(key)
+            self._download_pending.pop(key, None)
+
     def downloader(self):
         '''the download thread'''
-        while self.tiles_pending() > 0:
-            time.sleep(self.tile_delay)
-
-            keys = sorted(self._download_pending.keys())
-
-            # work out which one to download next, choosing by request_time
-            tile_info = self._download_pending[keys[0]]
-            for key in keys:
-                if self._download_pending[key].request_time > tile_info.request_time:
-                    tile_info = self._download_pending[key]
-
-            url = tile_info.url(self.service)
-            path = self.tile_to_path(tile_info)
-            key = tile_info.key()
-
+        while True:
+            tile_info = self._claim_download()
+            if tile_info is None:
+                break
             try:
-                if self.debug:
-                    print("Downloading %s [%u left]" % (url, len(keys)))
-                req = url_request(url)
-                req.add_header('User-Agent', 'MAVProxy')
+                self.download_tile(tile_info)
+            finally:
+                self._release_download(tile_info.key())
 
-                # try to re-use our cached data:
-                try:
-                    mtime = os.path.getmtime(path)
-                    req.add_header('If-Modified-Since', time.strftime('%a, %d %b %Y %H:%M:%S GMT', time.gmtime(mtime)))
-                except Exception:
-                    pass
+    def download_tile(self, tile_info):
+        '''fetch one tile into the cache directory'''
+        time.sleep(self.tile_delay)
 
-                if url.find('google') != -1:
-                    req.add_header('Referer', 'https://maps.google.com/')
-                resp = url_open(req)
-                headers = resp.info()
-            except url_error as e:
-                try:
-                    if e.getcode() == 304:
-                        # cache hit; touch the file to reset its refresh time
-                        pathlib.Path(path).touch()
-                        self._download_pending.pop(key)
-                        continue
-                except Exception:
-                    pass
+        url = tile_info.url(self.service)
+        path = self.tile_to_path(tile_info)
+        key = tile_info.key()
 
-                # print('Error loading %s' % url)
-                if key not in self._tile_cache:
-                    self._tile_cache[key] = self._unavailable
-                self._download_pending.pop(key)
-                if self.debug:
-                    print("Failed %s: %s" % (url, str(e)))
-                continue
-            if 'content-type' not in headers or headers['content-type'].find('image') == -1:
-                if key not in self._tile_cache:
-                    self._tile_cache[key] = self._unavailable
-                self._download_pending.pop(key)
-                if self.debug:
-                    print("non-image response %s" % url)
-                continue
-            else:
-                img = resp.read()
+        try:
+            if self.debug:
+                print("Downloading %s [%u left]" % (url, self.tiles_pending()))
+            req = url_request(url)
+            req.add_header('User-Agent', 'MAVProxy')
 
-            # see if its a blank/unavailable tile
-            md5 = hashlib.md5(img).hexdigest()
-            if md5 in BLANK_TILES:
-                if self.debug:
-                    print("blank tile %s" % url)
-                    if key not in self._tile_cache:
-                        self._tile_cache[key] = self._unavailable
-                self._download_pending.pop(key)
-                continue
-
-            mp_util.mkdir_p(os.path.dirname(path))
-            # use a unique tmp name so concurrent downloaders (eg. two
-            # MAVProxy instances sharing the cache) can't race on the rename
-            tmppath = "%s.tmp.%u.%u" % (path, os.getpid(), threading.get_ident())
+            # try to re-use our cached data:
             try:
-                with open(tmppath, 'wb') as h:
-                    h.write(img)
-                os.replace(tmppath, path)
-            except OSError:
+                mtime = os.path.getmtime(path)
+                req.add_header('If-Modified-Since', time.strftime('%a, %d %b %Y %H:%M:%S GMT', time.gmtime(mtime)))
+            except Exception:
                 pass
-            self._download_pending.pop(key)
-        self._download_thread = None
+
+            if url.find('google') != -1:
+                req.add_header('Referer', 'https://maps.google.com/')
+            resp = url_open(req)
+            headers = resp.info()
+        except url_error as e:
+            try:
+                if e.getcode() == 304:
+                    # cache hit; touch the file to reset its refresh time
+                    pathlib.Path(path).touch()
+                    return
+            except Exception:
+                pass
+
+            # print('Error loading %s' % url)
+            if key not in self._tile_cache:
+                self._tile_cache[key] = self._unavailable
+            if self.debug:
+                print("Failed %s: %s" % (url, str(e)))
+            return
+        if 'content-type' not in headers or headers['content-type'].find('image') == -1:
+            if key not in self._tile_cache:
+                self._tile_cache[key] = self._unavailable
+            if self.debug:
+                print("non-image response %s" % url)
+            return
+        else:
+            img = resp.read()
+
+        # see if its a blank/unavailable tile
+        md5 = hashlib.md5(img).hexdigest()
+        if md5 in BLANK_TILES:
+            if self.debug:
+                print("blank tile %s" % url)
+                if key not in self._tile_cache:
+                    self._tile_cache[key] = self._unavailable
+            return
+
+        mp_util.mkdir_p(os.path.dirname(path))
+        # use a unique tmp name so concurrent downloaders (eg. two
+        # MAVProxy instances sharing the cache) can't race on the rename
+        tmppath = "%s.tmp.%u.%u" % (path, os.getpid(), threading.get_ident())
+        try:
+            with open(tmppath, 'wb') as h:
+                h.write(img)
+            os.replace(tmppath, path)
+        except OSError:
+            pass
 
     def start_download_thread(self):
-        '''start the downloader'''
-        if self._download_thread and self._download_thread.is_alive():
-            return
-        t = threading.Thread(target=self.downloader)
-        t.daemon = True
-        self._download_thread = t
-        t.start()
+        '''start the downloaders, up to download_threads of them'''
+        with self._download_lock:
+            self._download_threads = [t for t in self._download_threads
+                                      if t.is_alive()]
+            starting = [threading.Thread(target=self.downloader)
+                        for _ in range(self.download_threads - len(self._download_threads))]
+            self._download_threads.extend(starting)
+        for t in starting:
+            t.daemon = True
+            t.start()
 
     def load_tile_lowres(self, tile):
         '''load a lower resolution tile from cache to fill in a
@@ -479,10 +515,7 @@ class MPTile:
             # cv2.rectangle(ret, (0,0), (TILES_WIDTH-1,TILES_WIDTH-1), (255,0,0), 1)
             # if it is an old tile, then try to refresh
             if os.path.getmtime(path) + self.refresh_age < time.time():
-                try:
-                    self._download_pending[key].refresh_time()
-                except Exception:
-                    self._download_pending[key] = tile
+                self.queue_download(key, tile)
                 self.start_download_thread()
 
             # add it to the tile cache
@@ -497,10 +530,7 @@ class MPTile:
                 img = self._unavailable
             return img
 
-        try:
-            self._download_pending[key].refresh_time()
-        except Exception:
-            self._download_pending[key] = tile
+        self.queue_download(key, tile)
         self.start_download_thread()
 
         img = self.load_tile_lowres(tile)

--- a/MAVProxy/modules/mavproxy_map/mp_tile.py
+++ b/MAVProxy/modules/mavproxy_map/mp_tile.py
@@ -262,6 +262,7 @@ class MPTile:
         self._download_pending = {}
         self._download_active = set()
         self._download_running = 0
+        self._download_revision = 0
         self._download_lock = threading.Lock()
         self._loading = mp_icon('loading.jpg')
         self._unavailable = mp_icon('unavailable.jpg')
@@ -313,17 +314,32 @@ class MPTile:
         '''return number of tiles pending download'''
         return len(self._download_pending)
 
+    def download_revision(self):
+        '''return a counter that changes whenever a download finishes'''
+        with self._download_lock:
+            return self._download_revision
+
+    def _queue_download(self, key, tile_info, priority):
+        '''queue one download while holding _download_lock'''
+        pending = self._download_pending.get(key)
+        if pending is not None:
+            pending.refresh_time()
+            pending.priority = min(pending.priority, priority)
+        else:
+            tile_info.priority = priority
+            self._download_pending[key] = tile_info
+
     def queue_download(self, key, tile_info, priority=0.0):
         '''queue a tile for download. priority orders the queue, lowest first;
         a tile already queued keeps the most urgent priority it was asked with'''
         with self._download_lock:
-            pending = self._download_pending.get(key)
-            if pending is not None:
-                pending.refresh_time()
-                pending.priority = min(pending.priority, priority)
-            else:
-                tile_info.priority = priority
-                self._download_pending[key] = tile_info
+            self._queue_download(key, tile_info, priority)
+
+    def queue_downloads(self, requests):
+        '''atomically queue a list of (key, tile_info, priority) requests'''
+        with self._download_lock:
+            for key, tile_info, priority in requests:
+                self._queue_download(key, tile_info, priority)
 
     def _claim_download(self):
         '''claim the next tile to fetch, or None when there is nothing left.
@@ -354,6 +370,7 @@ class MPTile:
         with self._download_lock:
             self._download_active.discard(key)
             self._download_pending.pop(key, None)
+            self._download_revision += 1
 
     def downloader(self):
         '''a download thread: fetch tiles until there are none left to claim'''
@@ -366,6 +383,14 @@ class MPTile:
                     return
                 try:
                     self.download_tile(tile_info)
+                except Exception as e:
+                    # keep draining the queue. Deliberately not cached as
+                    # unavailable: an error out here is a dropped connection or
+                    # a read timeout rather than a verdict on the tile, so let
+                    # the next redraw ask for it again
+                    if self.debug:
+                        print("Failed %s: %s" %
+                              (tile_info.url(self.service), str(e)))
                 finally:
                     self._release_download(tile_info.key())
         finally:
@@ -510,7 +535,7 @@ class MPTile:
             return scaled
         return None
 
-    def load_tile(self, tile, priority=0.0):
+    def load_tile(self, tile, priority=0.0, download_queue=None):
         '''load a tile from cache or tile server. priority orders any download
         this triggers, lowest first'''
 
@@ -533,8 +558,11 @@ class MPTile:
             # cv2.rectangle(ret, (0,0), (TILES_WIDTH-1,TILES_WIDTH-1), (255,0,0), 1)
             # if it is an old tile, then try to refresh
             if os.path.getmtime(path) + self.refresh_age < time.time():
-                self.queue_download(key, tile, priority)
-                self.start_download_thread()
+                if download_queue is None:
+                    self.queue_download(key, tile, priority)
+                    self.start_download_thread()
+                else:
+                    download_queue.append((key, tile, priority))
 
             # add it to the tile cache
             self._tile_cache[key] = ret
@@ -548,8 +576,11 @@ class MPTile:
                 img = self._unavailable
             return img
 
-        self.queue_download(key, tile, priority)
-        self.start_download_thread()
+        if download_queue is None:
+            self.queue_download(key, tile, priority)
+            self.start_download_thread()
+        else:
+            download_queue.append((key, tile, priority))
 
         img = self.load_tile_lowres(tile)
         if img is None:
@@ -713,9 +744,20 @@ class MPTile:
             for ((_, _, tinfo), distance) in zip(tiles, distances):
                 tile_priority[tinfo.key()] = priority + distance * scale
 
+        # Load and queue in mosaic order, then start the workers once every
+        # request and its priority are visible to the claimers.
+        loaded_tiles = []
+        download_queue = []
         for (ix, iy, tinfo) in tiles:
             tile_img = self.load_tile(tinfo,
-                                      tile_priority.get(tinfo.key(), priority))
+                                      tile_priority.get(tinfo.key(), priority),
+                                      download_queue=download_queue)
+            loaded_tiles.append((ix, iy, tile_img))
+        self.queue_downloads(download_queue)
+        if self.tiles_pending() > 0:
+            self.start_download_thread()
+
+        for (ix, iy, tile_img) in loaded_tiles:
             if tile_img is None:
                 continue
             if tile_img.shape[0] != TILES_HEIGHT or tile_img.shape[1] != TILES_WIDTH:

--- a/MAVProxy/modules/mavproxy_map/mp_tile.py
+++ b/MAVProxy/modules/mavproxy_map/mp_tile.py
@@ -156,6 +156,7 @@ class TileInfo:
         self.zoom = zoom
         self.service = service
         (self.offsetx, self.offsety) = offset
+        self.priority = 0.0     # download queue order, lowest fetched first
         self.refresh_time()
 
     def key(self):
@@ -312,13 +313,16 @@ class MPTile:
         '''return number of tiles pending download'''
         return len(self._download_pending)
 
-    def queue_download(self, key, tile_info):
-        '''queue a tile for download, or bump its priority if already queued'''
+    def queue_download(self, key, tile_info, priority=0.0):
+        '''queue a tile for download. priority orders the queue, lowest first;
+        a tile already queued keeps the most urgent priority it was asked with'''
         with self._download_lock:
             pending = self._download_pending.get(key)
             if pending is not None:
                 pending.refresh_time()
+                pending.priority = min(pending.priority, priority)
             else:
+                tile_info.priority = priority
                 self._download_pending[key] = tile_info
 
     def _claim_download(self):
@@ -331,13 +335,15 @@ class MPTile:
         '''
         with self._download_lock:
             tile_info = None
+            best = None
             for key in sorted(self._download_pending.keys()):
                 pending = self._download_pending[key]
                 if key in self._download_active:
                     continue
-                # choose by request_time, newest first
-                if tile_info is None or pending.request_time > tile_info.request_time:
-                    tile_info = pending
+                # lowest priority value first, then the newest request
+                rank = (pending.priority, -pending.request_time)
+                if best is None or rank < best:
+                    (best, tile_info) = (rank, pending)
             if tile_info is None:
                 self._download_running -= 1
             else:
@@ -504,8 +510,9 @@ class MPTile:
             return scaled
         return None
 
-    def load_tile(self, tile):
-        '''load a tile from cache or tile server'''
+    def load_tile(self, tile, priority=0.0):
+        '''load a tile from cache or tile server. priority orders any download
+        this triggers, lowest first'''
 
         # see if its in the tile cache
         key = tile.key()
@@ -526,7 +533,7 @@ class MPTile:
             # cv2.rectangle(ret, (0,0), (TILES_WIDTH-1,TILES_WIDTH-1), (255,0,0), 1)
             # if it is an old tile, then try to refresh
             if os.path.getmtime(path) + self.refresh_age < time.time():
-                self.queue_download(key, tile)
+                self.queue_download(key, tile, priority)
                 self.start_download_thread()
 
             # add it to the tile cache
@@ -541,7 +548,7 @@ class MPTile:
                 img = self._unavailable
             return img
 
-        self.queue_download(key, tile)
+        self.queue_download(key, tile, priority)
         self.start_download_thread()
 
         img = self.load_tile_lowres(tile)
@@ -666,7 +673,8 @@ class MPTile:
                                           (srcx, srcy), (dstx, dsty), self.service))
         return ret
 
-    def area_to_image(self, lat, lon, width, height, ground_width, zoom=None, ordered=True):
+    def area_to_image(self, lat, lon, width, height, ground_width, zoom=None,
+                      ordered=True, priority=0.0):
         '''return an RGB image for an area of land, with ground_width
         in meters, and width/height in pixels.
 
@@ -693,14 +701,21 @@ class MPTile:
                 tx = (tile_min.x + ix) % world_tiles
                 tiles.append((ix, iy, TileInfo((tx, ty), zoom, self.service)))
 
-        # request the tiles nearest the middle last so they get the most
-        # recent download request and are fetched first
+        # fetch the tiles nearest the middle first. The distance is folded into
+        # the fraction below the caller's priority, so a caller compositing
+        # several images still gets all of a nearer one before a further one
+        tile_priority = {}
         if ordered:
             (midlat, midlon) = self.coord_from_area(width/2, height/2, lat, lon, width, ground_width)
-            tiles.sort(key=lambda t: t[2].distance(midlat, midlon), reverse=True)
+            distances = [t[2].distance(midlat, midlon) for t in tiles]
+            furthest = max(distances) if distances else 0.0
+            scale = 1.0 / (furthest * 1.0001) if furthest > 0 else 0.0
+            for ((_, _, tinfo), distance) in zip(tiles, distances):
+                tile_priority[tinfo.key()] = priority + distance * scale
 
         for (ix, iy, tinfo) in tiles:
-            tile_img = self.load_tile(tinfo)
+            tile_img = self.load_tile(tinfo,
+                                      tile_priority.get(tinfo.key(), priority))
             if tile_img is None:
                 continue
             if tile_img.shape[0] != TILES_HEIGHT or tile_img.shape[1] != TILES_WIDTH:

--- a/MAVProxy/modules/mavproxy_map3d/__init__.py
+++ b/MAVProxy/modules/mavproxy_map3d/__init__.py
@@ -67,7 +67,7 @@ class Map3DModule(mp_module.MPModule):
         self.last_attitude = (0.0, 0.0, 0.0)
         self.home_amsl = None
         self.home_position = None
-        self.vehicle_type = None
+        self.icon_type = None
         self.follow = True
         self.kml_change_state = None
         self.terrain_lock = threading.Lock()
@@ -151,9 +151,9 @@ class Map3DModule(mp_module.MPModule):
         if heartbeat is not None:
             name = mp_util.vehicle_type_name(heartbeat.type)
             if name is not None:
-                self.vehicle_type = name
-        if self.vehicle_type is not None:
-            self.map.set_vehicle_type(self.vehicle_type)
+                self.icon_type = name
+        if self.icon_type is not None:
+            self.map.set_vehicle_type(self.icon_type)
 
         attitude = messages.get('ATTITUDE')
         if attitude is not None:
@@ -300,12 +300,14 @@ class Map3DModule(mp_module.MPModule):
             items.append((lat, lon, z, frame, w.command, w.seq))
         self.map.set_mission(items)
 
-    def set_vehicle_type(self, vehicle_type):
-        '''vehicle type changed: the viewer picks its icon from it'''
-        if vehicle_type is None or vehicle_type == self.vehicle_type:
+    def set_icon_type(self, name):
+        '''vehicle type changed: the viewer picks its icon from it. Not named
+        vehicle_type: MPModule has a read-only property of that name, and it is
+        a coarser mapping than the icons need (no heli or boat of its own)'''
+        if name is None or name == self.icon_type:
             return
-        self.vehicle_type = vehicle_type
-        self.map.set_vehicle_type(vehicle_type)
+        self.icon_type = name
+        self.map.set_vehicle_type(name)
 
     def set_home_position(self, lat, lon):
         '''home moved: around-home fence circles are centred on it, and a
@@ -468,7 +470,7 @@ class Map3DModule(mp_module.MPModule):
             return
         mtype = m.get_type()
         if mtype in ('HEARTBEAT', 'HIGH_LATENCY2'):
-            self.set_vehicle_type(mp_util.vehicle_type_name(m.type))
+            self.set_icon_type(mp_util.vehicle_type_name(m.type))
         elif mtype == 'HOME_POSITION':
             self.home_amsl = m.altitude * 1.0e-3     # AMSL (mm -> m)
             self.map.set_home(self.home_amsl)

--- a/MAVProxy/modules/mavproxy_map3d/__init__.py
+++ b/MAVProxy/modules/mavproxy_map3d/__init__.py
@@ -23,6 +23,9 @@ FENCE_EXCLUSION_BGR = (255, 0, 0)
 FENCE_RETURN_BGR = (255, 127, 127)
 FENCE_RETURN_RADIUS = 10.0
 
+# takeoff items normally carry an altitude and no position
+TAKEOFF_COMMANDS = (22, 84)      # NAV_TAKEOFF, NAV_VTOL_TAKEOFF
+
 
 def bgr_to_rgb(bgr, default=(1.0, 0.0, 1.0)):
     '''SlipMap/OpenCV colours are BGR; VTK wants RGB floats'''
@@ -245,7 +248,21 @@ class Map3DModule(mp_module.MPModule):
             if resolved:
                 self.terrain_resolved = True
 
+    def mission_home(self, wploader):
+        '''lat/lon a positionless takeoff climbs from, or None'''
+        if self.home_position is not None:
+            return self.home_position
+        try:
+            home = wploader.wp(0)
+        except Exception:
+            return None
+        if home is None or (home.x == 0 and home.y == 0):
+            return None
+        return (home.x, home.y)
+
     def send_mission(self):
+        if self.map is None:
+            return
         try:
             wploader = self.module('wp').wploader
         except Exception:
@@ -253,23 +270,33 @@ class Map3DModule(mp_module.MPModule):
         items = []
         for w in wploader.wpoints:
             frame = getattr(w, 'frame', 0)
-            if w.x == 0 and w.y == 0 and w.command not in (16, 22, 82):
+            (lat, lon) = (w.x, w.y)
+            if lat == 0 and lon == 0 and w.command in TAKEOFF_COMMANDS:
+                # draw the climb from home, otherwise the takeoff altitude is
+                # dropped and the mission appears to start at the first waypoint
+                home = self.mission_home(wploader)
+                if home is None:
+                    continue
+                (lat, lon) = home
+            if lat == 0 and lon == 0:
                 continue
             z = w.z
             if frame in (10, 11):    # terrain-relative -> resolve to AMSL
-                terr = self.terrain_alt(w.x, w.y)
+                terr = self.terrain_alt(lat, lon)
                 if terr is not None:
                     z = terr + w.z
                     frame = 0
-            items.append((w.x, w.y, z, frame, w.command, w.seq))
+            items.append((lat, lon, z, frame, w.command, w.seq))
         self.map.set_mission(items)
 
     def set_home_position(self, lat, lon):
-        '''home moved: around-home fence circles are centred on it'''
+        '''home moved: around-home fence circles are centred on it, and a
+        positionless takeoff is drawn there'''
         if (lat, lon) == self.home_position:
             return
         self.home_position = (lat, lon)
         self.send_fence()
+        self.send_mission()
 
     @staticmethod
     def _fence_latlon(item):

--- a/MAVProxy/modules/mavproxy_map3d/__init__.py
+++ b/MAVProxy/modules/mavproxy_map3d/__init__.py
@@ -13,6 +13,7 @@ import time
 
 from MAVProxy.modules.lib import mp_module
 from MAVProxy.modules.lib import mp_settings
+from MAVProxy.modules.lib import mp_util
 from MAVProxy.modules.mavproxy_map3d.map3d import (
     Map3D, missing_packages, missing_packages_message)
 
@@ -66,6 +67,7 @@ class Map3DModule(mp_module.MPModule):
         self.last_attitude = (0.0, 0.0, 0.0)
         self.home_amsl = None
         self.home_position = None
+        self.vehicle_type = None
         self.follow = True
         self.kml_change_state = None
         self.terrain_lock = threading.Lock()
@@ -143,6 +145,15 @@ class Map3DModule(mp_module.MPModule):
             messages = self.master.messages
         except Exception:
             return
+
+        # a restarted viewer child knows nothing, so push the type again
+        heartbeat = messages.get('HEARTBEAT')
+        if heartbeat is not None:
+            name = mp_util.vehicle_type_name(heartbeat.type)
+            if name is not None:
+                self.vehicle_type = name
+        if self.vehicle_type is not None:
+            self.map.set_vehicle_type(self.vehicle_type)
 
         attitude = messages.get('ATTITUDE')
         if attitude is not None:
@@ -288,6 +299,13 @@ class Map3DModule(mp_module.MPModule):
                     frame = 0
             items.append((lat, lon, z, frame, w.command, w.seq))
         self.map.set_mission(items)
+
+    def set_vehicle_type(self, vehicle_type):
+        '''vehicle type changed: the viewer picks its icon from it'''
+        if vehicle_type is None or vehicle_type == self.vehicle_type:
+            return
+        self.vehicle_type = vehicle_type
+        self.map.set_vehicle_type(vehicle_type)
 
     def set_home_position(self, lat, lon):
         '''home moved: around-home fence circles are centred on it, and a
@@ -449,7 +467,9 @@ class Map3DModule(mp_module.MPModule):
         if self.map is None or not self.map.is_alive():
             return
         mtype = m.get_type()
-        if mtype == 'HOME_POSITION':
+        if mtype in ('HEARTBEAT', 'HIGH_LATENCY2'):
+            self.set_vehicle_type(mp_util.vehicle_type_name(m.type))
+        elif mtype == 'HOME_POSITION':
             self.home_amsl = m.altitude * 1.0e-3     # AMSL (mm -> m)
             self.map.set_home(self.home_amsl)
             self.set_home_position(m.latitude * 1.0e-7, m.longitude * 1.0e-7)

--- a/MAVProxy/modules/mavproxy_map3d/elements.py
+++ b/MAVProxy/modules/mavproxy_map3d/elements.py
@@ -77,26 +77,135 @@ def _polyline(points_enu, colour, width, dashed=False):
     return actor
 
 
-def _vehicle_icon():
-    '''Return an opaque aircraft glyph in the local horizontal plane.
+def _circle(cx, cy, radius, segments=20):
+    '''polygon approximating a circle'''
+    return [(cx + radius * math.sin(2 * math.pi * i / segments),
+             cy + radius * math.cos(2 * math.pi * i / segments))
+            for i in range(segments)]
 
-    Using native geometry avoids platform-dependent PNG alpha/texture issues.
-    The outline coordinates describe a unit aircraft pointing towards +Y.
-    '''
-    outline = [
+
+def _ellipse(cx, cy, rx, ry, segments=24):
+    return [(cx + rx * math.sin(2 * math.pi * i / segments),
+             cy + ry * math.cos(2 * math.pi * i / segments))
+            for i in range(segments)]
+
+
+def _bar(p0, p1, width):
+    '''rectangle of the given width running along p0 -> p1'''
+    ((x0, y0), (x1, y1)) = (p0, p1)
+    (dx, dy) = (x1 - x0, y1 - y0)
+    length = math.hypot(dx, dy)
+    (ox, oy) = (-dy / length * width * 0.5, dx / length * width * 0.5)
+    return [(x0 + ox, y0 + oy), (x1 + ox, y1 + oy),
+            (x1 - ox, y1 - oy), (x0 - ox, y0 - oy)]
+
+
+def _plane_shape():
+    return [[
         (0.00, 0.50), (-0.07, 0.24), (-0.48, 0.02), (-0.48, -0.07),
         (-0.08, 0.00), (-0.07, -0.30), (-0.22, -0.43), (-0.22, -0.50),
         (0.00, -0.42), (0.22, -0.50), (0.22, -0.43), (0.07, -0.30),
         (0.08, 0.00), (0.48, -0.07), (0.48, 0.02), (0.07, 0.24),
-    ]
+    ]]
+
+
+def _copter_shape():
+    '''motors on X arms, with a forward pointing body so heading reads'''
+    shapes = []
+    arm = 0.32
+    for (x, y) in ((-arm, arm), (arm, arm), (-arm, -arm), (arm, -arm)):
+        shapes.append(_bar((0.0, 0.0), (x, y), 0.09))
+        shapes.append(_circle(x, y, 0.16))
+    shapes.append([(0.00, 0.36), (0.15, -0.06), (0.00, -0.18), (-0.15, -0.06)])
+    return shapes
+
+
+def _singlecopter_shape():
+    '''ducted rotor with control vanes below it'''
+    return [_circle(0.0, 0.06, 0.32),
+            [(0.00, 0.50), (0.15, 0.22), (-0.15, 0.22)],
+            _bar((-0.34, -0.30), (0.34, -0.30), 0.12),
+            _bar((0.0, -0.44), (0.0, -0.16), 0.12)]
+
+
+def _heli_shape():
+    '''crossed rotor blades, cabin, and a tail boom reaching past the disc'''
+    return [_bar((-0.34, 0.46), (0.34, -0.22), 0.05),
+            _bar((-0.34, -0.22), (0.34, 0.46), 0.05),
+            _ellipse(0.0, 0.16, 0.14, 0.26),
+            _bar((0.0, 0.16), (0.0, -0.48), 0.07),
+            _bar((-0.13, -0.44), (0.13, -0.44), 0.20)]
+
+
+def _rover_shape():
+    '''car body with the wheels clear of it in silhouette'''
+    return [[(0.00, 0.46), (0.16, 0.30), (0.16, -0.44), (-0.16, -0.44),
+             (-0.16, 0.30)],
+            _bar((-0.30, 0.30), (-0.30, 0.04), 0.16),
+            _bar((0.30, 0.30), (0.30, 0.04), 0.16),
+            _bar((-0.30, -0.14), (-0.30, -0.40), 0.16),
+            _bar((0.30, -0.14), (0.30, -0.40), 0.16)]
+
+
+def _boat_shape():
+    '''pointed bow and square transom, with a beam across midships'''
+    return [[(0.00, 0.50), (0.16, 0.10), (0.16, -0.40), (-0.16, -0.40),
+             (-0.16, 0.10)],
+            _bar((-0.34, 0.02), (0.34, 0.02), 0.10)]
+
+
+def _sub_shape():
+    '''slim hull with bow planes and tail fins'''
+    return [_ellipse(0.0, 0.02, 0.12, 0.44),
+            _bar((-0.20, 0.14), (0.20, 0.14), 0.14),
+            _bar((-0.26, -0.36), (0.26, -0.36), 0.09)]
+
+
+def _antenna_shape():
+    '''a dish on a mast, pointing the way the tracker is aimed'''
+    return [[(0.00, 0.08), (0.34, 0.44), (0.20, 0.50), (-0.20, 0.50),
+             (-0.34, 0.44)],
+            _bar((0.0, 0.16), (0.0, -0.30), 0.09),
+            _bar((-0.26, -0.42), (0.26, -0.42), 0.16)]
+
+
+def _blimp_shape():
+    '''fat envelope with large tail fins'''
+    return [_ellipse(0.0, 0.06, 0.22, 0.42),
+            _bar((-0.34, -0.30), (0.34, -0.30), 0.12)]
+
+
+# keyed by the names mp_util.vehicle_type_name() returns
+VEHICLE_SHAPES = {
+    'plane': _plane_shape,
+    'copter': _copter_shape,
+    'singlecopter': _singlecopter_shape,
+    'heli': _heli_shape,
+    'rover': _rover_shape,
+    'boat': _boat_shape,
+    'sub': _sub_shape,
+    'antenna': _antenna_shape,
+    'blimp': _blimp_shape,
+}
+DEFAULT_VEHICLE_TYPE = 'plane'
+
+
+def _vehicle_icon(vehicle_type=DEFAULT_VEHICLE_TYPE):
+    '''Return an opaque vehicle glyph in the local horizontal plane.
+
+    Using native geometry avoids platform-dependent PNG alpha/texture issues.
+    The outlines describe a unit vehicle pointing towards +Y. The glyph is a
+    single colour, so overlapping shapes just merge into one silhouette.
+    '''
+    shape = VEHICLE_SHAPES.get(vehicle_type, VEHICLE_SHAPES[DEFAULT_VEHICLE_TYPE])
     points = vtk.vtkPoints()
-    polygon = vtk.vtkPolygon()
-    polygon.GetPointIds().SetNumberOfIds(len(outline))
-    for i, (x, y) in enumerate(outline):
-        points.InsertNextPoint(x, y, 0.0)
-        polygon.GetPointIds().SetId(i, i)
     cells = vtk.vtkCellArray()
-    cells.InsertNextCell(polygon)
+    for outline in shape():
+        polygon = vtk.vtkPolygon()
+        polygon.GetPointIds().SetNumberOfIds(len(outline))
+        for i, (x, y) in enumerate(outline):
+            polygon.GetPointIds().SetId(i, points.InsertNextPoint(x, y, 0.0))
+        cells.InsertNextCell(polygon)
     poly = vtk.vtkPolyData()
     poly.SetPoints(points)
     poly.SetPolys(cells)
@@ -148,6 +257,7 @@ class ElementManager:
         self.vehicle = None
         self.vehicle_pose = None
         self.vehicle_visible = True
+        self.vehicle_type = DEFAULT_VEHICLE_TYPE
         self.terrain_height = None
         self.fence = []
         self.fence_geometry = None
@@ -186,6 +296,16 @@ class ElementManager:
         self.vehicle_visible = bool(visible)
         if self.vehicle is not None:
             self.vehicle.SetVisibility(self.vehicle_visible)
+
+    def set_vehicle_type(self, vehicle_type):
+        '''vehicle_type is a name from mp_util.vehicle_type_name()'''
+        if vehicle_type not in VEHICLE_SHAPES or vehicle_type == self.vehicle_type:
+            return
+        self.vehicle_type = vehicle_type
+        if self.vehicle is not None:
+            self.ren.RemoveActor(self.vehicle)
+            self.vehicle = None
+            self.refresh_vehicle()
 
     def set_path(self, path):
         '''path: list of (lat,lon,amsl)'''
@@ -338,7 +458,7 @@ class ElementManager:
             return None
         lat, lon, amsl, roll, pitch, yaw = self.vehicle_pose
         if self.vehicle is None:
-            self.vehicle = _vehicle_icon()
+            self.vehicle = _vehicle_icon(self.vehicle_type)
             self.vehicle.SetVisibility(self.vehicle_visible)
             self.ren.AddActor(self.vehicle)
         e, n, u = self._enu(lat, lon, amsl)

--- a/MAVProxy/modules/mavproxy_map3d/map3d.py
+++ b/MAVProxy/modules/mavproxy_map3d/map3d.py
@@ -103,6 +103,10 @@ class Map3D:
     def set_vehicle(self, lat, lon, amsl, roll=0.0, pitch=0.0, yaw=0.0):
         self._put(('vehicle', lat, lon, amsl, roll, pitch, yaw))
 
+    def set_vehicle_type(self, vehicle_type):
+        '''vehicle_type is a name from mp_util.vehicle_type_name()'''
+        self._put(('vehicletype', vehicle_type))
+
     def set_path(self, path):
         self._put(('path', list(path)))
 

--- a/MAVProxy/modules/mavproxy_map3d/map3d_test.py
+++ b/MAVProxy/modules/mavproxy_map3d/map3d_test.py
@@ -16,7 +16,8 @@ import vtk
 
 from pymavlink import mavutil
 from MAVProxy.modules.mavproxy_map import mp_tile
-from MAVProxy.modules.mavproxy_map3d.terrain import TerrainManager, R
+from MAVProxy.modules.mavproxy_map3d.terrain import (
+    TerrainManager, R, TILE_DOWNLOAD_THREADS)
 from MAVProxy.modules.mavproxy_map3d.elements import ElementManager
 from MAVProxy.modules.mavproxy_map3d.camera import TerrainCamera
 
@@ -86,7 +87,8 @@ def main():
     # offscreen: drive the core directly
     ren = vtk.vtkRenderer()
     ren.SetBackground(0.45, 0.62, 0.85)
-    mt = mp_tile.MPTile(service=args.service, tile_delay=0.02)
+    mt = mp_tile.MPTile(service=args.service, tile_delay=0.02,
+                        download_threads=TILE_DOWNLOAD_THREADS)
     terrain = TerrainManager(ren, mt, lat0, lon0, zexag=args.zexag,
                              fine_radius=3, screen_h=args.height)
     elements = ElementManager(ren, lat0, lon0, args.zexag)

--- a/MAVProxy/modules/mavproxy_map3d/map3d_ui.py
+++ b/MAVProxy/modules/mavproxy_map3d/map3d_ui.py
@@ -91,6 +91,7 @@ class Map3DFrame(wx.Frame):
         self.follow = bool(state.follow)
         self.last_vehicle = None
         self.last_vehicle_pose = None
+        self.vehicle_type = None
         self.kml_features = []
         self.kml_refresh_due = None
         self.overlay_mesh_revision = -1
@@ -157,6 +158,8 @@ class Map3DFrame(wx.Frame):
                                       shading=self.terrain_shading,
                                       wireframe=self.terrain_wireframe)
         self.elements = ElementManager(self.ren, lat0, lon0, self.state.zexag)
+        if self.vehicle_type is not None:
+            self.elements.set_vehicle_type(self.vehicle_type)
         self.elements.set_terrain_height(self.terrain.height_at)
         self.elements.set_home(amsl_ref)
         self.elements.set_kml(self.kml_features, self.terrain.height_at,
@@ -330,6 +333,13 @@ class Map3DFrame(wx.Frame):
             return
         if kind == 'follow':
             self.set_follow_enabled(msg[1])
+            return
+        if kind == 'vehicletype':
+            # may arrive before the scene exists, so keep it for init_scene
+            self.vehicle_type = msg[1]
+            if self.elements is not None:
+                self.elements.set_vehicle_type(self.vehicle_type)
+                self.render()
             return
         if kind == 'kml':
             self.kml_features = list(msg[1])

--- a/MAVProxy/modules/mavproxy_map3d/map3d_ui.py
+++ b/MAVProxy/modules/mavproxy_map3d/map3d_ui.py
@@ -13,7 +13,8 @@ from vtkmodules.wx.wxVTKRenderWindowInteractor import wxVTKRenderWindowInteracto
 
 from MAVProxy.modules.mavproxy_map import mp_tile
 from MAVProxy.modules.mavproxy_map3d.camera import TerrainCamera, TerrainStyle
-from MAVProxy.modules.mavproxy_map3d.terrain import TerrainManager, R
+from MAVProxy.modules.mavproxy_map3d.terrain import (
+    TerrainManager, R, TILE_DOWNLOAD_THREADS)
 from MAVProxy.modules.mavproxy_map3d.elements import ElementManager
 
 import vtk
@@ -147,7 +148,8 @@ class Map3DFrame(wx.Frame):
     # ----------------------------------------------------------------- scene
     def init_scene(self, lat0, lon0, amsl_ref):
         self.status_actor.SetInput("Loading terrain...")
-        self.mt = mp_tile.MPTile(service=self.state.service, tile_delay=0.02)
+        self.mt = mp_tile.MPTile(service=self.state.service, tile_delay=0.02,
+                                 download_threads=TILE_DOWNLOAD_THREADS)
         self.terrain = TerrainManager(self.ren, self.mt, lat0, lon0,
                                       zexag=self.state.zexag,
                                       screen_h=self.GetClientSize()[1] or self.state.height,

--- a/MAVProxy/modules/mavproxy_map3d/terrain.py
+++ b/MAVProxy/modules/mavproxy_map3d/terrain.py
@@ -278,16 +278,20 @@ class Tile:
         self.tex_key = key
 
 
-def build_texture_image(mt, lock, vw, vs, ve, vn, img_zoom, tex_w):
+def build_texture_image(mt, lock, vw, vs, ve, vn, img_zoom, tex_w, priority=0.0):
     '''worker thread: assemble the draped Mercator image for a tile. Does NOT
     block on downloads (mp_tile fetches imagery on its own thread); missing
-    imagery comes back as placeholders and is refreshed once downloads settle.'''
+    imagery comes back as placeholders and is refreshed once downloads settle.
+
+    priority is the tile's rank from the camera, so the imagery queue drains
+    from the middle of the view outwards however the workers interleave.'''
     dlon = math.radians(ve - vw)
     C = tex_w / dlon
     tex_h = max(1, int(round(C * (mp_tile.mercator_y(vn) - mp_tile.mercator_y(vs)))))
     gw = R * math.cos(math.radians(vn)) * dlon
     with lock:   # mp_tile's in-memory cache is not thread-safe
-        img = mt.area_to_image(vn, vw, tex_w, tex_h, gw, zoom=img_zoom)
+        img = mt.area_to_image(vn, vw, tex_w, tex_h, gw, zoom=img_zoom,
+                               priority=priority)
     return img
 
 
@@ -342,10 +346,11 @@ class TerrainManager:
                     (z, x, y) = payload
                     self.results.put(("decode", jid, decode_terrain(z, x, y)))
                 elif kind == "texture":
-                    (_tilekey, _tkey, params) = payload
+                    (_tilekey, _tkey, params, priority) = payload
                     (vw, vs, ve, vn, img_zoom, tex_w) = params
                     img = build_texture_image(self.mt, self.tex_lock,
-                                              vw, vs, ve, vn, img_zoom, tex_w)
+                                              vw, vs, ve, vn, img_zoom, tex_w,
+                                              priority)
                     self.results.put(("texture", jid, (img, payload)))
             except Exception as e:
                 self.results.put(("error", jid, e))
@@ -412,9 +417,13 @@ class TerrainManager:
                 removed_tile = True
         if removed_tile:
             self.mesh_revision += 1
-        # request textures for present tiles (at most one outstanding per tile)
+        # request textures for present tiles (at most one outstanding per tile),
+        # nearest the camera first. The rank goes down to mp_tile so the imagery
+        # queue is ordered too: several workers fetch tiles concurrently, so the
+        # order jobs are queued in does not by itself decide the download order
         fov_deg = tc.cam.GetViewAngle()
-        for key, tile in self.tiles.items():
+        for rank, key in enumerate(sorted(self.tiles.keys(), key=tile_priority)):
+            tile = self.tiles[key]
             req = tile.texture_request(tc.pos, self.screen_h, self.mt, fov_deg)
             if req is None:
                 continue
@@ -424,7 +433,7 @@ class TerrainManager:
                 continue
             tile.want_key = tkey
             self.inflight.add(jid)
-            self.jobs.put(("texture", jid, (key, tkey, params)))
+            self.jobs.put(("texture", jid, (key, tkey, params, rank)))
 
     def process(self, tc):
         '''main thread: drain worker results, build/update VTK. Returns True if
@@ -460,7 +469,7 @@ class TerrainManager:
                 self.mesh_revision += 1
                 changed = True
             elif kind == "texture":
-                img, (tilekey, tkey, params) = payload
+                img, (tilekey, tkey, params, _priority) = payload
                 (vw, vs, ve, vn, img_zoom, tex_w) = params
                 tile = self.tiles.get(tilekey)
                 if tile is not None and tkey == tile.want_key:

--- a/MAVProxy/modules/mavproxy_map3d/terrain.py
+++ b/MAVProxy/modules/mavproxy_map3d/terrain.py
@@ -319,7 +319,8 @@ class TerrainManager:
         self.jobs = queue.Queue()
         self.results = queue.Queue()
         self.tex_lock = threading.Lock()
-        self.prev_pending = 0
+        self.download_revision = mt.download_revision()
+        self.redrape_pending = False
         self.last_tc = None
         self.stop = False
         self.workers = [threading.Thread(target=self._worker, daemon=True)
@@ -440,13 +441,10 @@ class TerrainManager:
         anything changed (caller should render).'''
         self.last_tc = tc
         changed = False
-        # once imagery downloads settle, re-drape so placeholder tiles sharpen
-        pend = self.mt.tiles_pending()
-        if self.prev_pending > 0 and pend == 0:
-            for t in self.tiles.values():
-                t.tex_key = None
-            self.update(tc)
-        self.prev_pending = pend
+        revision = self.mt.download_revision()
+        if revision != self.download_revision:
+            self.download_revision = revision
+            self.redrape_pending = True
         want = self.desired_set(*self.focal_latlon(tc)) if tc is not None else None
         for _ in range(64):
             try:
@@ -475,6 +473,15 @@ class TerrainManager:
                 if tile is not None and tkey == tile.want_key:
                     tile.apply_texture(img, vw, vs, ve, vn, tex_w, tkey)
                     changed = True
+        # Do not let an old placeholder result restore tex_key after it is
+        # invalidated. Wait for every old texture job, then request fresh ones.
+        texture_inflight = any(jid[0] == "T" for jid in self.inflight)
+        if (self.redrape_pending and self.mt.tiles_pending() == 0 and
+                not texture_inflight and tc is not None):
+            self.redrape_pending = False
+            for tile in self.tiles.values():
+                tile.tex_key = None
+            self.update(tc)
         # after building new tiles, request their textures next update
         if changed and tc is not None:
             self.update(tc)

--- a/MAVProxy/modules/mavproxy_map3d/terrain.py
+++ b/MAVProxy/modules/mavproxy_map3d/terrain.py
@@ -29,6 +29,11 @@ R = 6378137.0
 QUANTIZED_BASE = "https://plot.ardupilot.org/quantized"
 CACHE_DIR = os.path.join(mp_tile.default_cache_path(), "quantized")
 
+# a 3D view drapes hundreds of imagery tiles before it looks like anything, and
+# the fetches are latency bound rather than bandwidth bound, so run them in
+# parallel. One at a time takes minutes on a high latency link such as WSL2.
+TILE_DOWNLOAD_THREADS = 8
+
 # ArduPilot tiles include the optional lighting extension. This decoder warns
 # when it skips that extension, but map3d computes its own VTK normals anyway.
 warnings.filterwarnings(

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,24 @@ requirements=['pymavlink>=2.4.14',
               'numpy',
               'pynmeagps']
 
+# the map3d module needs these, and we want a plain "pip install -U MAVProxy"
+# to bring them in rather than leaving the module dead until someone finds the
+# extra. quantized-mesh-tile requires numpy>=2, which leaves a distro opencv or
+# matplotlib built against numpy 1 unimportable, so the floors are here to pull
+# in builds that match. The floors are needed because pip leaves an unpinned
+# requirement alone when the distro build already satisfies it.
+#
+# vtk only publishes wheels for 64 bit x86/arm on python 3.9 to 3.14, and has no
+# sdist, so an unguarded requirement would fail the whole MAVProxy install on
+# eg. 32 bit Raspberry Pi OS. Where the marker excludes it map3d stays dormant
+# and prints its own install message. Raise the python_version bound when vtk
+# publishes wheels for a newer python.
+MAP3D_MARKER = ('platform_machine in "x86_64 AMD64 aarch64 arm64"'
+                ' and python_version < "3.15"')
+map3d_requirements = ['vtk', 'quantized-mesh-tile',
+                      'opencv-python>=4.10', 'matplotlib>=3.9']
+requirements.extend(['%s; %s' % (r, MAP3D_MARKER) for r in map3d_requirements])
+
 if platform.system() == "Darwin":
     # on MacOS we can have a more complete requirements list
     requirements.extend(['billiard>=3.5.0',
@@ -98,11 +116,11 @@ on how to use MAVProxy.''',
       install_requires=requirements,
       extras_require={
         'cesium': ['tornado'],
-        # map3d module (native 3D terrain map). quantized-mesh-tile needs
-        # numpy>=2, which leaves a distro opencv/matplotlib built against
-        # numpy 1 unimportable, so pull in builds that match
-        'map3d': ['vtk', 'quantized-mesh-tile',
-                  'opencv-python>=4.10', 'matplotlib>=3.9'],
+        # map3d is in the base requirements now. The extra is kept so the
+        # documented MAVProxy[map3d] still works, and asks for the packages
+        # without the platform marker: someone naming it explicitly wants a
+        # loud failure rather than a silently dormant module
+        'map3d': map3d_requirements,
         # restserver module
         'server': ['flask'],
         'recommended': ['flask', 'PyYAML', 'lxml', 'wxpython',

--- a/setup.py
+++ b/setup.py
@@ -38,13 +38,30 @@ requirements=['pymavlink>=2.4.14',
 # in builds that match. The floors are needed because pip leaves an unpinned
 # requirement alone when the distro build already satisfies it.
 #
-# vtk only publishes wheels for 64 bit x86/arm on python 3.9 to 3.14, and has no
-# sdist, so an unguarded requirement would fail the whole MAVProxy install on
-# eg. 32 bit Raspberry Pi OS. Where the marker excludes it map3d stays dormant
-# and prints its own install message. Raise the python_version bound when vtk
-# publishes wheels for a newer python.
-MAP3D_MARKER = ('platform_machine in "x86_64 AMD64 aarch64 arm64"'
-                ' and python_version < "3.15"')
+# These are guarded because a requirement pip cannot satisfy fails the whole
+# MAVProxy install, not just map3d. The marker names exactly the platforms vtk
+# publishes wheels for: it has no sdist, so anywhere else pip has nothing to
+# fall back on. matplotlib>=3.9 sets the python floor. Where the marker excludes
+# it, MAVProxy still installs and map3d stays dormant, printing its own install
+# message if loaded. Raise the python_version bound when vtk publishes wheels
+# for a newer python.
+#
+# It has to be a PEP 508 marker rather than a platform.system() test like the
+# ones below: MAVProxy ships a py3-none-any wheel, so anything decided here at
+# build time is baked in on the build machine, while a marker is evaluated on
+# the installing machine. Equality tests, not "in": the marker "in" operator is
+# substring containment, so platform_machine values of "64" or "" would match.
+#
+# The one gap markers cannot express is the C library, so musl (Alpine) still
+# matches without having vtk wheels. Use the extra there instead.
+MAP3D_MARKER = ('platform_python_implementation == "CPython"'
+                ' and python_version >= "3.9" and python_version < "3.15"'
+                ' and (sys_platform == "linux" or sys_platform == "darwin"'
+                ' or sys_platform == "win32")'
+                ' and (platform_machine == "x86_64"'
+                ' or platform_machine == "AMD64"'
+                ' or platform_machine == "aarch64"'
+                ' or platform_machine == "arm64")')
 map3d_requirements = ['vtk', 'quantized-mesh-tile',
                       'opencv-python>=4.10', 'matplotlib>=3.9']
 requirements.extend(['%s; %s' % (r, MAP3D_MARKER) for r in map3d_requirements])


### PR DESCRIPTION
Fixes the three items in #1721, and makes a normal `pip install` bring map3d's dependencies in.

### Slow initial imagery (WSL2)

The tile downloader was a single thread fetching one tile at a time, so a large area is bounded by round trip latency rather than bandwidth. A 3D view drapes hundreds of imagery tiles before it looks like anything: one view of a test log queued 1002 of them, which at the old rate is around seven minutes of blank terrain.

`mp_tile` gains a `download_threads` option, defaulting to the existing single thread so the 2D map is unchanged, with the pending set under a lock so threads claim distinct tiles. map3d uses eight. Measured on 169 tiles: 74s to 9.0s.

Three further problems turned up while testing that:

- A downloader decided it was finished outside the lock guarding the pending set, so a tile queued in that window could be left with nobody to fetch it. The 2D map hides this by re-requesting on every redraw; map3d waits for the pending count to reach zero before re-draping, so a stranded tile left placeholder imagery on screen indefinitely.
- Centre first fetching relied on requesting the middle tiles last so they carried the newest request time. That only holds with a single caller feeding the queue. Tiles now carry an explicit priority, and `area_to_image` folds the distance from the middle into the fraction below the caller's value. Over one view, 670 tiles, the correlation between fetch order and distance from the view centre goes from -0.64 to 0.87: it was draining the far ring first, worse than random.
- An exception out of `download_tile` killed the worker and stranded the rest of the queue, which left `mavflightview` waiting forever in its `tiles_pending()` loop. `resp.read()` raising `IncompleteRead` or a reset is outside the `url_error` handler, so this was reachable.

### Takeoff altitude

A copter `NAV_TAKEOFF` carries an altitude and no position, so it was dropped as a 0,0 item and the mission appeared to start at the first waypoint with no climb. It is drawn at home now, which is where the vehicle climbs from, and the mission is resent when home arrives. `NAV_VTOL_TAKEOFF` too.

### Vehicle icons

The viewer drew a fixed plane glyph whatever the vehicle was. It follows the type from HEARTBEAT now and draws a glyph for each of the nine types the 2D map has an icon for. They stay native geometry rather than the 2D map's PNGs, which avoids the platform dependent alpha and texture problems. The `MAV_TYPE` to name table moved to `mp_util` so the 2D map and map3d cannot drift apart.

### Dependencies

map3d was left dead after a normal `pip install -U MAVProxy` unless the user found the extra, and the failure surfaces as an unrelated looking numpy or import error from the viewer child rather than as a missing package. The dependencies are in `install_requires` now.

They carry a marker, because a requirement pip cannot satisfy fails the whole MAVProxy install rather than just leaving map3d dormant. vtk publishes no sdist, so the marker names exactly the platforms it ships wheels for: checked against PyPI, it covers all 24 python/platform/machine combinations vtk publishes and excludes everything else. It has to be a marker rather than a `platform.system()` test like the ones further down `setup.py`, because MAVProxy ships a `py3-none-any` wheel and anything decided at build time is baked in on the build machine.

Two things worth knowing before this merges:

- On a matching platform this adds about 250MB of wheels to every install, vtk alone being 146MB, whether or not map3d is used. `quantized-mesh-tile` requires numpy>=2, so the opencv and matplotlib floors come with it to replace distro builds made against numpy 1.
- musl is the one thing a marker cannot express, so Alpine matches without having vtk wheels. The `map3d` extra is still there for that case.

### Testing

- Loaded against SITL and checked the copter icon, the terrain and the drape.
- Offscreen renders from a dataflash log, byte identical before and after the download changes.
- Tile downloads: 169 tiles fetched exactly once each, no duplicates, no partial files, all decodable.
- Concurrency: a stress test over the queue and claim paths, no tile fetched by two threads at once, nothing stranded, no leaked worker slots.
- The mosaic `area_to_image` produces is pixel identical whatever the ordering, so the 2D map and `mavflightview` are unaffected.
- The dependency marker checked over 17 platform cases and against the vtk wheel list.
