### PR TITLE
asterix: restrict default UDP bind address

### DIFF
--- a/MAVProxy/modules/mavproxy_asterix.py
+++ b/MAVProxy/modules/mavproxy_asterix.py
@@ -60,7 +60,8 @@ class AsterixModule(mp_module.MPModule):
                          ["<start|stop>","set (ASTERIXSETTING)"])
 
         # filter_dist is distance in metres
-        self.asterix_settings = mp_settings.MPSettings([("port", int, 45454),
+        self.asterix_settings = mp_settings.MPSettings([('bind_address', str, '127.0.0.1'),
+                                                        ("port", int, 45454),
                                                         ('debug', int, 0),
                                                         ('filter_dist_xy', int, 1000),
                                                         ('filter_dist_z', int, 250),
@@ -122,7 +123,8 @@ class AsterixModule(mp_module.MPModule):
             self.sock.close()
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
         self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        self.sock.bind(('', self.asterix_settings.port))
+        self.sock.bind((self.asterix_settings.bind_address,
+                        self.asterix_settings.port))
         self.sock.setblocking(False)
         print("Started on port %u" % self.asterix_settings.port)
 


### PR DESCRIPTION
Refs #1725.

Adds a configurable `bind_address` setting for the Asterix UDP listener, defaulting to `127.0.0.1` instead of listening on all interfaces.

Users who intentionally need to receive ASTERIX/SDPS traffic from another host can restore the previous all-interface behavior with:

```text
asterix set bind_address 0.0.0.0
asterix restart
```

This changes the default network exposure but otherwise preserves the existing Asterix behavior. The port remains configurable and defaults to `45454`.

The built-in `genobstacles` sender was also tested against an Asterix listener bound specifically to `127.0.0.1` and continues to work without modification.

### Testing

I tested the listener directly, including the default bind, an explicit wildcard bind, restart with a changed address, existing packet handling, and the built-in `genobstacles` sender.

<details>
<summary>Standalone regression test</summary>

```python
#!/usr/bin/env python3
import os
import pickle
import socket
import sys
import tempfile
import time
from types import SimpleNamespace

sys.modules.setdefault('asterix', SimpleNamespace(parse=lambda packet: []))

from MAVProxy.modules import mavproxy_asterix
from MAVProxy.modules import mavproxy_genobstacles


class Console:
    def set_status(self, *args, **kwargs):
        pass


class FakeMAV:
    def adsb_vehicle_encode(self, icao_address, lat, lon, altitude_type,
                            altitude, heading, hor_velocity, ver_velocity,
                            callsign, emitter_type, tslc, flags, squawk):
        return SimpleNamespace(
            ICAO_address=icao_address,
            lat=lat,
            lon=lon,
            altitude=altitude,
            heading=heading,
            hor_velocity=hor_velocity,
            ver_velocity=ver_velocity,
            emitter_type=emitter_type,
        )


class MPState:
    def __init__(self, logdir):
        self.command_map = {}
        self.completions = {}
        self.completion_functions = {}
        self.console = Console()
        self.status = SimpleNamespace(logdir=logdir)
        self.attitude_time_s = 1.0
        self.start_time_s = time.time()
        self.is_sitl = False
        self.mav_master = []
        self.sysid_outputs = {}
        self.public_modules = {}
        self.multi_instance = {}
        self.instance_count = {}
        self._master = SimpleNamespace(mav=FakeMAV())

    def master(self):
        return self._master

    def module(self, name):
        return None


def obstacle_packet():
    return {
        'I010': {'SAC': {'val': 4}, 'SIC': {'val': 0}},
        'I040': {'TrkN': {'val': 0xA00001}},
        'I105': {'Lat': {'val': -27.298440},
                 'Lon': {'val': 151.290775}},
        'I130': {'Alt': {'val': 1000.0}},
        'I220': {'RoC': {'val': 0.0}},
    }


def main():
    with tempfile.TemporaryDirectory(prefix='asterix-1725-') as logdir:
        module = mavproxy_asterix.AsterixModule(MPState(logdir))
        try:
            assert module.asterix_settings.bind_address == '127.0.0.1'
            assert module.asterix_settings.port == 45454
            assert module.sock.getsockname() == ('127.0.0.1', 45454)
            print('PASS default setting and real loopback listener')

            module.asterix_settings.bind_address = '0.0.0.0'
            module.cmd_asterix(['restart'])
            assert module.sock.getsockname() == ('0.0.0.0', 45454)
            print('PASS configured wildcard bind')

            module.asterix_settings.bind_address = '127.0.0.2'
            module.cmd_asterix(['restart'])
            assert module.sock.getsockname() == ('127.0.0.2', 45454)
            print('PASS restart uses newly configured bind address')

            module.asterix_settings.bind_address = '127.0.0.1'
            module.cmd_asterix(['restart'])
            sender = mavproxy_genobstacles.GenobstaclesModule.__new__(
                mavproxy_genobstacles.GenobstaclesModule)
            sender.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM,
                                        socket.IPPROTO_UDP)
            sender.sock.connect(('', mavproxy_genobstacles.gen_settings.port))
            sender.pkt_queue = [b'PICKLED:' + pickle.dumps(obstacle_packet())]
            sender.idle_task()
            deadline = time.time() + 1.0
            while module.pkt_count == 0 and time.time() < deadline:
                module.idle_task()
                time.sleep(0.01)
            assert sender.pkt_queue == []
            assert module.pkt_count == 1
            assert 0xA00001 in module.tracks
            print('PASS built-in genobstacles sender reaches loopback and packet processing works')
            sender.sock.close()
        finally:
            module.stop_listener()
            module.logfile.close()


if __name__ == '__main__':
    main()

```

</details>

The test produced:

```text
default bind_address = 127.0.0.1       PASS
default port = 45454                    PASS
real listener bind to 127.0.0.1        PASS
explicit 0.0.0.0 bind                  PASS
restart with changed bind address      PASS
existing PICKLED packet handling       PASS
genobstacles -> loopback listener      PASS
```

This verifies that the default listener is restricted to loopback, while users can still explicitly restore all-interface listening.

It also verifies that changing the setting and restarting the module uses the new address, and that the existing built-in `genobstacles` workflow continues to work without modifying its sender.

Repository checks:

```text
scripts/run_flake8.py MAVProxy
python -m py_compile MAVProxy/modules/mavproxy_asterix.py
git diff --check
```

All passed.

This PR intentionally does not change the existing `PICKLED:` / `pickle.loads()` transport. See #1728.
