### PR TITLE
mavproxy_ftp: add concurrent resilient transfers

### DIFF
--- a/MAVProxy/modules/mavproxy_ftp.py
+++ b/MAVProxy/modules/mavproxy_ftp.py
@@ -37,6 +37,9 @@ OP_TruncateFile = 12
 OP_Rename = 13
 OP_CalcFileCRC32 = 14
 OP_BurstReadFile = 15
+# Like OP_ListDirectory, with an mtime field appended to file entries.  Older
+# servers either NACK this request or ignore it, so callers must fall back.
+OP_ListDirectoryWithTime = 16
 OP_Ack = 128
 OP_Nack = 129
 
@@ -144,6 +147,8 @@ class FTPWorker(mp_module.MPModule):
         self.last_burst_read = None
         self.op_start = None
         self.dir_offset = 0
+        self.list_dname = None
+        self.list_with_time = False
         self.last_op_time = time.time()
         self.rtt = 0.5
         self.rttvar = 0.25
@@ -307,11 +312,50 @@ class FTPWorker(mp_module.MPModule):
         enc_dname = bytearray(dname, 'ascii')
         self.total_size = 0
         self.dir_offset = 0
-        op = FTP_OP(self.seq, self.session, OP_ListDirectory, len(enc_dname), 0, 0, self.dir_offset, enc_dname)
+        self.list_dname = enc_dname
+        self.list_with_time = (
+            self.ftp_settings.list_time != 0 and
+            self.manager.list_time_supported.get(self.list_target_key()) is not False)
+        self.send_list_request()
+
+    def list_target_key(self):
+        '''Return the target whose listing opcode support is being learned.'''
+        return (self.target_system, self.target_component)
+
+    def send_list_request(self):
+        '''Request the next page using state owned by this listing worker.'''
+        opcode = (OP_ListDirectoryWithTime if self.list_with_time
+                  else OP_ListDirectory)
+        op = FTP_OP(self.seq, self.session, opcode, len(self.list_dname), 0, 0,
+                    self.dir_offset, self.list_dname)
         self.send(op)
 
+    def list_without_time(self):
+        '''Restart a listing using the opcode understood by older servers.'''
+        if self.ftp_settings.debug > 0:
+            print("FTP: no directory listing with time, retrying without")
+        self.list_with_time = False
+        self.dir_offset = 0
+        self.total_size = 0
+        self.send_list_request()
+
+    def list_mtime_str(self, mtime):
+        '''Format UTC wire time in local time, or '-' when it is unknown.'''
+        if mtime == 0:
+            return '-'
+        try:
+            return time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(mtime))
+        except (ValueError, OSError):
+            return str(mtime)
+
     def handle_list_reply(self, op, m):
-        '''handle OP_ListDirectory reply'''
+        '''Handle OP_ListDirectory and OP_ListDirectoryWithTime replies.'''
+        with_time = op.req_opcode == OP_ListDirectoryWithTime
+        if with_time != self.list_with_time:
+            # This is a delayed reply to the opcode used before fallback.
+            return
+        if with_time and op.opcode == OP_Ack:
+            self.manager.list_time_supported[self.list_target_key()] = True
         if op.opcode == OP_Ack:
             dentries = sorted(op.payload.split(b'\x00'))
             #print(dentries)
@@ -329,20 +373,42 @@ class FTPWorker(mp_module.MPModule):
                 if d[0] == 'D':
                     print(" D %s" % d[1:])
                 elif d[0] == 'F':
-                    (name, size) = d[1:].split('\t')
-                    size = int(size)
+                    # Names can contain tabs. Size and optional mtime are the
+                    # fields at the end of an entry, so parse from that end.
+                    fields = d[1:].split('\t')
+                    trailing = 2 if with_time else 1
+                    if len(fields) < trailing + 1:
+                        print(d)
+                        continue
+                    name = '\t'.join(fields[:-trailing])
+                    try:
+                        size = int(fields[-trailing])
+                    except ValueError:
+                        print(d)
+                        continue
                     self.total_size += size
-                    print("   %s\t%u" % (name, size))
+                    if with_time:
+                        try:
+                            mtime = int(fields[-1])
+                        except ValueError:
+                            mtime = 0
+                        print("   %s\t%u\t%s" % (
+                            name, size, self.list_mtime_str(mtime)))
+                    else:
+                        print("   %s\t%u" % (name, size))
                 else:
                     print(d)
             # ask for more
-            more = self.last_op
-            more.offset = self.dir_offset
-            self.send(more)
+            self.send_list_request()
         elif op.opcode == OP_Nack and len(op.payload) == 1 and op.payload[0] == ERR_EndOfFile:
             print("Total size %.2f kByte" % (self.total_size / 1024.0))
             self.total_size = 0
             self.terminate_session()
+        elif (with_time and self.dir_offset == 0 and
+              op.opcode == OP_Nack and len(op.payload) >= 1 and
+              op.payload[0] in [ERR_Fail, ERR_UnknownCommand]):
+            self.manager.list_time_supported[self.list_target_key()] = False
+            self.list_without_time()
         else:
             print('LIST: %s' % op)
             self.terminate_session()
@@ -1128,7 +1194,8 @@ class FTPWorker(mp_module.MPModule):
                op.req_opcode == self.last_op.opcode and \
                op.seq == (self.last_op.seq + 1) % 256:
                 self.last_op_reply = True
-            if op.req_opcode == OP_ListDirectory:
+            if op.req_opcode in [OP_ListDirectory,
+                                 OP_ListDirectoryWithTime]:
                 self.handle_list_reply(op, m)
             elif op.req_opcode == OP_OpenFileRO:
                 self.handle_open_RO_reply(op, m)
@@ -1202,13 +1269,29 @@ class FTPWorker(mp_module.MPModule):
         # sequence number makes this safe whether the request or its reply was
         # lost: the server's duplicate-request cache returns the old reply.
         initial_opcodes = (
-            OP_ListDirectory, OP_OpenFileRO, OP_CreateFile, OP_RemoveFile,
-            OP_RemoveDirectory, OP_Rename, OP_CreateDirectory,
-            OP_CalcFileCRC32,
+            OP_ListDirectory, OP_ListDirectoryWithTime, OP_OpenFileRO,
+            OP_CreateFile, OP_RemoveFile, OP_RemoveDirectory, OP_Rename,
+            OP_CreateDirectory, OP_CalcFileCRC32,
         )
+        initial_timeout = self.retry_timeout()
+        if self.last_op is not None and \
+           self.last_op.opcode == OP_ListDirectoryWithTime:
+            # Capability probing needs a generous floor: variable-lag links
+            # should not make a capable server look like an old one.
+            initial_timeout = max(
+                initial_timeout, self.ftp_settings.list_time_timeout)
         if self.last_op is not None and not self.last_op_reply and \
            self.last_op.opcode in initial_opcodes and \
-           now - self.last_op_time > self.retry_timeout():
+           now - self.last_op_time > initial_timeout:
+            if self.last_op.opcode == OP_ListDirectoryWithTime and \
+               self.dir_offset == 0 and \
+               self.request_retries >= self.ftp_settings.list_retries:
+                # Some servers silently ignore unknown FTP opcodes. After
+                # several RTT-sensitive retries, remember the old server and
+                # restart this listing using the baseline opcode.
+                self.manager.list_time_supported[self.list_target_key()] = False
+                self.list_without_time()
+                return
             self.request_retries += 1
             if self.request_retries > 10:
                 print("FTP: request timed out: %s" % self.last_op)
@@ -1281,6 +1364,9 @@ class FTPModule(mp_module.MPModule):
              ('write_batch_size', int, 0),
              ('retry_time', float, 0.5),
              ('crccmp_timeout', float, 120.0),
+             ('list_time', int, 1),
+             ('list_time_timeout', float, 3.0),
+             ('list_retries', int, 3),
              # ArduPilot currently has five GCS_FTP server sessions.  Keeping
              # the cap configurable also supports smaller/custom servers.
              ('max_sessions', int, 5)])
@@ -1288,6 +1374,8 @@ class FTPModule(mp_module.MPModule):
                                      self.ftp_settings.completion)
         self.workers = {}
         self.pending = []
+        # Cache ListDirectoryWithTime support independently for each target.
+        self.list_time_supported = {}
         # A previous process can leave delayed packets or a cached reply on a
         # poor link. Starting every process at session zero can then turn a
         # stale CreateFile ACK into writes against a closed server session.

--- a/MAVProxy/modules/mavproxy_ftp.py
+++ b/MAVProxy/modules/mavproxy_ftp.py
@@ -137,12 +137,21 @@ class FTPWorker(mp_module.MPModule):
     A worker deliberately isn't registered as a public MAVProxy module.  The
     public FTPModule owns and routes to several of these at once.
     '''
-    def __init__(self, manager, session):
+    def __init__(self, manager, session, target_system=None,
+                 target_component=None):
         super(FTPWorker, self).__init__(manager.mpstate, "ftp_worker")
         self.manager = manager
         self.ftp_settings = manager.ftp_settings
         self.seq = 0
         self.session = session
+        # MPModule.target_system/target_component follow the live global
+        # selection.  An FTP operation must stay with the vehicle against
+        # which it was submitted, including while it waits in the queue.
+        self.ftp_target_system = (manager.target_system if target_system is None
+                                  else target_system)
+        self.ftp_target_component = (
+            manager.target_component if target_component is None
+            else target_component)
         self.network = 0
         self.last_op = None
         self.fh = None
@@ -336,7 +345,7 @@ class FTPWorker(mp_module.MPModule):
 
     def list_target_key(self):
         '''Return the target whose listing opcode support is being learned.'''
-        return (self.target_system, self.target_component)
+        return (self.ftp_target_system, self.ftp_target_component)
 
     def send_list_request(self):
         '''Request the next page using state owned by this listing worker.'''
@@ -462,10 +471,17 @@ class FTPWorker(mp_module.MPModule):
 
     def handle_open_RO_reply(self, op, m):
         '''handle OP_OpenFileRO reply'''
-        if op.opcode == OP_Ack:
+        if self.fh is not None:
+            # A preserved-sequence retry can leave more than one handshake
+            # reply in the link.  Once reading has begun, all of them are
+            # stale and must not reopen/truncate the local destination.
+            return
+        recovered_open = self.retry_found_open_session(op)
+        if op.opcode == OP_Ack or recovered_open:
             if self.filename is None:
                 return
-            if op.size == 4 and op.payload is not None and len(op.payload) >= 4:
+            if not recovered_open and op.size == 4 and \
+               op.payload is not None and len(op.payload) >= 4:
                 # servers report the file size here, giving us a progress total
                 self.remote_file_size = struct.unpack("<I", bytes(op.payload[:4]))[0]
             try:
@@ -484,6 +500,25 @@ class FTPWorker(mp_module.MPModule):
             if self.callback is None or self.ftp_settings.debug > 0:
                 print("ftp open failed")
             self.terminate_session()
+
+    def retry_found_open_session(self, op):
+        '''A retried open/create may find the first request already succeeded.
+
+        ArduPilot's duplicate-reply cache is shared by its FTP sessions.  If
+        another session evicts a lost ACK, replaying the same OpenFileRO or
+        CreateFile request reaches the existing open descriptor and returns
+        ERR_Fail.  Only accept that result after this worker actually retried;
+        an ERR_Fail reply to the first request remains a real failure.
+        '''
+        recovered = (
+            self.request_retries > 0 and
+            op.opcode == OP_Nack and
+            op.payload is not None and
+            len(op.payload) >= 1 and
+            op.payload[0] == ERR_Fail)
+        if recovered and self.ftp_settings.debug > 0:
+            print("FTP: retry found the remote session already open")
+        return recovered
 
     def check_read_finished(self):
         '''check if download has completed'''
@@ -540,6 +575,9 @@ class FTPWorker(mp_module.MPModule):
                 # writing an earlier portion, possibly remove a gap
                 gap = (op.offset, len(op.payload))
                 if gap in self.read_gaps:
+                    if self.read_gap_times.get(gap, 0) > 0 and \
+                       self.backlog > 0:
+                        self.backlog -= 1
                     self.read_gaps.remove(gap)
                     self.read_gap_times.pop(gap)
                     if self.ftp_settings.debug > 0:
@@ -620,8 +658,10 @@ class FTPWorker(mp_module.MPModule):
             return
         if op.opcode == OP_Ack and self.fh is not None:
             gap = (op.offset, op.size)
-            if gap in self.read_gaps:
-                if self.read_gap_times[gap] > 0 and self.backlog > 0:
+            requested_gap = next(
+                (g for g in self.read_gaps if g[0] == op.offset), None)
+            if requested_gap == gap:
+                if self.read_gap_times.get(gap, 0) > 0 and self.backlog > 0:
                     self.backlog -= 1
                 self.read_gaps.remove(gap)
                 self.read_gap_times.pop(gap)
@@ -632,7 +672,7 @@ class FTPWorker(mp_module.MPModule):
                     print("FTP: removed gap", gap, self.reached_eof, len(self.read_gaps))
                 if self.check_read_finished():
                     return
-            elif op.size < self.burst_size:
+            elif requested_gap is not None:
                 print("FTP: file size changed to %u" % op.offset+op.size)
                 self.terminate_session()
             else:
@@ -738,7 +778,11 @@ class FTPWorker(mp_module.MPModule):
         if self.fh is None:
             self.terminate_session()
             return
-        if op.opcode == OP_Ack:
+        if self.write_open:
+            # Ignore late ACK/NACK replies from preserved-sequence CreateFile
+            # retries after upload writes have started.
+            return
+        if op.opcode == OP_Ack or self.retry_found_open_session(op):
             self.write_open = True
             self.send_more_writes()
         else:
@@ -1259,8 +1303,9 @@ class FTPWorker(mp_module.MPModule):
         # ArduPilot's incoming FTP request queue has the same depth as its
         # session table.  Under contention an initial request can therefore be
         # dropped before the server has a chance to NACK it.  Reusing the same
-        # sequence number makes this safe whether the request or its reply was
-        # lost: the server's duplicate-request cache returns the old reply.
+        # sequence number lets the server return a cached reply when available.
+        # A different session may evict that cache entry; the OpenFileRO and
+        # CreateFile handlers also recognize the resulting already-open state.
         initial_opcodes = (
             OP_ListDirectory, OP_ListDirectoryWithTime, OP_OpenFileRO,
             OP_CreateFile, OP_RemoveFile, OP_RemoveDirectory, OP_Rename,
@@ -1491,8 +1536,8 @@ class FTPModule(mp_module.MPModule):
                     if not self.packet_lost('TX')]
         if not payloads:
             return
-        args = (worker.master, worker.network, worker.target_system,
-                worker.target_component, payloads)
+        args = (worker.master, worker.network, worker.ftp_target_system,
+                worker.ftp_target_component, payloads)
         lag = self.packet_delay('TX')
         if lag == 0:
             self._transmit_payloads(*args)
@@ -1508,7 +1553,21 @@ class FTPModule(mp_module.MPModule):
             session = m.payload[2]
         except (IndexError, TypeError):
             return None
-        return self.workers.get(session)
+        worker = self.workers.get(session)
+        if worker is None:
+            return None
+        try:
+            source_system = m.get_srcSystem()
+            source_component = m.get_srcComponent()
+        except AttributeError:
+            # Retain compatibility with synthetic/older message wrappers that
+            # do not expose source accessors.
+            return worker
+        if worker.ftp_target_system not in (0, source_system):
+            return None
+        if worker.ftp_target_component not in (0, source_component):
+            return None
+        return worker
 
     def cmd_ftp(self, args):
         '''FTP operations'''
@@ -1553,7 +1612,10 @@ class FTPModule(mp_module.MPModule):
         if session is None:
             self.pending.insert(0, operation)
             return None
-        worker = FTPWorker(self, session)
+        worker = FTPWorker(
+            self, session,
+            target_system=operation['target_system'],
+            target_component=operation['target_component'])
         worker.operation_name = operation['name']
         self.workers[session] = worker
         method = getattr(worker, operation['method'])
@@ -1569,6 +1631,8 @@ class FTPModule(mp_module.MPModule):
             'method': method,
             'args': args,
             'kwargs': kwargs,
+            'target_system': self.target_system,
+            'target_component': self.target_component,
         }
         limit = self._session_limit()
         if len(self.workers) >= limit:

--- a/MAVProxy/modules/mavproxy_ftp.py
+++ b/MAVProxy/modules/mavproxy_ftp.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 '''mavlink file transfer support'''
 
-import io
-import time, os, sys
 import glob
+import os
+import sys
+import time
 import struct
 import random
 import zlib
-from pymavlink import mavutil
 
 try:
     # py2
@@ -100,29 +100,18 @@ class WriteQueue:
         self.size = size
         self.last_send = 0
 
-class FTPModule(mp_module.MPModule):
-    def __init__(self, mpstate):
-        super(FTPModule, self).__init__(mpstate, "ftp", public=True)
-        self.add_command('ftp', self.cmd_ftp, "file transfer",
-                         ["<list|get|rm|rmdir|rename|mkdir|crc|cancel|status>",
-                          "set (FTPSETTING)",
-                          "put (FILENAME) (FILENAME)",
-                          "crclocal (FILENAME)",
-                          "crccmp (FILENAME)"])
-        self.ftp_settings = mp_settings.MPSettings(
-            [('debug', int, 0),
-             ('pkt_loss_tx', int, 0),
-             ('pkt_loss_rx', int, 0),
-             ('max_backlog', int, 5),
-             ('burst_read_size', int, 80),
-             ('write_size', int, 80),
-             ('write_qsize', int, 5),
-             ('retry_time', float, 0.5),
-             ('crccmp_timeout', float, 120.0)])
-        self.add_completion_function('(FTPSETTING)',
-                                     self.ftp_settings.completion)
+class FTPWorker(mp_module.MPModule):
+    '''State for one FTP operation/session.
+
+    A worker deliberately isn't registered as a public MAVProxy module.  The
+    public FTPModule owns and routes to several of these at once.
+    '''
+    def __init__(self, manager, session):
+        super(FTPWorker, self).__init__(manager.mpstate, "ftp_worker")
+        self.manager = manager
+        self.ftp_settings = manager.ftp_settings
         self.seq = 0
-        self.session = 0
+        self.session = session
         self.network = 0
         self.last_op = None
         self.fh = None
@@ -174,51 +163,16 @@ class FTPModule(mp_module.MPModule):
         self.crccmp_sent = None
         self.crccmp_start = 0
         self.crccmp_expect = None
+        self.session_waiting = False
+        self.session_wait_reported = False
+        self.done = False
+        self.last_op_reply = False
+        self.request_retries = 0
 
-    def cmd_ftp(self, args):
-        '''FTP operations'''
-        usage = "Usage: ftp <list|get|put|rm|rmdir|rename|mkdir|crc|crclocal|crccmp>"
-        if len(args) < 1:
-            print(usage)
-            return
-        # these all talk to the vehicle and would have their replies consumed
-        # by a running comparison, or clobber the op it is waiting on
-        if self.crccmp_dest is not None and args[0] in (
-                'list', 'crc', 'rm', 'rmdir', 'rename', 'mkdir', 'put'):
-            print("crccmp in progress, use 'ftp cancel' to stop it")
-            return
-        if args[0] == 'list':
-            self.cmd_list(args[1:])
-        elif args[0] == "set":
-            self.ftp_settings.command(args[1:])
-        elif args[0] == 'get':
-            self.cmd_get(args[1:])
-        elif args[0] == 'put':
-            self.cmd_put(args[1:])
-        elif args[0] == 'rm':
-            self.cmd_rm(args[1:])
-        elif args[0] == 'rmdir':
-            self.cmd_rmdir(args[1:])
-        elif args[0] == 'rename':
-            self.cmd_rename(args[1:])
-        elif args[0] == 'mkdir':
-            self.cmd_mkdir(args[1:])
-        elif args[0] == 'crc':
-            self.cmd_crc(args[1:])
-        elif args[0] == 'crclocal':
-            self.cmd_crclocal(args[1:])
-        elif args[0] == 'crccmp':
-            self.cmd_crccmp(args[1:])
-        elif args[0] == 'status':
-            self.cmd_status()
-        elif args[0] == 'cancel':
-            self.cmd_cancel()
-        else:
-            print(usage)
-
-    def send(self, op):
+    def send(self, op, preserve_seq=False):
         '''send a request'''
-        op.seq = self.seq
+        if not preserve_seq:
+            op.seq = self.seq
         payload = op.pack()
         plen = len(payload)
         if plen < MAX_Payload + HDR_Len:
@@ -227,8 +181,11 @@ class FTPModule(mp_module.MPModule):
             print("FTP: Can't send request, no master...")
             return
         self.master.mav.file_transfer_protocol_send(self.network, self.target_system, self.target_component, payload)
-        self.seq = (self.seq + 1) % 256
+        if not preserve_seq:
+            self.seq = (self.seq + 1) % 256
+            self.request_retries = 0
         self.last_op = op
+        self.last_op_reply = False
         now = time.time()
         if self.ftp_settings.debug > 1:
             print("> %s dt=%.2f" % (op, now - self.last_op_time))
@@ -238,6 +195,9 @@ class FTPModule(mp_module.MPModule):
         '''terminate current session. outcome describes an incomplete transfer
         for the status line: "cancelled" when the user or a new command ended
         it, "failed" for an error'''
+        if self.done:
+            return
+        self.done = True
         self.transfer_active = False
         if self.crccmp_dest is not None:
             print("crccmp: aborted")
@@ -269,12 +229,12 @@ class FTPModule(mp_module.MPModule):
         self.read_gap_times = {}
         self.last_read = None
         self.last_burst_read = None
-        self.session = (self.session + 1) % 256
         self.reached_eof = False
         self.backlog = 0
         self.duplicates = 0
         if self.ftp_settings.debug > 0:
             print("Terminated session")
+        self.manager.worker_done(self)
 
     def cmd_list(self, args):
         '''list files'''
@@ -321,15 +281,16 @@ class FTPModule(mp_module.MPModule):
         elif op.opcode == OP_Nack and len(op.payload) == 1 and op.payload[0] == ERR_EndOfFile:
             print("Total size %.2f kByte" % (self.total_size / 1024.0))
             self.total_size = 0
+            self.terminate_session()
         else:
             print('LIST: %s' % op)
+            self.terminate_session()
 
     def cmd_get(self, args, callback=None, callback_progress=None):
         '''get file'''
         if len(args) == 0:
             print("Usage: get FILENAME <LOCALNAME>")
             return
-        self.terminate_session("cancelled")
         fname = args[0]
         if len(args) > 1:
             self.filename = args[1]
@@ -721,6 +682,7 @@ class FTPModule(mp_module.MPModule):
         '''handle remove reply'''
         if op.opcode != OP_Ack:
             print("Remove failed %s" % op)
+        self.terminate_session()
 
     def cmd_rename(self, args):
         '''rename file'''
@@ -740,6 +702,7 @@ class FTPModule(mp_module.MPModule):
         '''handle rename reply'''
         if op.opcode != OP_Ack:
             print("Rename failed %s" % op)
+        self.terminate_session()
 
     def cmd_mkdir(self, args):
         '''make directory'''
@@ -756,6 +719,7 @@ class FTPModule(mp_module.MPModule):
         '''handle mkdir reply'''
         if op.opcode != OP_Ack:
             print("Create directory failed %s" % op)
+        self.terminate_session()
 
     def cmd_crc(self, args):
         '''get crc'''
@@ -930,6 +894,7 @@ class FTPModule(mp_module.MPModule):
                results.count('MISSING'),
                results.count('ERROR') + results.count('TIMEOUT'), dt))
         self.crccmp_reset()
+        self.terminate_session()
 
     def handle_crc_reply(self, op, m):
         '''handle crc reply'''
@@ -942,6 +907,7 @@ class FTPModule(mp_module.MPModule):
             print("crc: %s 0x%08x in %.1fs" % (self.filename, crc, now - self.op_start))
         else:
             print("crc failed %s" % op)
+        self.terminate_session()
 
     def cmd_cancel(self):
         '''cancel any pending op'''
@@ -1039,7 +1005,20 @@ class FTPModule(mp_module.MPModule):
                         print("FTP: dropping packet RX")
                     return
 
+            if op.opcode == OP_Nack and op.payload is not None and \
+               len(op.payload) == 1 and op.payload[0] == ERR_NoSessionsAvailable:
+                # Another client may also be using the server, so the local
+                # concurrency cap is not sufficient on its own.  Keep this
+                # operation intact and retry instead of failing its callback.
+                self.session_waiting = True
+                self.last_op_time = now
+                if not self.session_wait_reported:
+                    print("FTP: no sessions available, waiting to retry")
+                    self.session_wait_reported = True
+                return
+
             if op.req_opcode == self.last_op.opcode and op.seq == (self.last_op.seq + 1) % 256:
+                self.last_op_reply = True
                 self.rtt = max(min(self.rtt, dt), 0.01)
             if op.req_opcode == OP_ListDirectory:
                 self.handle_list_reply(op, m)
@@ -1112,6 +1091,37 @@ class FTPModule(mp_module.MPModule):
         '''check for file gaps and lost requests'''
         now = time.time()
 
+        if self.session_waiting:
+            if now - self.last_op_time >= self.ftp_settings.retry_time:
+                self.session_waiting = False
+                if self.last_op.opcode == OP_OpenFileRO:
+                    self.op_start = now
+                self.send(self.last_op)
+            return
+
+        # ArduPilot's incoming FTP request queue has the same depth as its
+        # session table.  Under contention an initial request can therefore be
+        # dropped before the server has a chance to NACK it.  Reusing the same
+        # sequence number makes this safe whether the request or its reply was
+        # lost: the server's duplicate-request cache returns the old reply.
+        initial_opcodes = (
+            OP_ListDirectory, OP_OpenFileRO, OP_CreateFile, OP_RemoveFile,
+            OP_RemoveDirectory, OP_Rename, OP_CreateDirectory,
+            OP_CalcFileCRC32,
+        )
+        if self.last_op is not None and not self.last_op_reply and \
+           self.last_op.opcode in initial_opcodes and \
+           now - self.last_op_time > 1.0:
+            self.request_retries += 1
+            if self.request_retries > 10:
+                print("FTP: request timed out: %s" % self.last_op)
+                self.terminate_session()
+                return
+            if self.ftp_settings.debug > 0:
+                print("FTP: retry request: %s" % self.last_op)
+            self.send(self.last_op, preserve_seq=True)
+            return
+
         # ahead of the early returns below, which skip idle transfers
         self.update_status()
 
@@ -1121,23 +1131,6 @@ class FTPModule(mp_module.MPModule):
             self.crccmp_sent = None
             self.crccmp_expect = None
             self.crccmp_next()
-
-        # see if we lost an open reply
-        if self.op_start is not None and now - self.op_start > 1.0 and self.last_op.opcode == OP_OpenFileRO:
-            self.op_start = now
-            self.open_retries += 1
-            if self.open_retries > 2:
-                # fail the get
-                self.op_start = None
-                self.terminate_session()
-                return
-            if self.ftp_settings.debug > 0:
-                print("FTP: retry open")
-            send_op = self.last_op
-            self.send(FTP_OP(self.seq, self.session, OP_TerminateSession, 0, 0, 0, 0, None))
-            self.session = (self.session + 1) % 256
-            send_op.session = self.session
-            self.send(send_op)
 
         if len(self.read_gaps) == 0 and self.last_burst_read is None and self.write_list is None:
             return
@@ -1159,6 +1152,202 @@ class FTPModule(mp_module.MPModule):
 
         if self.write_list is not None:
             self.send_more_writes()
+
+
+class FTPModule(mp_module.MPModule):
+    '''Public FTP module and concurrent-session manager.'''
+
+    def __init__(self, mpstate):
+        super(FTPModule, self).__init__(mpstate, "ftp", public=True)
+        self.add_command('ftp', self.cmd_ftp, "file transfer",
+                         ["<list|get|rm|rmdir|rename|mkdir|crc|cancel|status>",
+                          "set (FTPSETTING)",
+                          "put (FILENAME) (FILENAME)",
+                          "crclocal (FILENAME)",
+                          "crccmp (FILENAME)"])
+        self.ftp_settings = mp_settings.MPSettings(
+            [('debug', int, 0),
+             ('pkt_loss_tx', int, 0),
+             ('pkt_loss_rx', int, 0),
+             ('max_backlog', int, 5),
+             ('burst_read_size', int, 80),
+             ('write_size', int, 80),
+             ('write_qsize', int, 5),
+             ('retry_time', float, 0.5),
+             ('crccmp_timeout', float, 120.0),
+             # ArduPilot currently has five GCS_FTP server sessions.  Keeping
+             # the cap configurable also supports smaller/custom servers.
+             ('max_sessions', int, 5)])
+        self.add_completion_function('(FTPSETTING)',
+                                     self.ftp_settings.completion)
+        self.workers = {}
+        self.pending = []
+        self.next_session = 0
+        self.warned_component = False
+
+    def cmd_ftp(self, args):
+        '''FTP operations'''
+        usage = "Usage: ftp <list|get|put|rm|rmdir|rename|mkdir|crc|crclocal|crccmp>"
+        if len(args) < 1:
+            print(usage)
+            return
+        command = args[0]
+        if command == 'set':
+            self.ftp_settings.command(args[1:])
+        elif command == 'status':
+            self.cmd_status()
+        elif command == 'cancel':
+            self.cmd_cancel()
+        elif command == 'crclocal':
+            self.cmd_crclocal(args[1:])
+        else:
+            method = getattr(self, 'cmd_' + command, None)
+            if method is None:
+                print(usage)
+            else:
+                method(args[1:])
+
+    def _allocate_session(self):
+        '''Return an unused client-selected uint8 session id.'''
+        for _ in range(256):
+            session = self.next_session
+            self.next_session = (self.next_session + 1) % 256
+            if session not in self.workers:
+                return session
+        return None
+
+    def _launch(self, operation):
+        session = self._allocate_session()
+        if session is None:
+            self.pending.insert(0, operation)
+            return None
+        worker = FTPWorker(self, session)
+        worker.operation_name = operation['name']
+        self.workers[session] = worker
+        method = getattr(worker, operation['method'])
+        method(*operation['args'], **operation['kwargs'])
+        # Bad arguments or a local-file error can return without sending.
+        if worker.last_op is None:
+            self.worker_done(worker)
+        return worker
+
+    def _submit(self, name, method, *args, **kwargs):
+        operation = {
+            'name': name,
+            'method': method,
+            'args': args,
+            'kwargs': kwargs,
+        }
+        limit = self._session_limit()
+        if len(self.workers) >= limit:
+            self.pending.append(operation)
+            print("FTP: queued %s (%u sessions active)" %
+                  (name, len(self.workers)))
+            return None
+        return self._launch(operation)
+
+    def worker_done(self, worker):
+        '''Forget a completed worker and start the oldest queued operation.'''
+        if self.workers.get(worker.session) is worker:
+            del self.workers[worker.session]
+        limit = self._session_limit()
+        while self.pending and len(self.workers) < limit:
+            operation = self.pending.pop(0)
+            self._launch(operation)
+
+    def _session_limit(self):
+        # Session ids are uint8.  Keep one value in reserve so allocation and
+        # queuing remain well defined even with an accidental oversized setting.
+        return min(255, max(1, int(self.ftp_settings.max_sessions)))
+
+    def cmd_list(self, args):
+        return self._submit('list', 'cmd_list', args)
+
+    def cmd_get(self, args, callback=None, callback_progress=None):
+        return self._submit('get', 'cmd_get', args,
+                            callback=callback,
+                            callback_progress=callback_progress)
+
+    def cmd_put(self, args, fh=None, callback=None, progress_callback=None):
+        return self._submit('put', 'cmd_put', args, fh=fh,
+                            callback=callback,
+                            progress_callback=progress_callback)
+
+    def cmd_rm(self, args):
+        return self._submit('rm', 'cmd_rm', args)
+
+    def cmd_rmdir(self, args):
+        return self._submit('rmdir', 'cmd_rmdir', args)
+
+    def cmd_rename(self, args):
+        return self._submit('rename', 'cmd_rename', args)
+
+    def cmd_mkdir(self, args):
+        return self._submit('mkdir', 'cmd_mkdir', args)
+
+    def cmd_crc(self, args):
+        return self._submit('crc', 'cmd_crc', args)
+
+    def cmd_crccmp(self, args):
+        return self._submit('crccmp', 'cmd_crccmp', args)
+
+    def cmd_crclocal(self, args):
+        # This operation is entirely local and consumes no server session.
+        return FTPWorker(self, 0).cmd_crclocal(args)
+
+    def cmd_cancel(self):
+        '''Cancel all active and queued operations.'''
+        pending = self.pending
+        self.pending = []
+        for operation in pending:
+            callback = operation['kwargs'].get('callback')
+            if callback is not None:
+                callback(None)
+            progress = operation['kwargs'].get('progress_callback')
+            if progress is not None:
+                progress(None)
+        for worker in list(self.workers.values()):
+            worker.terminate_session("cancelled")
+
+    def cmd_status(self):
+        if not self.workers and not self.pending:
+            print("No FTP operations in progress")
+            return
+        for session, worker in sorted(self.workers.items()):
+            status = worker.transfer_status()
+            if status is None:
+                status = worker.operation_name
+            if worker.session_waiting:
+                status += " (waiting for a server session)"
+            print("FTP session %u: %s" % (session, status))
+        if self.pending:
+            print("FTP queued: %s" %
+                  ', '.join(operation['name'] for operation in self.pending))
+
+    def mavlink_packet(self, m):
+        if m.get_type() != "FILE_TRANSFER_PROTOCOL":
+            return
+        if (m.target_system != self.settings.source_system or
+                m.target_component != self.settings.source_component):
+            if m.target_system == self.settings.source_system and not self.warned_component:
+                self.warned_component = True
+                print("FTP reply for mavlink component %u" % m.target_component)
+            return
+        try:
+            session = m.payload[2]
+        except (IndexError, TypeError):
+            return
+        worker = self.workers.get(session)
+        if worker is not None:
+            worker.mavlink_packet(m)
+
+    def idle_task(self):
+        for worker in list(self.workers.values()):
+            worker.idle_task()
+
+    def unload(self):
+        self.cmd_cancel()
+        super(FTPModule, self).unload()
 
 def init(mpstate):
     '''initialise module'''

--- a/MAVProxy/modules/mavproxy_ftp.py
+++ b/MAVProxy/modules/mavproxy_ftp.py
@@ -1593,7 +1593,8 @@ class FTPModule(mp_module.MPModule):
 
     def cmd_status(self):
         if not self.workers and not self.pending:
-            print("No FTP operations in progress")
+            # Keep the longstanding wording used by scripts and autotests.
+            print("No transfer in progress")
             return
         for session, worker in sorted(self.workers.items()):
             status = worker.transfer_status()

--- a/MAVProxy/modules/mavproxy_ftp.py
+++ b/MAVProxy/modules/mavproxy_ftp.py
@@ -8,6 +8,7 @@ import time
 import struct
 import random
 import zlib
+import heapq
 
 try:
     # py2
@@ -145,6 +146,9 @@ class FTPWorker(mp_module.MPModule):
         self.dir_offset = 0
         self.last_op_time = time.time()
         self.rtt = 0.5
+        self.rttvar = 0.25
+        self.rtt_valid = False
+        self.send_times = {}
         self.reached_eof = False
         self.backlog = 0
         self.burst_size = self.ftp_settings.burst_read_size
@@ -159,6 +163,7 @@ class FTPWorker(mp_module.MPModule):
         self.write_pending = 0
         self.write_inflight = set()
         self.write_last_send = None
+        self.write_open = False
         self.write_qsize = (self.ftp_settings.write_qsize
                             if self.ftp_settings.write_qsize > 0 else 5)
         self.write_batch_size = (self.ftp_settings.write_batch_size
@@ -186,47 +191,65 @@ class FTPWorker(mp_module.MPModule):
         self.last_op_reply = False
         self.request_retries = 0
 
-    def send(self, op, preserve_seq=False):
-        '''send a request'''
+    def prepare_send(self, op, preserve_seq=False):
+        '''prepare a request and update protocol state as if it was sent'''
         if not preserve_seq:
             op.seq = self.seq
         payload = op.pack()
         plen = len(payload)
         if plen < MAX_Payload + HDR_Len:
             payload.extend(bytearray([0]*((HDR_Len+MAX_Payload)-plen)))
-        if self.master is None:
-            print("FTP: Can't send request, no master...")
-            return
-        self.master.mav.file_transfer_protocol_send(self.network, self.target_system, self.target_component, payload)
+        now = time.time()
         if not preserve_seq:
             self.seq = (self.seq + 1) % 256
             self.request_retries = 0
+            self.send_times[op.seq] = now
+        else:
+            # Do not use replies to retransmitted requests as RTT samples: a
+            # reply may belong to either transmission (Karn's algorithm).
+            self.send_times[op.seq] = None
         self.last_op = op
         self.last_op_reply = False
-        now = time.time()
         if self.ftp_settings.debug > 1:
             print("> %s dt=%.2f" % (op, now - self.last_op_time))
-        self.last_op_time = time.time()
+        self.last_op_time = now
+        return payload
+
+    def send(self, op, preserve_seq=False):
+        '''send a request'''
+        if self.master is None:
+            print("FTP: Can't send request, no master...")
+            return
+        payload = self.prepare_send(op, preserve_seq=preserve_seq)
+        self.manager.send_payloads(self, [payload])
 
     def send_batch(self, ops):
         '''send requests in one link write when supported by pymavlink'''
-        if len(ops) <= 1 or self.master is None or \
-           not hasattr(self.master.mav, 'file'):
-            for op in ops:
-                self.send(op)
+        if len(ops) == 0:
             return
+        if self.master is None:
+            print("FTP: Can't send request, no master...")
+            return
+        payloads = [self.prepare_send(op) for op in ops]
+        self.manager.send_payloads(self, payloads)
 
-        mav = self.master.mav
-        link = mav.file
-        collector = MAVLinkBatchWriter()
-        mav.file = collector
-        try:
-            for op in ops:
-                self.send(op)
-        finally:
-            mav.file = link
-        if collector.packets:
-            link.write(b''.join(collector.packets))
+    def update_rtt(self, sample):
+        '''Update the smoothed RTT and variance from an unambiguous reply.'''
+        sample = max(0.001, sample)
+        if not self.rtt_valid:
+            self.rtt = sample
+            self.rttvar = sample / 2.0
+            self.rtt_valid = True
+            return
+        self.rttvar = 0.75 * self.rttvar + 0.25 * abs(self.rtt - sample)
+        self.rtt = 0.875 * self.rtt + 0.125 * sample
+
+    def retry_timeout(self):
+        '''Return an RTT-sensitive retransmission timeout.'''
+        minimum = max(0.05, self.ftp_settings.retry_time)
+        if not self.rtt_valid:
+            return max(1.0, minimum)
+        return max(minimum, min(10.0, self.rtt + 4.0 * self.rttvar))
 
     def terminate_session(self, outcome="failed"):
         '''terminate current session. outcome describes an incomplete transfer
@@ -250,6 +273,7 @@ class FTPWorker(mp_module.MPModule):
         self.fh = None
         self.filename = None
         self.write_list = None
+        self.write_open = False
         if self.callback is not None:
             # tell caller that the transfer failed
             self.callback(None)
@@ -414,11 +438,6 @@ class FTPWorker(mp_module.MPModule):
     
     def handle_burst_read(self, op, m):
         '''handle OP_BurstReadFile reply'''
-        if self.ftp_settings.pkt_loss_tx > 0:
-            if random.uniform(0,100) < self.ftp_settings.pkt_loss_tx:
-                if self.ftp_settings.debug > 0:
-                    print("FTP: dropping TX")
-                return
         if self.fh is None or self.filename is None:
             if op.session != self.session:
                 # old session
@@ -515,11 +534,11 @@ class FTPWorker(mp_module.MPModule):
                 print("FTP Unexpected read reply")
                 print(op)
             return
-        if self.backlog > 0:
-            self.backlog -= 1
         if op.opcode == OP_Ack and self.fh is not None:
             gap = (op.offset, op.size)
             if gap in self.read_gaps:
+                if self.read_gap_times[gap] > 0 and self.backlog > 0:
+                    self.backlog -= 1
                 self.read_gaps.remove(gap)
                 self.read_gap_times.pop(gap)
                 ofs = self.fh.tell()
@@ -598,6 +617,7 @@ class FTPWorker(mp_module.MPModule):
         self.write_pending = 0
         self.write_inflight = set()
         self.write_last_send = None
+        self.write_open = False
 
         self.put_callback = callback
         self.put_callback_progress = progress_callback
@@ -637,6 +657,7 @@ class FTPWorker(mp_module.MPModule):
             self.terminate_session()
             return
         if op.opcode == OP_Ack:
+            self.write_open = True
             if op.size >= 3 and op.payload[0] == WRITE_CAPABILITY_MAGIC:
                 if self.ftp_settings.write_qsize <= 0:
                     self.write_qsize = max(1, op.payload[1])
@@ -649,6 +670,8 @@ class FTPWorker(mp_module.MPModule):
 
     def send_more_writes(self):
         '''send some more writes'''
+        if not self.write_open:
+            return
         if len(self.write_list) == 0:
             # all done
             self.put_finished(self.write_file_size)
@@ -657,7 +680,7 @@ class FTPWorker(mp_module.MPModule):
 
         now = time.time()
         if self.write_last_send is not None:
-            if now - self.write_last_send > max(min(10*self.rtt, 1),0.2):
+            if now - self.write_last_send > self.retry_timeout():
                 # we seem to have lost a block of replies
                 self.write_inflight.clear()
                 self.write_pending = 0
@@ -694,7 +717,7 @@ class FTPWorker(mp_module.MPModule):
             self.terminate_session()
             return
         if op.opcode != OP_Ack:
-            print("Write failed")
+            print("Write failed: %s" % op)
             self.terminate_session()
             return
 
@@ -1083,11 +1106,11 @@ class FTPWorker(mp_module.MPModule):
             if self.ftp_settings.debug > 1:
                 print("< %s dt=%.2f" % (op, dt))
             self.last_op_time = now
-            if self.ftp_settings.pkt_loss_rx > 0:
-                if random.uniform(0,100) < self.ftp_settings.pkt_loss_rx:
-                    if self.ftp_settings.debug > 1:
-                        print("FTP: dropping packet RX")
-                    return
+
+            request_seq = (op.seq - 1) % 256
+            sent = self.send_times.pop(request_seq, None)
+            if sent is not None:
+                self.update_rtt(now - sent)
 
             if op.opcode == OP_Nack and op.payload is not None and \
                len(op.payload) == 1 and op.payload[0] == ERR_NoSessionsAvailable:
@@ -1101,9 +1124,10 @@ class FTPWorker(mp_module.MPModule):
                     self.session_wait_reported = True
                 return
 
-            if op.req_opcode == self.last_op.opcode and op.seq == (self.last_op.seq + 1) % 256:
+            if self.last_op is not None and \
+               op.req_opcode == self.last_op.opcode and \
+               op.seq == (self.last_op.seq + 1) % 256:
                 self.last_op_reply = True
-                self.rtt = max(min(self.rtt, dt), 0.01)
             if op.req_opcode == OP_ListDirectory:
                 self.handle_list_reply(op, m)
             elif op.req_opcode == OP_OpenFileRO:
@@ -1136,47 +1160,36 @@ class FTPWorker(mp_module.MPModule):
             print("Gap read of %u at %u rem=%u blog=%u" % (length, offset, len(self.read_gaps), self.backlog))
         read = FTP_OP(self.seq, self.session, OP_ReadFile, length, 0, 0, offset, None)
         self.send(read)
-        self.read_gaps.remove(g)
-        self.read_gaps.append(g)
         self.last_gap_send = time.time()
         self.read_gap_times[g] = self.last_gap_send
         self.backlog += 1
 
     def check_read_send(self):
-        '''see if we should send another gap read'''
+        '''keep a bounded window of gap reads in flight'''
         if len(self.read_gaps) == 0:
             return
-        g = self.read_gaps[0]
         now = time.time()
-        dt = now - self.read_gap_times[g]
-        if not self.reached_eof:
-            # send gap reads once
-            for g in self.read_gap_times.keys():
-                if self.read_gap_times[g] == 0:
-                    self.send_gap_read(g)
-            return
-        if self.read_gap_times[g] > 0 and dt > self.ftp_settings.retry_time:
-            if self.backlog > 0:
-                self.backlog -= 1
-            self.read_gap_times[g] = 0
+        timeout = self.retry_timeout()
+        for g in self.read_gaps:
+            sent = self.read_gap_times[g]
+            if sent > 0 and now - sent > timeout:
+                self.read_gap_times[g] = 0
+                if self.backlog > 0:
+                    self.backlog -= 1
 
-        if self.read_gap_times[g] != 0:
-            # still pending
-            return
-        if not self.reached_eof and self.backlog >= self.ftp_settings.max_backlog:
-            # don't fill queue too far until we have got past the burst
-            return
-        if now - self.last_gap_send < 0.05:
-            # don't send too fast
-            return
-        self.send_gap_read(g)
+        limit = max(1, self.ftp_settings.max_backlog)
+        for g in self.read_gaps:
+            if self.backlog >= limit:
+                break
+            if self.read_gap_times[g] == 0:
+                self.send_gap_read(g)
 
     def idle_task(self):
         '''check for file gaps and lost requests'''
         now = time.time()
 
         if self.session_waiting:
-            if now - self.last_op_time >= self.ftp_settings.retry_time:
+            if now - self.last_op_time >= self.retry_timeout():
                 self.session_waiting = False
                 if self.last_op.opcode == OP_OpenFileRO:
                     self.op_start = now
@@ -1195,7 +1208,7 @@ class FTPWorker(mp_module.MPModule):
         )
         if self.last_op is not None and not self.last_op_reply and \
            self.last_op.opcode in initial_opcodes and \
-           now - self.last_op_time > 1.0:
+           now - self.last_op_time > self.retry_timeout():
             self.request_retries += 1
             if self.request_retries > 10:
                 print("FTP: request timed out: %s" % self.last_op)
@@ -1223,7 +1236,8 @@ class FTPWorker(mp_module.MPModule):
             return
 
         # see if burst read has stalled
-        if not self.reached_eof and self.last_burst_read is not None and now - self.last_burst_read > self.ftp_settings.retry_time:
+        if not self.reached_eof and self.last_burst_read is not None and \
+           now - self.last_burst_read > self.retry_timeout():
             dt = now - self.last_burst_read
             self.last_burst_read = now
             if self.ftp_settings.debug > 0:
@@ -1253,6 +1267,11 @@ class FTPModule(mp_module.MPModule):
             [('debug', int, 0),
              ('pkt_loss_tx', int, 0),
              ('pkt_loss_rx', int, 0),
+             ('pkt_lag_tx', float, 0.0),
+             ('pkt_lag_rx', float, 0.0),
+             ('pkt_lag_jitter_tx', float, 0.0),
+             ('pkt_lag_jitter_rx', float, 0.0),
+             ('loss_seed', int, 0),
              ('max_backlog', int, 5),
              ('burst_read_size', int, MAX_Payload),
              ('write_size', int, MAX_Payload),
@@ -1269,8 +1288,96 @@ class FTPModule(mp_module.MPModule):
                                      self.ftp_settings.completion)
         self.workers = {}
         self.pending = []
-        self.next_session = 0
+        # A previous process can leave delayed packets or a cached reply on a
+        # poor link. Starting every process at session zero can then turn a
+        # stale CreateFile ACK into writes against a closed server session.
+        self.next_session = random.SystemRandom().randrange(256)
         self.warned_component = False
+        self.loss_rng = random.Random()
+        self.active_loss_seed = None
+        self.delay_sequence = 0
+        self.tx_delay_queue = []
+        self.rx_delay_queue = []
+        self.last_tx_deadline = 0.0
+        self.last_rx_deadline = 0.0
+
+    def packet_lost(self, direction):
+        '''Return true when the configured link simulator drops a packet.'''
+        seed = self.ftp_settings.loss_seed
+        if seed != self.active_loss_seed:
+            self.loss_rng.seed(None if seed == 0 else seed)
+            self.active_loss_seed = seed
+        percent = (self.ftp_settings.pkt_loss_tx if direction == 'TX'
+                   else self.ftp_settings.pkt_loss_rx)
+        lost = percent > 0 and self.loss_rng.uniform(0, 100) < percent
+        if lost and self.ftp_settings.debug > 1:
+            print("FTP: dropping packet %s" % direction)
+        return lost
+
+    def packet_delay(self, direction):
+        '''Return simulated one-way delay in seconds.
+
+        Jitter is a uniformly distributed extra delay. Delivery deadlines are
+        constrained separately per direction so jitter models FIFO
+        head-of-line blocking instead of reordering a serial telemetry link.
+        '''
+        if direction == 'TX':
+            base = self.ftp_settings.pkt_lag_tx
+            jitter = self.ftp_settings.pkt_lag_jitter_tx
+        else:
+            base = self.ftp_settings.pkt_lag_rx
+            jitter = self.ftp_settings.pkt_lag_jitter_rx
+        delay_ms = max(0.0, base)
+        if jitter > 0:
+            delay_ms += self.loss_rng.uniform(0, jitter)
+        return delay_ms * 0.001
+
+    def _transmit_payloads(self, master, network, target_system,
+                           target_component, payloads):
+        '''Serialize and transmit one logical batch of FTP requests.'''
+        mav = master.mav
+        if len(payloads) <= 1 or not hasattr(mav, 'file'):
+            for payload in payloads:
+                mav.file_transfer_protocol_send(
+                    network, target_system, target_component, payload)
+            return
+
+        link = mav.file
+        collector = MAVLinkBatchWriter()
+        mav.file = collector
+        try:
+            for payload in payloads:
+                mav.file_transfer_protocol_send(
+                    network, target_system, target_component, payload)
+        finally:
+            mav.file = link
+        if collector.packets:
+            link.write(b''.join(collector.packets))
+
+    def send_payloads(self, worker, payloads):
+        '''Apply outgoing loss/lag, preserving batches that survive.'''
+        payloads = [bytes(payload) for payload in payloads
+                    if not self.packet_lost('TX')]
+        if not payloads:
+            return
+        args = (worker.master, worker.network, worker.target_system,
+                worker.target_component, payloads)
+        lag = self.packet_delay('TX')
+        if lag == 0:
+            self._transmit_payloads(*args)
+            return
+        self.delay_sequence += 1
+        deadline = max(time.monotonic() + lag, self.last_tx_deadline)
+        self.last_tx_deadline = deadline
+        heapq.heappush(self.tx_delay_queue,
+                       (deadline, self.delay_sequence, args))
+
+    def _packet_worker(self, m):
+        try:
+            session = m.payload[2]
+        except (IndexError, TypeError):
+            return None
+        return self.workers.get(session)
 
     def cmd_ftp(self, args):
         '''FTP operations'''
@@ -1420,15 +1527,30 @@ class FTPModule(mp_module.MPModule):
                 self.warned_component = True
                 print("FTP reply for mavlink component %u" % m.target_component)
             return
-        try:
-            session = m.payload[2]
-        except (IndexError, TypeError):
+        if self.packet_lost('RX'):
             return
-        worker = self.workers.get(session)
-        if worker is not None:
+        worker = self._packet_worker(m)
+        if worker is None:
+            return
+        lag = self.packet_delay('RX')
+        if lag == 0:
             worker.mavlink_packet(m)
+            return
+        self.delay_sequence += 1
+        deadline = max(time.monotonic() + lag, self.last_rx_deadline)
+        self.last_rx_deadline = deadline
+        heapq.heappush(self.rx_delay_queue,
+                       (deadline, self.delay_sequence, worker, m))
 
     def idle_task(self):
+        now = time.monotonic()
+        while self.tx_delay_queue and self.tx_delay_queue[0][0] <= now:
+            _, _, args = heapq.heappop(self.tx_delay_queue)
+            self._transmit_payloads(*args)
+        while self.rx_delay_queue and self.rx_delay_queue[0][0] <= now:
+            _, _, worker, m = heapq.heappop(self.rx_delay_queue)
+            if self.workers.get(worker.session) is worker:
+                worker.mavlink_packet(m)
         for worker in list(self.workers.values()):
             worker.idle_task()
 

--- a/MAVProxy/modules/mavproxy_ftp.py
+++ b/MAVProxy/modules/mavproxy_ftp.py
@@ -9,6 +9,7 @@ import struct
 import random
 import zlib
 import heapq
+import socket
 
 try:
     # py2
@@ -58,7 +59,19 @@ ERR_FileNotFound = 10
 
 HDR_Len = 12
 MAX_Payload = 239
-WRITE_CAPABILITY_MAGIC = 0xA5
+# Four bytes make accidental capability detection from a legacy server's
+# CreateFile reply vanishingly unlikely.  The bytes on the wire spell MFQ1.
+WRITE_CAPABILITY_MAGIC = b'MFQ1'
+
+# Keep network writes below a normal Ethernet MTU.  MAVLink parsers accept
+# multiple frames in one datagram, while avoiding IP fragmentation makes the
+# whole batch much less likely to be lost on a poor link.
+MAX_NETWORK_BATCH = 1200
+
+# A retired session may still have packets in a real link's buffers.  This is
+# longer than ArduPilot's FTP session expiry and prevents a stale reply or
+# request being routed to a new operation after the uint8 session ID wraps.
+SESSION_REUSE_DELAY = 30.0
 
 # the server null terminates the last byte of its name buffer, so a name
 # filling the payload exactly would be silently truncated
@@ -274,6 +287,10 @@ class FTPWorker(mp_module.MPModule):
             self.set_progress_status("%s %s %s" % (
                 "Uploading" if self.write_list is not None else "Downloading",
                 self.filename, outcome))
+        # Requests queued by the lag simulator belong to this operation and
+        # must never run after cancellation or completion.  Queue only the
+        # final TerminateSession after removing them.
+        self.manager.discard_delayed(self)
         self.send(FTP_OP(self.seq, self.session, OP_TerminateSession, 0, 0, 0, 0, None))
         self.fh = None
         self.filename = None
@@ -724,11 +741,11 @@ class FTPWorker(mp_module.MPModule):
             return
         if op.opcode == OP_Ack:
             self.write_open = True
-            if op.size >= 3 and op.payload[0] == WRITE_CAPABILITY_MAGIC:
+            if op.size >= 6 and bytes(op.payload[:4]) == WRITE_CAPABILITY_MAGIC:
                 if self.ftp_settings.write_qsize <= 0:
-                    self.write_qsize = max(1, op.payload[1])
+                    self.write_qsize = max(1, op.payload[4])
                 if self.ftp_settings.write_batch_size <= 0:
-                    self.write_batch_size = max(1, op.payload[2])
+                    self.write_batch_size = max(1, op.payload[5])
             self.send_more_writes()
         else:
             print("Create failed")
@@ -793,6 +810,11 @@ class FTPWorker(mp_module.MPModule):
         previous_idx = self.write_recv_idx
         acked = [idx]
         if op.burst_complete:
+            if op.size >= 5 and self.ftp_settings.write_qsize <= 0:
+                # The server may enlarge this session's reservation when a
+                # competing writer closes.  Windows never shrink while
+                # requests are outstanding.
+                self.write_qsize = max(self.write_qsize, op.payload[4])
             if op.size >= 4:
                 start_offset, = struct.unpack('<I', bytes(op.payload[:4]))
                 start_idx = start_offset // self.write_block_size
@@ -1388,6 +1410,7 @@ class FTPModule(mp_module.MPModule):
         self.rx_delay_queue = []
         self.last_tx_deadline = 0.0
         self.last_rx_deadline = 0.0
+        self.retired_sessions = {}
 
     def packet_lost(self, direction):
         '''Return true when the configured link simulator drops a packet.'''
@@ -1439,8 +1462,60 @@ class FTPModule(mp_module.MPModule):
                     network, target_system, target_component, payload)
         finally:
             mav.file = link
-        if collector.packets:
-            link.write(b''.join(collector.packets))
+        if not collector.packets:
+            return
+
+        port = getattr(link, 'port', None)
+        port_type = getattr(port, 'type', None)
+        link_name = type(link).__name__
+        is_stream = (link_name in ('mavtcp', 'mavtcpin') or
+                     port_type == socket.SOCK_STREAM)
+        is_network = (link_name == 'mavudp' or
+                      port_type == socket.SOCK_DGRAM or is_stream)
+        if not is_network:
+            # Serial writes benefit substantially from being combined into a
+            # single USB transfer.
+            self._write_link_data(link, b''.join(collector.packets), False)
+            return
+
+        batch = bytearray()
+        for packet in collector.packets:
+            if batch and len(batch) + len(packet) > MAX_NETWORK_BATCH:
+                self._write_link_data(link, bytes(batch), is_stream)
+                batch = bytearray()
+            batch.extend(packet)
+        if batch:
+            self._write_link_data(link, bytes(batch), is_stream)
+
+    def _write_link_data(self, link, data, is_stream):
+        '''Write one encoded batch without ignoring partial stream writes.'''
+        if is_stream:
+            port = getattr(link, 'port', None)
+            if port is None and hasattr(link, 'reconnect'):
+                try:
+                    link.reconnect()
+                except OSError:
+                    return
+                port = getattr(link, 'port', None)
+            if port is not None and hasattr(port, 'sendall'):
+                try:
+                    port.sendall(data)
+                except OSError:
+                    if hasattr(link, 'handle_disconnect'):
+                        link.handle_disconnect()
+                return
+
+        offset = 0
+        while offset < len(data):
+            written = link.write(data[offset:])
+            # Datagram and several pymavlink wrappers return None after a
+            # complete write.  Integer-returning serial writers can be safely
+            # resumed when they accept only part of the buffer.
+            if written is None:
+                return
+            if written <= 0:
+                return
+            offset += written
 
     def send_payloads(self, worker, payloads):
         '''Apply outgoing loss/lag, preserving batches that survive.'''
@@ -1458,7 +1533,7 @@ class FTPModule(mp_module.MPModule):
         deadline = max(time.monotonic() + lag, self.last_tx_deadline)
         self.last_tx_deadline = deadline
         heapq.heappush(self.tx_delay_queue,
-                       (deadline, self.delay_sequence, args))
+                       (deadline, self.delay_sequence, worker, args))
 
     def _packet_worker(self, m):
         try:
@@ -1491,10 +1566,17 @@ class FTPModule(mp_module.MPModule):
 
     def _allocate_session(self):
         '''Return an unused client-selected uint8 session id.'''
+        now = time.monotonic()
+        self.retired_sessions = {
+            session: deadline
+            for session, deadline in self.retired_sessions.items()
+            if deadline > now
+        }
         for _ in range(256):
             session = self.next_session
             self.next_session = (self.next_session + 1) % 256
-            if session not in self.workers:
+            if session not in self.workers and \
+               session not in self.retired_sessions:
                 return session
         return None
 
@@ -1532,10 +1614,33 @@ class FTPModule(mp_module.MPModule):
         '''Forget a completed worker and start the oldest queued operation.'''
         if self.workers.get(worker.session) is worker:
             del self.workers[worker.session]
+            deadline = time.monotonic() + SESSION_REUSE_DELAY
+            # A configured lag can exceed the normal network quarantine.  Do
+            # not reuse the ID before its delayed TerminateSession is sent.
+            for queued_deadline, _, queued_worker, _ in self.tx_delay_queue:
+                if queued_worker is worker:
+                    deadline = max(deadline, queued_deadline + 1.0)
+            self.retired_sessions[worker.session] = deadline
+        self._start_pending()
+
+    def _start_pending(self):
+        '''Start queued work when both a slot and a safe session ID exist.'''
         limit = self._session_limit()
         while self.pending and len(self.workers) < limit:
             operation = self.pending.pop(0)
-            self._launch(operation)
+            if self._launch(operation) is None:
+                break
+
+    def discard_delayed(self, worker):
+        '''Discard simulated-link traffic belonging to a finished worker.'''
+        self.tx_delay_queue = [
+            item for item in self.tx_delay_queue if item[2] is not worker
+        ]
+        heapq.heapify(self.tx_delay_queue)
+        self.rx_delay_queue = [
+            item for item in self.rx_delay_queue if item[2] is not worker
+        ]
+        heapq.heapify(self.rx_delay_queue)
 
     def _session_limit(self):
         # Session ids are uint8.  Keep one value in reserve so allocation and
@@ -1634,14 +1739,19 @@ class FTPModule(mp_module.MPModule):
     def idle_task(self):
         now = time.monotonic()
         while self.tx_delay_queue and self.tx_delay_queue[0][0] <= now:
-            _, _, args = heapq.heappop(self.tx_delay_queue)
-            self._transmit_payloads(*args)
+            _, _, worker, args = heapq.heappop(self.tx_delay_queue)
+            active = self.workers.get(worker.session) is worker
+            terminal = all(payload[3] == OP_TerminateSession
+                           for payload in args[-1])
+            if active or terminal:
+                self._transmit_payloads(*args)
         while self.rx_delay_queue and self.rx_delay_queue[0][0] <= now:
             _, _, worker, m = heapq.heappop(self.rx_delay_queue)
             if self.workers.get(worker.session) is worker:
                 worker.mavlink_packet(m)
         for worker in list(self.workers.values()):
             worker.idle_task()
+        self._start_pending()
 
     def unload(self):
         self.cmd_cancel()

--- a/MAVProxy/modules/mavproxy_ftp.py
+++ b/MAVProxy/modules/mavproxy_ftp.py
@@ -54,6 +54,7 @@ ERR_FileNotFound = 10
 
 HDR_Len = 12
 MAX_Payload = 239
+WRITE_CAPABILITY_MAGIC = 0xA5
 
 # the server null terminates the last byte of its name buffer, so a name
 # filling the payload exactly would be silently truncated
@@ -100,6 +101,17 @@ class WriteQueue:
         self.size = size
         self.last_send = 0
 
+
+class MAVLinkBatchWriter:
+    '''Collect MAVLink packets so several FTP requests use one link write.'''
+    def __init__(self):
+        self.packets = []
+
+    def write(self, packet):
+        self.packets.append(bytes(packet))
+        return len(packet)
+
+
 class FTPWorker(mp_module.MPModule):
     '''State for one FTP operation/session.
 
@@ -145,7 +157,12 @@ class FTPWorker(mp_module.MPModule):
         self.write_idx = 0
         self.write_recv_idx = -1
         self.write_pending = 0
+        self.write_inflight = set()
         self.write_last_send = None
+        self.write_qsize = (self.ftp_settings.write_qsize
+                            if self.ftp_settings.write_qsize > 0 else 5)
+        self.write_batch_size = (self.ftp_settings.write_batch_size
+                                 if self.ftp_settings.write_batch_size > 0 else 1)
         self.warned_component = False
         # console progress is only for interactive ftp get/put, not for the
         # callback-driven transfers behind "param ftp" and "wp ftp"
@@ -190,6 +207,26 @@ class FTPWorker(mp_module.MPModule):
         if self.ftp_settings.debug > 1:
             print("> %s dt=%.2f" % (op, now - self.last_op_time))
         self.last_op_time = time.time()
+
+    def send_batch(self, ops):
+        '''send requests in one link write when supported by pymavlink'''
+        if len(ops) <= 1 or self.master is None or \
+           not hasattr(self.master.mav, 'file'):
+            for op in ops:
+                self.send(op)
+            return
+
+        mav = self.master.mav
+        link = mav.file
+        collector = MAVLinkBatchWriter()
+        mav.file = collector
+        try:
+            for op in ops:
+                self.send(op)
+        finally:
+            mav.file = link
+        if collector.packets:
+            link.write(b''.join(collector.packets))
 
     def terminate_session(self, outcome="failed"):
         '''terminate current session. outcome describes an incomplete transfer
@@ -559,6 +596,7 @@ class FTPWorker(mp_module.MPModule):
         self.write_idx = 0
         self.write_recv_idx = -1
         self.write_pending = 0
+        self.write_inflight = set()
         self.write_last_send = None
 
         self.put_callback = callback
@@ -568,7 +606,10 @@ class FTPWorker(mp_module.MPModule):
         self.read_retries = 0
         self.op_start = time.time()
         enc_fname = bytearray(self.filename, 'ascii')
-        op = FTP_OP(self.seq, self.session, OP_CreateFile, len(enc_fname), 0, 0, 0, enc_fname)
+        # burst_complete is otherwise unused for CreateFile. It opts in to
+        # cumulative ACKs from servers that can commit contiguous write
+        # requests as a batch; older servers safely ignore it.
+        op = FTP_OP(self.seq, self.session, OP_CreateFile, len(enc_fname), 0, 1, 0, enc_fname)
         self.send(op)
 
     def write_block_len(self, idx):
@@ -585,7 +626,9 @@ class FTPWorker(mp_module.MPModule):
             self.put_callback(flen)
             self.put_callback = None
         else:
-            print("Sent file of length ", flen)
+            dt = max(time.time() - self.op_start, 1.0e-6)
+            print("Sent file of length %u in %.2fs %.1fkByte/s" %
+                  (flen, dt, (flen / dt) / 1024.0))
         self.finished_status("uploading", self.filename, flen)
         
     def handle_create_file_reply(self, op, m):
@@ -594,6 +637,11 @@ class FTPWorker(mp_module.MPModule):
             self.terminate_session()
             return
         if op.opcode == OP_Ack:
+            if op.size >= 3 and op.payload[0] == WRITE_CAPABILITY_MAGIC:
+                if self.ftp_settings.write_qsize <= 0:
+                    self.write_qsize = max(1, op.payload[1])
+                if self.ftp_settings.write_batch_size <= 0:
+                    self.write_batch_size = max(1, op.payload[2])
             self.send_more_writes()
         else:
             print("Create failed")
@@ -611,22 +659,34 @@ class FTPWorker(mp_module.MPModule):
         if self.write_last_send is not None:
             if now - self.write_last_send > max(min(10*self.rtt, 1),0.2):
                 # we seem to have lost a block of replies
-                self.write_pending = max(0, self.write_pending-1)
+                self.write_inflight.clear()
+                self.write_pending = 0
+                self.write_last_send = now
 
-        n = min(self.ftp_settings.write_qsize-self.write_pending, len(self.write_list))
+        qsize = max(1, self.write_qsize)
+        batch_size = max(1, min(self.write_batch_size, qsize))
+        free_slots = qsize - self.write_pending
+        if self.write_pending > 0 and free_slots < batch_size:
+            return
+
+        unsent = len(self.write_list - self.write_inflight)
+        n = min(free_slots, unsent)
+        writes = []
         for i in range(n):
             # send in round-robin, skipping any that have been acked
             idx = self.write_idx
-            while idx not in self.write_list:
+            while idx not in self.write_list or idx in self.write_inflight:
                 idx = (idx + 1) % self.write_total
             ofs = idx * self.write_block_size
             self.fh.seek(ofs)
             data = self.fh.read(self.write_block_size)
             write = FTP_OP(self.seq, self.session, OP_WriteFile, len(data), 0, 0, ofs, bytearray(data))
-            self.send(write)
+            writes.append(write)
             self.write_idx = (idx + 1) % self.write_total
+            self.write_inflight.add(idx)
             self.write_pending += 1
             self.write_last_send = now
+        self.send_batch(writes)
 
     def handle_write_reply(self, op, m):
         '''handle OP_WriteFile reply'''
@@ -638,20 +698,44 @@ class FTPWorker(mp_module.MPModule):
             self.terminate_session()
             return
 
-        # assume the FTP server processes the blocks sequentially. This means
-        # when we receive an ack that any blocks between the last ack and this
-        # one have been lost
+        # Legacy servers ACK one block at a time. Negotiated batch ACKs carry
+        # an explicit contiguous range so gaps remain eligible for retry.
         idx = op.offset // self.write_block_size
-        count = (idx - self.write_recv_idx) % self.write_total
-
-        self.write_pending = max(0, self.write_pending - count)
+        previous_idx = self.write_recv_idx
+        acked = [idx]
+        if op.burst_complete:
+            if op.size >= 4:
+                start_offset, = struct.unpack('<I', bytes(op.payload[:4]))
+                start_idx = start_offset // self.write_block_size
+                count = ((idx - start_idx) % self.write_total) + 1
+                acked = [((start_idx + i) % self.write_total)
+                         for i in range(count)]
+            else:
+                # Compatibility with early servers that only marked the last
+                # block. The negotiated format also supplies the start offset
+                # so a dropped request cannot be mistaken for a written block.
+                count = (idx - previous_idx) % self.write_total
+                if count == 0:
+                    count = self.write_total
+                acked = [((previous_idx + i) % self.write_total)
+                         for i in range(1, count + 1)]
+        else:
+            count = (idx - previous_idx) % self.write_total
+            # An ACK jump on a legacy server means intervening requests were
+            # dropped. Mark them sendable again, while only idx is complete.
+            for i in range(1, count):
+                self.write_inflight.discard(
+                    (previous_idx + i) % self.write_total)
+        for ack_idx in acked:
+            if ack_idx in self.write_list:
+                # servers are required to resend replies to repeated requests,
+                # so only count a block the first time it is acked
+                self.write_list.discard(ack_idx)
+                self.write_acks += 1
+                self.write_acked_bytes += self.write_block_len(ack_idx)
+            self.write_inflight.discard(ack_idx)
+        self.write_pending = len(self.write_inflight)
         self.write_recv_idx = idx
-        if idx in self.write_list:
-            # servers are required to resend replies to repeated requests, so
-            # only count a block the first time it is acked
-            self.write_list.discard(idx)
-            self.write_acks += 1
-            self.write_acked_bytes += self.write_block_len(idx)
         if self.put_callback_progress:
             self.put_callback_progress(self.write_acks/float(self.write_total))
         self.send_more_writes()
@@ -1170,9 +1254,12 @@ class FTPModule(mp_module.MPModule):
              ('pkt_loss_tx', int, 0),
              ('pkt_loss_rx', int, 0),
              ('max_backlog', int, 5),
-             ('burst_read_size', int, 80),
-             ('write_size', int, 80),
-             ('write_qsize', int, 5),
+             ('burst_read_size', int, MAX_Payload),
+             ('write_size', int, MAX_Payload),
+             # zero selects the server-advertised values, with conservative
+             # fallbacks for servers predating write batching
+             ('write_qsize', int, 0),
+             ('write_batch_size', int, 0),
              ('retry_time', float, 0.5),
              ('crccmp_timeout', float, 120.0),
              # ArduPilot currently has five GCS_FTP server sessions.  Keeping

--- a/MAVProxy/modules/mavproxy_ftp.py
+++ b/MAVProxy/modules/mavproxy_ftp.py
@@ -38,8 +38,9 @@ OP_TruncateFile = 12
 OP_Rename = 13
 OP_CalcFileCRC32 = 14
 OP_BurstReadFile = 15
-# Like OP_ListDirectory, with an mtime field appended to file entries.  Older
-# servers either NACK this request or ignore it, so callers must fall back.
+# Peter Barker's extension: like OP_ListDirectory, with an mtime field appended
+# to file entries.  Older servers either NACK this request or ignore it, so
+# callers must fall back.
 OP_ListDirectoryWithTime = 16
 OP_Ack = 128
 OP_Nack = 129
@@ -59,9 +60,6 @@ ERR_FileNotFound = 10
 
 HDR_Len = 12
 MAX_Payload = 239
-# Four bytes make accidental capability detection from a legacy server's
-# CreateFile reply vanishingly unlikely.  The bytes on the wire spell MFQ1.
-WRITE_CAPABILITY_MAGIC = b'MFQ1'
 
 # Keep network writes below a normal Ethernet MTU.  MAVLink parsers accept
 # multiple frames in one datagram, while avoiding IP fragmentation makes the
@@ -77,6 +75,7 @@ SESSION_REUSE_DELAY = 30.0
 # filling the payload exactly would be silently truncated
 MAX_FTP_NAME = MAX_Payload - 1
 
+
 class FTP_OP:
     def __init__(self, seq, session, opcode, size, req_opcode, burst_complete, offset, payload):
         self.seq = seq
@@ -90,7 +89,9 @@ class FTP_OP:
 
     def pack(self):
         '''pack message'''
-        ret = struct.pack("<HBBBBBBI", self.seq, self.session, self.opcode, self.size, self.req_opcode, self.burst_complete, 0, self.offset)
+        ret = struct.pack("<HBBBBBBI", self.seq, self.session, self.opcode,
+                          self.size, self.req_opcode, self.burst_complete, 0,
+                          self.offset)
         if self.payload is not None:
             ret += self.payload
         ret = bytearray(ret)
@@ -111,6 +112,7 @@ class FTP_OP:
         if plen > 0:
             ret += " [%u]" % self.payload[0]
         return ret
+
 
 class WriteQueue:
     def __init__(self, ofs, size):
@@ -182,10 +184,7 @@ class FTPWorker(mp_module.MPModule):
         self.write_inflight = set()
         self.write_last_send = None
         self.write_open = False
-        self.write_qsize = (self.ftp_settings.write_qsize
-                            if self.ftp_settings.write_qsize > 0 else 5)
-        self.write_batch_size = (self.ftp_settings.write_batch_size
-                                 if self.ftp_settings.write_batch_size > 0 else 1)
+        self.write_qsize = max(1, self.ftp_settings.write_qsize)
         self.warned_component = False
         # console progress is only for interactive ftp get/put, not for the
         # callback-driven transfers behind "param ftp" and "wp ftp"
@@ -375,7 +374,7 @@ class FTPWorker(mp_module.MPModule):
             self.manager.list_time_supported[self.list_target_key()] = True
         if op.opcode == OP_Ack:
             dentries = sorted(op.payload.split(b'\x00'))
-            #print(dentries)
+            # print(dentries)
             for d in dentries:
                 if len(d) == 0:
                     continue
@@ -518,7 +517,7 @@ class FTPWorker(mp_module.MPModule):
         self.read_total += len(op.payload)
         if self.callback_progress is not None:
             self.callback_progress(self.fh, self.read_total)
-    
+
     def handle_burst_read(self, op, m):
         '''handle OP_BurstReadFile reply'''
         if self.fh is None or self.filename is None:
@@ -575,7 +574,9 @@ class FTPWorker(mp_module.MPModule):
                     # a burst complete with non-zero size and less than burst packet size
                     # means EOF
                     if not self.reached_eof and self.ftp_settings.debug > 0:
-                        print("EOF at %u with %u gaps t=%.2f" % (self.fh.tell(), len(self.read_gaps), time.time() - self.op_start))
+                        print("EOF at %u with %u gaps t=%.2f" %
+                              (self.fh.tell(), len(self.read_gaps),
+                               time.time() - self.op_start))
                     self.reached_eof = True
                     if self.check_read_finished():
                         return
@@ -642,7 +643,7 @@ class FTPWorker(mp_module.MPModule):
             print("Read failed with %u gaps" % len(self.read_gaps), str(op))
             self.terminate_session()
         self.check_read_send()
-            
+
     def cmd_put(self, args, fh=None, callback=None, progress_callback=None):
         '''put file'''
         if len(args) == 0:
@@ -675,7 +676,7 @@ class FTPWorker(mp_module.MPModule):
             self.filename += os.path.basename(fname)
         if callback is None:
             print("Putting %s as %s" % (fname, self.filename))
-        self.fh.seek(0,2)
+        self.fh.seek(0, 2)
         file_size = self.fh.tell()
         self.fh.seek(0)
 
@@ -709,10 +710,8 @@ class FTPWorker(mp_module.MPModule):
         self.read_retries = 0
         self.op_start = time.time()
         enc_fname = bytearray(self.filename, 'ascii')
-        # burst_complete is otherwise unused for CreateFile. It opts in to
-        # cumulative ACKs from servers that can commit contiguous write
-        # requests as a batch; older servers safely ignore it.
-        op = FTP_OP(self.seq, self.session, OP_CreateFile, len(enc_fname), 0, 1, 0, enc_fname)
+        op = FTP_OP(self.seq, self.session, OP_CreateFile, len(enc_fname), 0, 0,
+                    0, enc_fname)
         self.send(op)
 
     def write_block_len(self, idx):
@@ -733,7 +732,7 @@ class FTPWorker(mp_module.MPModule):
             print("Sent file of length %u in %.2fs %.1fkByte/s" %
                   (flen, dt, (flen / dt) / 1024.0))
         self.finished_status("uploading", self.filename, flen)
-        
+
     def handle_create_file_reply(self, op, m):
         '''handle OP_CreateFile reply'''
         if self.fh is None:
@@ -741,11 +740,6 @@ class FTPWorker(mp_module.MPModule):
             return
         if op.opcode == OP_Ack:
             self.write_open = True
-            if op.size >= 6 and bytes(op.payload[:4]) == WRITE_CAPABILITY_MAGIC:
-                if self.ftp_settings.write_qsize <= 0:
-                    self.write_qsize = max(1, op.payload[4])
-                if self.ftp_settings.write_batch_size <= 0:
-                    self.write_batch_size = max(1, op.payload[5])
             self.send_more_writes()
         else:
             print("Create failed")
@@ -770,9 +764,8 @@ class FTPWorker(mp_module.MPModule):
                 self.write_last_send = now
 
         qsize = max(1, self.write_qsize)
-        batch_size = max(1, min(self.write_batch_size, qsize))
         free_slots = qsize - self.write_pending
-        if self.write_pending > 0 and free_slots < batch_size:
+        if free_slots <= 0:
             return
 
         unsent = len(self.write_list - self.write_inflight)
@@ -804,47 +797,23 @@ class FTPWorker(mp_module.MPModule):
             self.terminate_session()
             return
 
-        # Legacy servers ACK one block at a time. Negotiated batch ACKs carry
-        # an explicit contiguous range so gaps remain eligible for retry.
+        # MAVFTP servers ACK one block at a time.  An ACK jump means an earlier
+        # request was dropped, so make the intervening blocks eligible for
+        # retransmission while completing only the explicitly acknowledged
+        # block.
         idx = op.offset // self.write_block_size
         previous_idx = self.write_recv_idx
-        acked = [idx]
-        if op.burst_complete:
-            if op.size >= 5 and self.ftp_settings.write_qsize <= 0:
-                # The server may enlarge this session's reservation when a
-                # competing writer closes.  Windows never shrink while
-                # requests are outstanding.
-                self.write_qsize = max(self.write_qsize, op.payload[4])
-            if op.size >= 4:
-                start_offset, = struct.unpack('<I', bytes(op.payload[:4]))
-                start_idx = start_offset // self.write_block_size
-                count = ((idx - start_idx) % self.write_total) + 1
-                acked = [((start_idx + i) % self.write_total)
-                         for i in range(count)]
-            else:
-                # Compatibility with early servers that only marked the last
-                # block. The negotiated format also supplies the start offset
-                # so a dropped request cannot be mistaken for a written block.
-                count = (idx - previous_idx) % self.write_total
-                if count == 0:
-                    count = self.write_total
-                acked = [((previous_idx + i) % self.write_total)
-                         for i in range(1, count + 1)]
-        else:
-            count = (idx - previous_idx) % self.write_total
-            # An ACK jump on a legacy server means intervening requests were
-            # dropped. Mark them sendable again, while only idx is complete.
-            for i in range(1, count):
-                self.write_inflight.discard(
-                    (previous_idx + i) % self.write_total)
-        for ack_idx in acked:
-            if ack_idx in self.write_list:
-                # servers are required to resend replies to repeated requests,
-                # so only count a block the first time it is acked
-                self.write_list.discard(ack_idx)
-                self.write_acks += 1
-                self.write_acked_bytes += self.write_block_len(ack_idx)
-            self.write_inflight.discard(ack_idx)
+        count = (idx - previous_idx) % self.write_total
+        for i in range(1, count):
+            self.write_inflight.discard(
+                (previous_idx + i) % self.write_total)
+        if idx in self.write_list:
+            # Servers resend replies to repeated requests, so only count a
+            # block the first time it is acknowledged.
+            self.write_list.discard(idx)
+            self.write_acks += 1
+            self.write_acked_bytes += self.write_block_len(idx)
+        self.write_inflight.discard(idx)
         self.write_pending = len(self.write_inflight)
         self.write_recv_idx = idx
         if self.put_callback_progress:
@@ -1168,7 +1137,9 @@ class FTPWorker(mp_module.MPModule):
             ofs = self.fh.tell()
             dt = time.time() - self.op_start
             rate = (ofs / dt) / 1024.0
-            print("Transfer at offset %u with %u gaps %u retries %.1f kByte/sec" % (ofs, len(self.read_gaps), self.read_retries, rate))
+            print("Transfer at offset %u with %u gaps %u retries "
+                  "%.1f kByte/sec" %
+                  (ofs, len(self.read_gaps), self.read_retries, rate))
 
     def op_parse(self, m):
         '''parse a FILE_TRANSFER_PROTOCOL msg'''
@@ -1182,7 +1153,7 @@ class FTPWorker(mp_module.MPModule):
         mtype = m.get_type()
         if mtype == "FILE_TRANSFER_PROTOCOL":
             if (m.target_system != self.settings.source_system or
-                m.target_component != self.settings.source_component):
+                    m.target_component != self.settings.source_component):
                 if m.target_system == self.settings.source_system and not self.warned_component:
                     self.warned_component = True
                     print("FTP reply for mavlink component %u" % m.target_component)
@@ -1380,10 +1351,7 @@ class FTPModule(mp_module.MPModule):
              ('max_backlog', int, 5),
              ('burst_read_size', int, MAX_Payload),
              ('write_size', int, MAX_Payload),
-             # zero selects the server-advertised values, with conservative
-             # fallbacks for servers predating write batching
-             ('write_qsize', int, 0),
-             ('write_batch_size', int, 0),
+             ('write_qsize', int, 5),
              ('retry_time', float, 0.5),
              ('crccmp_timeout', float, 120.0),
              ('list_time', int, 1),
@@ -1756,6 +1724,7 @@ class FTPModule(mp_module.MPModule):
     def unload(self):
         self.cmd_cancel()
         super(FTPModule, self).unload()
+
 
 def init(mpstate):
     '''initialise module'''

--- a/tests/test_mavproxy_ftp.py
+++ b/tests/test_mavproxy_ftp.py
@@ -2,6 +2,7 @@ import importlib.util
 import io
 from pathlib import Path
 import struct
+import time
 import types
 import unittest
 
@@ -84,6 +85,7 @@ class TestConcurrentFTP(unittest.TestCase):
     def setUp(self):
         self.mpstate = FakeMPState()
         self.ftp = mavproxy_ftp.FTPModule(self.mpstate)
+        self.ftp.next_session = 0
 
     def test_gets_and_list_have_independent_sessions_and_state(self):
         results = {}
@@ -160,6 +162,7 @@ class TestConcurrentFTP(unittest.TestCase):
         self.assertIs(self.ftp.workers[0], worker)
 
         self.ftp.ftp_settings.retry_time = 0
+        worker.last_op_time -= worker.retry_timeout()
         sent_before = len(self.mpstate._master.mav.sent)
         self.ftp.idle_task()
         self.assertEqual(len(self.mpstate._master.mav.sent), sent_before + 1)
@@ -211,6 +214,13 @@ class TestConcurrentFTP(unittest.TestCase):
         self.assertEqual(worker.write_qsize, 5)
         self.assertEqual(worker.write_batch_size, 1)
 
+        # A delayed or lost CreateFile must not let idle processing send file
+        # data before the remote file exists.
+        sent = len(self.mpstate._master.mav.sent)
+        for _ in range(10):
+            worker.idle_task()
+        self.assertEqual(len(self.mpstate._master.mav.sent), sent)
+
         capabilities = bytes([
             mavproxy_ftp.WRITE_CAPABILITY_MAGIC, 64, 8,
         ])
@@ -242,6 +252,108 @@ class TestConcurrentFTP(unittest.TestCase):
         self.assertEqual(worker.write_list, {0, 1, 4, 5})
         self.assertEqual(worker.write_pending, 4)
         self.assertEqual(worker.write_acked_bytes, 4)
+
+    def test_packet_loss_uses_actual_link_directions(self):
+        self.ftp.ftp_settings.pkt_loss_tx = 100
+        self.ftp.cmd_list(['/'])
+        worker = self.ftp.workers[0]
+
+        # TX loss makes the request invisible to the transport while keeping
+        # enough protocol state to retry it.
+        self.assertEqual(self.mpstate._master.mav.sent, [])
+        self.assertEqual(worker.seq, 1)
+        self.ftp.ftp_settings.pkt_loss_tx = 0
+        worker.last_op_time -= worker.retry_timeout() + 0.01
+        self.ftp.idle_task()
+        self.assertEqual(len(self.mpstate._master.mav.sent), 1)
+
+        # RX loss must likewise be invisible to the worker.
+        eof = reply(0, mavproxy_ftp.OP_ListDirectory,
+                    opcode=mavproxy_ftp.OP_Nack,
+                    payload=bytes([mavproxy_ftp.ERR_EndOfFile]))
+        self.ftp.ftp_settings.pkt_loss_rx = 100
+        self.ftp.mavlink_packet(eof)
+        self.assertIn(0, self.ftp.workers)
+        self.ftp.ftp_settings.pkt_loss_rx = 0
+        self.ftp.mavlink_packet(eof)
+        self.assertNotIn(0, self.ftp.workers)
+
+    def test_packet_lag_is_nonblocking_and_bidirectional(self):
+        self.ftp.ftp_settings.pkt_lag_tx = 100
+        self.ftp.cmd_list(['/'])
+        self.assertEqual(self.mpstate._master.mav.sent, [])
+        self.assertEqual(len(self.ftp.tx_delay_queue), 1)
+
+        deadline, sequence, args = self.ftp.tx_delay_queue[0]
+        self.ftp.tx_delay_queue[0] = (time.monotonic() - 1,
+                                      sequence, args)
+        self.ftp.idle_task()
+        self.assertEqual(len(self.mpstate._master.mav.sent), 1)
+
+        self.ftp.ftp_settings.pkt_lag_rx = 100
+        eof = reply(0, mavproxy_ftp.OP_ListDirectory,
+                    opcode=mavproxy_ftp.OP_Nack,
+                    payload=bytes([mavproxy_ftp.ERR_EndOfFile]))
+        self.ftp.mavlink_packet(eof)
+        self.assertIn(0, self.ftp.workers)
+        self.assertEqual(len(self.ftp.rx_delay_queue), 1)
+
+        deadline, sequence, worker, message = self.ftp.rx_delay_queue[0]
+        self.ftp.rx_delay_queue[0] = (time.monotonic() - 1,
+                                      sequence, worker, message)
+        self.ftp.idle_task()
+        self.assertNotIn(0, self.ftp.workers)
+
+    def test_loss_seed_replays_variable_lag(self):
+        other = mavproxy_ftp.FTPModule(FakeMPState())
+        for ftp in (self.ftp, other):
+            ftp.ftp_settings.loss_seed = 1234
+            ftp.ftp_settings.pkt_lag_tx = 100
+            ftp.ftp_settings.pkt_lag_jitter_tx = 500
+            # packet_lost initialises the private deterministic generator even
+            # when the configured loss percentage is zero.
+            ftp.packet_lost('TX')
+
+        first = [self.ftp.packet_delay('TX') for _ in range(10)]
+        second = [other.packet_delay('TX') for _ in range(10)]
+        self.assertEqual(first, second)
+        self.assertTrue(all(0.1 <= delay <= 0.6 for delay in first))
+
+    def test_delayed_reply_raises_retransmission_timeout(self):
+        self.ftp.cmd_get(['/remote'], callback=lambda fh: None)
+        worker = self.ftp.workers[0]
+        request_seq = worker.last_op.seq
+        worker.send_times[request_seq] -= 2.0
+
+        self.ftp.mavlink_packet(reply(
+            0, mavproxy_ftp.OP_OpenFileRO, payload=struct.pack('<I', 10)))
+
+        self.assertTrue(worker.rtt_valid)
+        self.assertGreater(worker.retry_timeout(), 5.0)
+        sent = len(self.mpstate._master.mav.sent)
+        worker.last_burst_read -= 1.0
+        self.ftp.idle_task()
+        self.assertEqual(len(self.mpstate._master.mav.sent), sent)
+
+    def test_gap_reads_use_bounded_parallel_window(self):
+        self.ftp.ftp_settings.max_backlog = 2
+        self.ftp.cmd_get(['/remote'], callback=lambda fh: None)
+        self.ftp.mavlink_packet(reply(
+            0, mavproxy_ftp.OP_OpenFileRO, payload=struct.pack('<I', 1000)))
+        worker = self.ftp.workers[0]
+        worker.read_gaps = [(0, 100), (100, 100), (200, 100)]
+        worker.read_gap_times = {gap: 0 for gap in worker.read_gaps}
+
+        sent = len(self.mpstate._master.mav.sent)
+        worker.check_read_send()
+        self.assertEqual(worker.backlog, 2)
+        self.assertEqual(len(self.mpstate._master.mav.sent), sent + 2)
+
+        for gap in worker.read_gaps[:2]:
+            worker.read_gap_times[gap] -= worker.retry_timeout() + 0.01
+        worker.check_read_send()
+        self.assertEqual(worker.backlog, 2)
+        self.assertEqual(len(self.mpstate._master.mav.sent), sent + 4)
 
 
 if __name__ == '__main__':

--- a/tests/test_mavproxy_ftp.py
+++ b/tests/test_mavproxy_ftp.py
@@ -23,10 +23,12 @@ FTP_SPEC.loader.exec_module(mavproxy_ftp)
 class FakeMAV:
     def __init__(self):
         self.sent = []
+        self.targets = []
 
     def file_transfer_protocol_send(self, network, target_system,
                                     target_component, payload):
         self.sent.append(bytes(payload))
+        self.targets.append((target_system, target_component))
 
 
 class FakeMaster:
@@ -92,21 +94,32 @@ class FakeMPState:
 
 
 class FTPMessage:
-    def __init__(self, payload):
+    def __init__(self, payload, source_system=1, source_component=1):
         self.payload = payload
         self.target_system = 255
         self.target_component = 0
+        self.source_system = source_system
+        self.source_component = source_component
 
     def get_type(self):
         return "FILE_TRANSFER_PROTOCOL"
 
+    def get_srcSystem(self):
+        return self.source_system
+
+    def get_srcComponent(self):
+        return self.source_component
+
 
 def reply(session, req_opcode, opcode=mavproxy_ftp.OP_Ack, payload=b'',
-          offset=0, burst_complete=0, seq=1):
+          offset=0, burst_complete=0, seq=1, source_system=1,
+          source_component=1):
     header = struct.pack(
         '<HBBBBBBI', seq, session, opcode, len(payload), req_opcode,
         burst_complete, 0, offset)
-    return FTPMessage(bytearray(header + payload).ljust(251, b'\x00'))
+    return FTPMessage(bytearray(header + payload).ljust(251, b'\x00'),
+                      source_system=source_system,
+                      source_component=source_component)
 
 
 def request_session(payload):
@@ -170,6 +183,43 @@ class TestConcurrentFTP(unittest.TestCase):
         self.assertEqual(results, {'first': b'first', 'second': b'second'})
         self.assertEqual(self.ftp.workers, {})
 
+    def test_active_and_queued_operations_keep_submission_target(self):
+        self.ftp.ftp_settings.max_sessions = 1
+        self.ftp.cmd_list(['/'])
+        self.ftp.cmd_get(['/remote'], callback=lambda fh: None)
+        self.assertEqual(len(self.ftp.pending), 1)
+
+        # Changing MAVProxy's selected vehicle must not retarget either the
+        # active listing or the operation queued while system 1 was selected.
+        self.mpstate.settings.target_system = 2
+        self.ftp.mavlink_packet(reply(
+            0, mavproxy_ftp.OP_ListDirectoryWithTime,
+            opcode=mavproxy_ftp.OP_Nack,
+            payload=bytes([mavproxy_ftp.ERR_EndOfFile])))
+
+        worker = self.ftp.workers[1]
+        self.assertEqual(worker.ftp_target_system, 1)
+        self.assertTrue(all(target == (1, 1)
+                            for target in self.mpstate._master.mav.targets))
+
+        self.ftp.mavlink_packet(reply(
+            1, mavproxy_ftp.OP_OpenFileRO, payload=struct.pack('<I', 10)))
+        self.assertEqual(self.mpstate._master.mav.targets[-1], (1, 1))
+
+    def test_reply_from_another_vehicle_is_not_routed_by_session_alone(self):
+        self.ftp.cmd_list(['/'])
+        self.ftp.mavlink_packet(reply(
+            0, mavproxy_ftp.OP_ListDirectoryWithTime,
+            opcode=mavproxy_ftp.OP_Nack,
+            payload=bytes([mavproxy_ftp.ERR_EndOfFile]), source_system=2))
+        self.assertIn(0, self.ftp.workers)
+
+        self.ftp.mavlink_packet(reply(
+            0, mavproxy_ftp.OP_ListDirectoryWithTime,
+            opcode=mavproxy_ftp.OP_Nack,
+            payload=bytes([mavproxy_ftp.ERR_EndOfFile])))
+        self.assertNotIn(0, self.ftp.workers)
+
     def test_sixth_operation_is_queued_until_a_session_finishes(self):
         for _ in range(6):
             self.ftp.cmd_list(['/'])
@@ -228,6 +278,61 @@ class TestConcurrentFTP(unittest.TestCase):
         self.assertEqual(request_session(retried_packet), 0)
         self.assertEqual(worker.request_retries, 1)
         self.assertEqual(len(self.ftp.workers), 1)
+
+    def test_retried_open_recovers_when_cached_ack_was_evicted(self):
+        self.ftp.cmd_get(['/remote'], callback=lambda fh: None)
+        worker = self.ftp.workers[0]
+        worker.last_op_time -= worker.retry_timeout() + 0.01
+        self.ftp.idle_task()
+        self.assertEqual(worker.request_retries, 1)
+
+        # A shared server reply cache can lose the original ACK to another
+        # session. Re-executing OpenFileRO then reports ERR_Fail because this
+        # session's descriptor is already open.
+        self.ftp.mavlink_packet(reply(
+            0, mavproxy_ftp.OP_OpenFileRO, opcode=mavproxy_ftp.OP_Nack,
+            payload=bytes([mavproxy_ftp.ERR_Fail])))
+
+        self.assertIn(0, self.ftp.workers)
+        self.assertIsNotNone(worker.fh)
+        self.assertEqual(request_opcode(self.mpstate._master.mav.sent[-1]),
+                         mavproxy_ftp.OP_BurstReadFile)
+        fh = worker.fh
+        sent = len(self.mpstate._master.mav.sent)
+        self.ftp.mavlink_packet(reply(
+            0, mavproxy_ftp.OP_OpenFileRO, opcode=mavproxy_ftp.OP_Nack,
+            payload=bytes([mavproxy_ftp.ERR_Fail]), seq=1))
+        self.assertIs(worker.fh, fh)
+        self.assertEqual(len(self.mpstate._master.mav.sent), sent)
+
+    def test_retried_create_recovers_when_cached_ack_was_evicted(self):
+        self.ftp.cmd_put(['unused', '/remote'], fh=io.BytesIO(b'abc'))
+        worker = self.ftp.workers[0]
+        worker.last_op_time -= worker.retry_timeout() + 0.01
+        self.ftp.idle_task()
+        self.assertEqual(worker.request_retries, 1)
+
+        self.ftp.mavlink_packet(reply(
+            0, mavproxy_ftp.OP_CreateFile, opcode=mavproxy_ftp.OP_Nack,
+            payload=bytes([mavproxy_ftp.ERR_Fail])))
+
+        self.assertTrue(worker.write_open)
+        self.assertEqual(request_opcode(self.mpstate._master.mav.sent[-1]),
+                         mavproxy_ftp.OP_WriteFile)
+        sent = len(self.mpstate._master.mav.sent)
+        self.ftp.mavlink_packet(reply(
+            0, mavproxy_ftp.OP_CreateFile, opcode=mavproxy_ftp.OP_Nack,
+            payload=bytes([mavproxy_ftp.ERR_Fail]), seq=1))
+        self.assertIn(0, self.ftp.workers)
+        self.assertEqual(len(self.mpstate._master.mav.sent), sent)
+
+    def test_initial_open_failure_is_not_treated_as_recovery(self):
+        self.ftp.cmd_get(['/remote'], callback=lambda fh: None)
+        self.ftp.mavlink_packet(reply(
+            0, mavproxy_ftp.OP_OpenFileRO, opcode=mavproxy_ftp.OP_Nack,
+            payload=bytes([mavproxy_ftp.ERR_Fail])))
+
+        self.assertNotIn(0, self.ftp.workers)
 
     def test_list_with_time_parses_names_from_the_end(self):
         output = io.StringIO()
@@ -540,6 +645,45 @@ class TestConcurrentFTP(unittest.TestCase):
         worker.check_read_send()
         self.assertEqual(worker.backlog, 2)
         self.assertEqual(len(self.mpstate._master.mav.sent), sent + 4)
+
+    def test_burst_filling_inflight_gaps_releases_read_window(self):
+        self.ftp.ftp_settings.max_backlog = 2
+        self.ftp.cmd_get(['/remote'], callback=lambda fh: None)
+        self.ftp.mavlink_packet(reply(
+            0, mavproxy_ftp.OP_OpenFileRO, payload=struct.pack('<I', 1000)))
+        worker = self.ftp.workers[0]
+        worker.fh.seek(300)
+        worker.read_gaps = [(0, 100), (100, 100), (200, 100)]
+        now = time.time()
+        worker.read_gap_times = {
+            (0, 100): now,
+            (100, 100): now,
+            (200, 100): 0,
+        }
+        worker.backlog = 2
+
+        # Late burst packets can fill gaps for which OP_ReadFile requests are
+        # already outstanding. Each must release its slot immediately.
+        self.ftp.mavlink_packet(reply(
+            0, mavproxy_ftp.OP_BurstReadFile, payload=b'a' * 100,
+            offset=0, seq=3))
+        self.ftp.mavlink_packet(reply(
+            0, mavproxy_ftp.OP_BurstReadFile, payload=b'b' * 100,
+            offset=100, seq=4))
+        self.assertEqual(worker.backlog, 0)
+        self.assertEqual(worker.read_gaps, [(200, 100)])
+
+        sent = len(self.mpstate._master.mav.sent)
+        worker.check_read_send()
+        self.assertEqual(worker.backlog, 1)
+        self.assertEqual(len(self.mpstate._master.mav.sent), sent + 1)
+
+        # A delayed short reply for a gap already filled by burst data is a
+        # duplicate, not evidence that the remote file changed.
+        self.ftp.mavlink_packet(reply(
+            0, mavproxy_ftp.OP_ReadFile, payload=b'a' * 100,
+            offset=0, seq=5))
+        self.assertIn(0, self.ftp.workers)
 
 
 if __name__ == '__main__':

--- a/tests/test_mavproxy_ftp.py
+++ b/tests/test_mavproxy_ftp.py
@@ -1,4 +1,5 @@
 import importlib.util
+import io
 from pathlib import Path
 import struct
 import types
@@ -181,6 +182,66 @@ class TestConcurrentFTP(unittest.TestCase):
         self.assertEqual(request_session(retried_packet), 0)
         self.assertEqual(worker.request_retries, 1)
         self.assertEqual(len(self.ftp.workers), 1)
+
+    def test_cumulative_write_ack_completes_contiguous_batch(self):
+        self.ftp.ftp_settings.write_size = 2
+        self.ftp.ftp_settings.write_qsize = 4
+        self.ftp.ftp_settings.write_batch_size = 2
+        completed = []
+        self.ftp.cmd_put(['unused', '/remote'], fh=io.BytesIO(b'abcdefgh'),
+                         callback=completed.append)
+
+        create = self.mpstate._master.mav.sent[0]
+        self.assertEqual(create[6], 1)
+        self.ftp.mavlink_packet(reply(0, mavproxy_ftp.OP_CreateFile))
+        worker = self.ftp.workers[0]
+        self.assertEqual(worker.write_pending, 4)
+
+        # One negotiated ACK covers blocks 0 through 3.
+        self.ftp.mavlink_packet(reply(
+            0, mavproxy_ftp.OP_WriteFile, offset=6,
+            payload=struct.pack('<I', 0), burst_complete=1, seq=5))
+
+        self.assertEqual(completed, [8])
+        self.assertNotIn(0, self.ftp.workers)
+
+    def test_write_window_uses_server_capabilities_in_auto_mode(self):
+        self.ftp.cmd_put(['unused', '/remote'], fh=io.BytesIO(b'abc'))
+        worker = self.ftp.workers[0]
+        self.assertEqual(worker.write_qsize, 5)
+        self.assertEqual(worker.write_batch_size, 1)
+
+        capabilities = bytes([
+            mavproxy_ftp.WRITE_CAPABILITY_MAGIC, 64, 8,
+        ])
+        self.ftp.mavlink_packet(reply(
+            0, mavproxy_ftp.OP_CreateFile, payload=capabilities))
+
+        self.assertEqual(worker.write_qsize, 64)
+        self.assertEqual(worker.write_batch_size, 8)
+        sent = len(self.mpstate._master.mav.sent)
+        for _ in range(10):
+            worker.idle_task()
+        self.assertEqual(len(self.mpstate._master.mav.sent), sent)
+
+    def test_cumulative_ack_does_not_cover_a_gap_before_its_start(self):
+        self.ftp.ftp_settings.write_size = 2
+        self.ftp.ftp_settings.write_qsize = 6
+        self.ftp.ftp_settings.write_batch_size = 6
+        self.ftp.cmd_put(['unused', '/remote'],
+                         fh=io.BytesIO(b'abcdefghijkl'))
+        self.ftp.mavlink_packet(reply(0, mavproxy_ftp.OP_CreateFile))
+        worker = self.ftp.workers[0]
+
+        # The server received and wrote only blocks 2 and 3. Blocks 0 and 1
+        # must remain queued even though the cumulative ACK ends after them.
+        self.ftp.mavlink_packet(reply(
+            0, mavproxy_ftp.OP_WriteFile, offset=6,
+            payload=struct.pack('<I', 4), burst_complete=1, seq=5))
+
+        self.assertEqual(worker.write_list, {0, 1, 4, 5})
+        self.assertEqual(worker.write_pending, 4)
+        self.assertEqual(worker.write_acked_bytes, 4)
 
 
 if __name__ == '__main__':

--- a/tests/test_mavproxy_ftp.py
+++ b/tests/test_mavproxy_ftp.py
@@ -301,50 +301,41 @@ class TestConcurrentFTP(unittest.TestCase):
         self.assertEqual(len(self.mpstate._master.mav.sent), sent)
         self.assertEqual(worker.dir_offset, 0)
 
-    def test_cumulative_write_ack_completes_contiguous_batch(self):
+    def test_upload_uses_baseline_create_and_per_block_acks(self):
         self.ftp.ftp_settings.write_size = 2
         self.ftp.ftp_settings.write_qsize = 4
-        self.ftp.ftp_settings.write_batch_size = 2
         completed = []
         self.ftp.cmd_put(['unused', '/remote'], fh=io.BytesIO(b'abcdefgh'),
                          callback=completed.append)
 
         create = self.mpstate._master.mav.sent[0]
-        self.assertEqual(create[6], 1)
+        self.assertEqual(create[6], 0)
         self.ftp.mavlink_packet(reply(0, mavproxy_ftp.OP_CreateFile))
         worker = self.ftp.workers[0]
         self.assertEqual(worker.write_pending, 4)
 
-        # One negotiated ACK covers blocks 0 through 3.
-        self.ftp.mavlink_packet(reply(
-            0, mavproxy_ftp.OP_WriteFile, offset=6,
-            payload=struct.pack('<I', 0), burst_complete=1, seq=5))
+        for seq, offset in enumerate(range(0, 8, 2), start=2):
+            self.ftp.mavlink_packet(reply(
+                0, mavproxy_ftp.OP_WriteFile, offset=offset, seq=seq))
 
         self.assertEqual(completed, [8])
         self.assertNotIn(0, self.ftp.workers)
 
-    def test_cumulative_write_ack_can_expand_server_window(self):
+    def test_create_reply_payload_does_not_negotiate_extensions(self):
         self.ftp.ftp_settings.write_size = 2
-        self.ftp.cmd_put(['unused', '/remote'], fh=io.BytesIO(b'abcdefgh'))
-        capabilities = mavproxy_ftp.WRITE_CAPABILITY_MAGIC + bytes([1, 8])
+        self.ftp.ftp_settings.write_qsize = 3
+        self.ftp.cmd_put(['unused', '/remote'],
+                         fh=io.BytesIO(b'abcdefghijkl'))
         self.ftp.mavlink_packet(reply(
-            0, mavproxy_ftp.OP_CreateFile, payload=capabilities))
+            0, mavproxy_ftp.OP_CreateFile, payload=b'MFQ1\x40\x08'))
         worker = self.ftp.workers[0]
-        self.assertEqual(worker.write_qsize, 1)
+        self.assertEqual(worker.write_qsize, 3)
+        self.assertEqual(worker.write_pending, 3)
 
-        self.ftp.mavlink_packet(reply(
-            0, mavproxy_ftp.OP_WriteFile, offset=0,
-            payload=struct.pack('<I', 0) + bytes([60]),
-            burst_complete=1, seq=2))
-
-        self.assertEqual(worker.write_qsize, 60)
-        self.assertGreater(worker.write_pending, 1)
-
-    def test_write_window_uses_server_capabilities_in_auto_mode(self):
+    def test_upload_waits_for_create_reply(self):
         self.ftp.cmd_put(['unused', '/remote'], fh=io.BytesIO(b'abc'))
         worker = self.ftp.workers[0]
         self.assertEqual(worker.write_qsize, 5)
-        self.assertEqual(worker.write_batch_size, 1)
 
         # A delayed or lost CreateFile must not let idle processing send file
         # data before the remote file exists.
@@ -353,44 +344,25 @@ class TestConcurrentFTP(unittest.TestCase):
             worker.idle_task()
         self.assertEqual(len(self.mpstate._master.mav.sent), sent)
 
-        # The obsolete one-byte marker is not enough to enable acceleration;
-        # a legacy server could coincidentally return these bytes.
-        self.ftp.mavlink_packet(reply(
-            0, mavproxy_ftp.OP_CreateFile, payload=b'\xA5\x40\x08'))
-        self.assertEqual(worker.write_qsize, 5)
-        self.assertEqual(worker.write_batch_size, 1)
+        self.ftp.mavlink_packet(reply(0, mavproxy_ftp.OP_CreateFile))
+        self.assertTrue(worker.write_open)
+        self.assertGreater(len(self.mpstate._master.mav.sent), sent)
 
-        # Restart with an unambiguous versioned capability reply.
-        worker.write_open = False
-        capabilities = mavproxy_ftp.WRITE_CAPABILITY_MAGIC + bytes([60, 8])
-        self.ftp.mavlink_packet(reply(
-            0, mavproxy_ftp.OP_CreateFile, payload=capabilities))
-
-        self.assertEqual(worker.write_qsize, 60)
-        self.assertEqual(worker.write_batch_size, 8)
-        sent = len(self.mpstate._master.mav.sent)
-        for _ in range(10):
-            worker.idle_task()
-        self.assertEqual(len(self.mpstate._master.mav.sent), sent)
-
-    def test_cumulative_ack_does_not_cover_a_gap_before_its_start(self):
+    def test_write_ack_does_not_cover_earlier_gap(self):
         self.ftp.ftp_settings.write_size = 2
         self.ftp.ftp_settings.write_qsize = 6
-        self.ftp.ftp_settings.write_batch_size = 6
         self.ftp.cmd_put(['unused', '/remote'],
                          fh=io.BytesIO(b'abcdefghijkl'))
         self.ftp.mavlink_packet(reply(0, mavproxy_ftp.OP_CreateFile))
         worker = self.ftp.workers[0]
 
-        # The server received and wrote only blocks 2 and 3. Blocks 0 and 1
-        # must remain queued even though the cumulative ACK ends after them.
+        # The server received only block 3.  An ACK jump must make blocks 0-2
+        # sendable again without treating them as successfully written.
         self.ftp.mavlink_packet(reply(
-            0, mavproxy_ftp.OP_WriteFile, offset=6,
-            payload=struct.pack('<I', 4), burst_complete=1, seq=5))
+            0, mavproxy_ftp.OP_WriteFile, offset=6, seq=5))
 
-        self.assertEqual(worker.write_list, {0, 1, 4, 5})
-        self.assertEqual(worker.write_pending, 4)
-        self.assertEqual(worker.write_acked_bytes, 4)
+        self.assertEqual(worker.write_list, {0, 1, 2, 4, 5})
+        self.assertEqual(worker.write_acked_bytes, 2)
 
     def test_packet_loss_uses_actual_link_directions(self):
         self.ftp.ftp_settings.pkt_loss_tx = 100

--- a/tests/test_mavproxy_ftp.py
+++ b/tests/test_mavproxy_ftp.py
@@ -3,6 +3,7 @@ import contextlib
 import io
 from pathlib import Path
 import struct
+import socket
 import time
 import types
 import unittest
@@ -31,6 +32,36 @@ class FakeMAV:
 class FakeMaster:
     def __init__(self):
         self.mav = FakeMAV()
+
+
+class FakeLink:
+    def __init__(self, port_type=None):
+        self.writes = []
+        self.port = types.SimpleNamespace(type=port_type)
+
+    def write(self, data):
+        self.writes.append(bytes(data))
+        return len(data)
+
+
+class FakeStreamPort:
+    type = socket.SOCK_STREAM
+
+    def __init__(self):
+        self.writes = []
+
+    def sendall(self, data):
+        self.writes.append(bytes(data))
+
+
+class FakeBatchMAV:
+    '''Minimal MAVLink encoder whose output can be collected by the module.'''
+    def __init__(self, link):
+        self.file = link
+
+    def file_transfer_protocol_send(self, network, target_system,
+                                    target_component, payload):
+        self.file.write(b'F' + bytes(payload))
 
 
 class FakeConsole:
@@ -292,6 +323,23 @@ class TestConcurrentFTP(unittest.TestCase):
         self.assertEqual(completed, [8])
         self.assertNotIn(0, self.ftp.workers)
 
+    def test_cumulative_write_ack_can_expand_server_window(self):
+        self.ftp.ftp_settings.write_size = 2
+        self.ftp.cmd_put(['unused', '/remote'], fh=io.BytesIO(b'abcdefgh'))
+        capabilities = mavproxy_ftp.WRITE_CAPABILITY_MAGIC + bytes([1, 8])
+        self.ftp.mavlink_packet(reply(
+            0, mavproxy_ftp.OP_CreateFile, payload=capabilities))
+        worker = self.ftp.workers[0]
+        self.assertEqual(worker.write_qsize, 1)
+
+        self.ftp.mavlink_packet(reply(
+            0, mavproxy_ftp.OP_WriteFile, offset=0,
+            payload=struct.pack('<I', 0) + bytes([60]),
+            burst_complete=1, seq=2))
+
+        self.assertEqual(worker.write_qsize, 60)
+        self.assertGreater(worker.write_pending, 1)
+
     def test_write_window_uses_server_capabilities_in_auto_mode(self):
         self.ftp.cmd_put(['unused', '/remote'], fh=io.BytesIO(b'abc'))
         worker = self.ftp.workers[0]
@@ -305,13 +353,20 @@ class TestConcurrentFTP(unittest.TestCase):
             worker.idle_task()
         self.assertEqual(len(self.mpstate._master.mav.sent), sent)
 
-        capabilities = bytes([
-            mavproxy_ftp.WRITE_CAPABILITY_MAGIC, 64, 8,
-        ])
+        # The obsolete one-byte marker is not enough to enable acceleration;
+        # a legacy server could coincidentally return these bytes.
+        self.ftp.mavlink_packet(reply(
+            0, mavproxy_ftp.OP_CreateFile, payload=b'\xA5\x40\x08'))
+        self.assertEqual(worker.write_qsize, 5)
+        self.assertEqual(worker.write_batch_size, 1)
+
+        # Restart with an unambiguous versioned capability reply.
+        worker.write_open = False
+        capabilities = mavproxy_ftp.WRITE_CAPABILITY_MAGIC + bytes([60, 8])
         self.ftp.mavlink_packet(reply(
             0, mavproxy_ftp.OP_CreateFile, payload=capabilities))
 
-        self.assertEqual(worker.write_qsize, 64)
+        self.assertEqual(worker.write_qsize, 60)
         self.assertEqual(worker.write_batch_size, 8)
         sent = len(self.mpstate._master.mav.sent)
         for _ in range(10):
@@ -369,9 +424,9 @@ class TestConcurrentFTP(unittest.TestCase):
         self.assertEqual(self.mpstate._master.mav.sent, [])
         self.assertEqual(len(self.ftp.tx_delay_queue), 1)
 
-        deadline, sequence, args = self.ftp.tx_delay_queue[0]
+        deadline, sequence, worker, args = self.ftp.tx_delay_queue[0]
         self.ftp.tx_delay_queue[0] = (time.monotonic() - 1,
-                                      sequence, args)
+                                      sequence, worker, args)
         self.ftp.idle_task()
         self.assertEqual(len(self.mpstate._master.mav.sent), 1)
 
@@ -388,6 +443,80 @@ class TestConcurrentFTP(unittest.TestCase):
                                       sequence, worker, message)
         self.ftp.idle_task()
         self.assertNotIn(0, self.ftp.workers)
+
+    def test_cancel_discards_delayed_writes_but_sends_termination(self):
+        self.ftp.ftp_settings.pkt_lag_tx = 100
+        self.ftp.cmd_put(['unused', '/remote'], fh=io.BytesIO(b'abcdefgh'))
+
+        # Deliver CreateFile and let its ACK queue the upload writes.
+        deadline, sequence, worker, args = self.ftp.tx_delay_queue[0]
+        self.ftp.tx_delay_queue[0] = (
+            time.monotonic() - 1, sequence, worker, args)
+        self.ftp.idle_task()
+        self.ftp.mavlink_packet(reply(0, mavproxy_ftp.OP_CreateFile))
+        self.assertTrue(any(
+            payload[3] == mavproxy_ftp.OP_WriteFile
+            for _, _, _, queued_args in self.ftp.tx_delay_queue
+            for payload in queued_args[-1]))
+
+        self.ftp.cmd_cancel()
+        self.assertEqual(len(self.ftp.tx_delay_queue), 1)
+        deadline, sequence, worker, args = self.ftp.tx_delay_queue[0]
+        self.assertTrue(all(payload[3] == mavproxy_ftp.OP_TerminateSession
+                            for payload in args[-1]))
+        self.ftp.tx_delay_queue[0] = (
+            time.monotonic() - 1, sequence, worker, args)
+        self.ftp.idle_task()
+
+        opcodes = [request_opcode(packet)
+                   for packet in self.mpstate._master.mav.sent]
+        self.assertEqual(opcodes, [mavproxy_ftp.OP_CreateFile,
+                                   mavproxy_ftp.OP_TerminateSession])
+
+    def test_retired_session_ids_are_quarantined(self):
+        self.ftp.retired_sessions[0] = (
+            time.monotonic() + mavproxy_ftp.SESSION_REUSE_DELAY)
+        self.ftp.next_session = 0
+        self.assertEqual(self.ftp._allocate_session(), 1)
+
+        self.ftp.retired_sessions[0] = time.monotonic() - 1
+        self.ftp.next_session = 0
+        self.assertEqual(self.ftp._allocate_session(), 0)
+
+    def test_network_batches_stay_below_mtu(self):
+        link = FakeLink(socket.SOCK_DGRAM)
+        master = types.SimpleNamespace(mav=FakeBatchMAV(link))
+        payloads = [bytes([i]) * 251 for i in range(16)]
+
+        self.ftp._transmit_payloads(master, 0, 1, 1, payloads)
+
+        expected = b''.join(b'F' + payload for payload in payloads)
+        self.assertEqual(b''.join(link.writes), expected)
+        self.assertGreater(len(link.writes), 1)
+        self.assertTrue(all(len(write) <= mavproxy_ftp.MAX_NETWORK_BATCH
+                            for write in link.writes))
+
+    def test_serial_batch_remains_one_write(self):
+        link = FakeLink()
+        master = types.SimpleNamespace(mav=FakeBatchMAV(link))
+        payloads = [b'x' * 251 for _ in range(16)]
+
+        self.ftp._transmit_payloads(master, 0, 1, 1, payloads)
+
+        self.assertEqual(len(link.writes), 1)
+
+    def test_tcp_batches_use_complete_writes(self):
+        link = FakeLink()
+        link.port = FakeStreamPort()
+        master = types.SimpleNamespace(mav=FakeBatchMAV(link))
+        payloads = [b'x' * 251 for _ in range(16)]
+
+        self.ftp._transmit_payloads(master, 0, 1, 1, payloads)
+
+        self.assertEqual(link.writes, [])
+        self.assertGreater(len(link.port.writes), 1)
+        self.assertTrue(all(len(write) <= mavproxy_ftp.MAX_NETWORK_BATCH
+                            for write in link.port.writes))
 
     def test_loss_seed_replays_variable_lag(self):
         other = mavproxy_ftp.FTPModule(FakeMPState())

--- a/tests/test_mavproxy_ftp.py
+++ b/tests/test_mavproxy_ftp.py
@@ -1,0 +1,187 @@
+import importlib.util
+from pathlib import Path
+import struct
+import types
+import unittest
+
+
+# Some developer environments have a released MAVProxy imported by a pytest
+# plugin before collection begins.  Load the worktree file explicitly so the
+# tests always exercise the code they accompany.
+FTP_MODULE_PATH = (Path(__file__).resolve().parents[1] /
+                   'MAVProxy/modules/mavproxy_ftp.py')
+FTP_SPEC = importlib.util.spec_from_file_location(
+    'mavproxy_ftp_under_test', FTP_MODULE_PATH)
+mavproxy_ftp = importlib.util.module_from_spec(FTP_SPEC)
+FTP_SPEC.loader.exec_module(mavproxy_ftp)
+
+
+class FakeMAV:
+    def __init__(self):
+        self.sent = []
+
+    def file_transfer_protocol_send(self, network, target_system,
+                                    target_component, payload):
+        self.sent.append(bytes(payload))
+
+
+class FakeMaster:
+    def __init__(self):
+        self.mav = FakeMAV()
+
+
+class FakeConsole:
+    def __init__(self):
+        self.status = {}
+
+    def set_status(self, name, value, row=None):
+        self.status[name] = (value, row)
+
+
+class FakeMPState:
+    def __init__(self):
+        self.public_modules = {}
+        self.command_map = {}
+        self.completions = {}
+        self.completion_functions = {}
+        self.settings = types.SimpleNamespace(
+            target_system=1,
+            target_component=1,
+            source_system=255,
+            source_component=0,
+        )
+        self.console = FakeConsole()
+        self._master = FakeMaster()
+
+    def master(self):
+        return self._master
+
+
+class FTPMessage:
+    def __init__(self, payload):
+        self.payload = payload
+        self.target_system = 255
+        self.target_component = 0
+
+    def get_type(self):
+        return "FILE_TRANSFER_PROTOCOL"
+
+
+def reply(session, req_opcode, opcode=mavproxy_ftp.OP_Ack, payload=b'',
+          offset=0, burst_complete=0, seq=1):
+    header = struct.pack(
+        '<HBBBBBBI', seq, session, opcode, len(payload), req_opcode,
+        burst_complete, 0, offset)
+    return FTPMessage(bytearray(header + payload).ljust(251, b'\x00'))
+
+
+def request_session(payload):
+    return payload[2]
+
+
+class TestConcurrentFTP(unittest.TestCase):
+    def setUp(self):
+        self.mpstate = FakeMPState()
+        self.ftp = mavproxy_ftp.FTPModule(self.mpstate)
+
+    def test_gets_and_list_have_independent_sessions_and_state(self):
+        results = {}
+
+        def completed(name):
+            def callback(fh):
+                results[name] = None if fh is None else fh.read()
+            return callback
+
+        self.ftp.cmd_get(['/first'], callback=completed('first'))
+        self.ftp.cmd_list(['/'])
+        self.ftp.cmd_get(['/second'], callback=completed('second'))
+
+        sent = self.mpstate._master.mav.sent
+        sessions = [request_session(packet) for packet in sent]
+        self.assertEqual(sessions, [0, 1, 2])
+        self.assertEqual(len(self.ftp.workers), 3)
+
+        # Both opens may complete around a directory reply.  Each worker must
+        # create and advance only its own in-memory file.
+        self.ftp.mavlink_packet(reply(2, mavproxy_ftp.OP_OpenFileRO,
+                                      payload=struct.pack('<I', 6)))
+        self.ftp.mavlink_packet(reply(0, mavproxy_ftp.OP_OpenFileRO,
+                                      payload=struct.pack('<I', 5)))
+        self.ftp.mavlink_packet(reply(1, mavproxy_ftp.OP_ListDirectory,
+                                      opcode=mavproxy_ftp.OP_Nack,
+                                      payload=bytes([mavproxy_ftp.ERR_EndOfFile])))
+
+        self.assertNotIn(1, self.ftp.workers)
+        self.assertIn(0, self.ftp.workers)
+        self.assertIn(2, self.ftp.workers)
+
+        self.ftp.mavlink_packet(reply(
+            0, mavproxy_ftp.OP_BurstReadFile, payload=b'first',
+            burst_complete=1))
+        self.ftp.mavlink_packet(reply(
+            2, mavproxy_ftp.OP_BurstReadFile, payload=b'second',
+            burst_complete=1))
+
+        self.assertEqual(results, {'first': b'first', 'second': b'second'})
+        self.assertEqual(self.ftp.workers, {})
+
+    def test_sixth_operation_is_queued_until_a_session_finishes(self):
+        for _ in range(6):
+            self.ftp.cmd_list(['/'])
+
+        self.assertEqual(len(self.ftp.workers), 5)
+        self.assertEqual(len(self.ftp.pending), 1)
+        self.assertEqual(len(self.mpstate._master.mav.sent), 5)
+
+        self.ftp.mavlink_packet(reply(
+            0, mavproxy_ftp.OP_ListDirectory,
+            opcode=mavproxy_ftp.OP_Nack,
+            payload=bytes([mavproxy_ftp.ERR_EndOfFile])))
+
+        self.assertEqual(len(self.ftp.workers), 5)
+        self.assertEqual(self.ftp.pending, [])
+        self.assertEqual(len(self.mpstate._master.mav.sent), 7)
+        # One packet terminated session 0; the other launched queued session 5.
+        self.assertEqual(request_session(self.mpstate._master.mav.sent[-1]), 5)
+
+    def test_server_session_exhaustion_waits_and_retries(self):
+        callbacks = []
+        self.ftp.cmd_get(['/params'], callback=callbacks.append)
+        worker = self.ftp.workers[0]
+
+        self.ftp.mavlink_packet(reply(
+            0, mavproxy_ftp.OP_OpenFileRO,
+            opcode=mavproxy_ftp.OP_Nack,
+            payload=bytes([mavproxy_ftp.ERR_NoSessionsAvailable])))
+
+        self.assertTrue(worker.session_waiting)
+        self.assertEqual(callbacks, [])
+        self.assertIs(self.ftp.workers[0], worker)
+
+        self.ftp.ftp_settings.retry_time = 0
+        sent_before = len(self.mpstate._master.mav.sent)
+        self.ftp.idle_task()
+        self.assertEqual(len(self.mpstate._master.mav.sent), sent_before + 1)
+        self.assertEqual(request_session(self.mpstate._master.mav.sent[-1]), 0)
+        self.assertEqual(callbacks, [])
+
+    def test_silently_dropped_initial_request_is_retried_idempotently(self):
+        self.ftp.cmd_list(['/'])
+        worker = self.ftp.workers[0]
+        first_packet = self.mpstate._master.mav.sent[-1]
+        first_seq = struct.unpack('<H', first_packet[:2])[0]
+
+        # No reply arrives, as happens when ArduPilot's request queue is full.
+        worker.last_op_time -= 2
+        self.ftp.idle_task()
+
+        retried_packet = self.mpstate._master.mav.sent[-1]
+        retried_seq = struct.unpack('<H', retried_packet[:2])[0]
+        self.assertEqual(retried_seq, first_seq)
+        self.assertEqual(request_session(retried_packet), 0)
+        self.assertEqual(worker.request_retries, 1)
+        self.assertEqual(len(self.ftp.workers), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_mavproxy_ftp.py
+++ b/tests/test_mavproxy_ftp.py
@@ -1,4 +1,5 @@
 import importlib.util
+import contextlib
 import io
 from pathlib import Path
 import struct
@@ -81,6 +82,10 @@ def request_session(payload):
     return payload[2]
 
 
+def request_opcode(payload):
+    return payload[3]
+
+
 class TestConcurrentFTP(unittest.TestCase):
     def setUp(self):
         self.mpstate = FakeMPState()
@@ -110,7 +115,7 @@ class TestConcurrentFTP(unittest.TestCase):
                                       payload=struct.pack('<I', 6)))
         self.ftp.mavlink_packet(reply(0, mavproxy_ftp.OP_OpenFileRO,
                                       payload=struct.pack('<I', 5)))
-        self.ftp.mavlink_packet(reply(1, mavproxy_ftp.OP_ListDirectory,
+        self.ftp.mavlink_packet(reply(1, mavproxy_ftp.OP_ListDirectoryWithTime,
                                       opcode=mavproxy_ftp.OP_Nack,
                                       payload=bytes([mavproxy_ftp.ERR_EndOfFile])))
 
@@ -137,7 +142,7 @@ class TestConcurrentFTP(unittest.TestCase):
         self.assertEqual(len(self.mpstate._master.mav.sent), 5)
 
         self.ftp.mavlink_packet(reply(
-            0, mavproxy_ftp.OP_ListDirectory,
+            0, mavproxy_ftp.OP_ListDirectoryWithTime,
             opcode=mavproxy_ftp.OP_Nack,
             payload=bytes([mavproxy_ftp.ERR_EndOfFile])))
 
@@ -176,7 +181,8 @@ class TestConcurrentFTP(unittest.TestCase):
         first_seq = struct.unpack('<H', first_packet[:2])[0]
 
         # No reply arrives, as happens when ArduPilot's request queue is full.
-        worker.last_op_time -= 2
+        worker.last_op_time -= max(
+            worker.retry_timeout(), self.ftp.ftp_settings.list_time_timeout) + 0.01
         self.ftp.idle_task()
 
         retried_packet = self.mpstate._master.mav.sent[-1]
@@ -185,6 +191,78 @@ class TestConcurrentFTP(unittest.TestCase):
         self.assertEqual(request_session(retried_packet), 0)
         self.assertEqual(worker.request_retries, 1)
         self.assertEqual(len(self.ftp.workers), 1)
+
+    def test_list_with_time_parses_names_from_the_end(self):
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            self.ftp.cmd_list(['/'])
+            self.assertEqual(
+                request_opcode(self.mpstate._master.mav.sent[-1]),
+                mavproxy_ftp.OP_ListDirectoryWithTime)
+
+            self.ftp.mavlink_packet(reply(
+                0, mavproxy_ftp.OP_ListDirectoryWithTime,
+                payload=b'Ftab\tname\t42\t0\x00Fmalformed\x00'))
+
+        continuation = self.mpstate._master.mav.sent[-1]
+        self.assertEqual(request_opcode(continuation),
+                         mavproxy_ftp.OP_ListDirectoryWithTime)
+        self.assertEqual(struct.unpack('<I', continuation[8:12])[0], 2)
+        self.assertIn('tab\tname\t42\t-', output.getvalue())
+        self.assertIn('Fmalformed', output.getvalue())
+        self.assertTrue(self.ftp.list_time_supported[(1, 1)])
+
+    def test_list_time_nack_falls_back_and_is_cached(self):
+        self.ftp.cmd_list(['/'])
+        self.assertEqual(request_opcode(self.mpstate._master.mav.sent[-1]),
+                         mavproxy_ftp.OP_ListDirectoryWithTime)
+
+        self.ftp.mavlink_packet(reply(
+            0, mavproxy_ftp.OP_ListDirectoryWithTime,
+            opcode=mavproxy_ftp.OP_Nack,
+            payload=bytes([mavproxy_ftp.ERR_UnknownCommand])))
+
+        fallback = self.mpstate._master.mav.sent[-1]
+        self.assertEqual(request_opcode(fallback),
+                         mavproxy_ftp.OP_ListDirectory)
+        self.assertFalse(self.ftp.list_time_supported[(1, 1)])
+
+        self.ftp.mavlink_packet(reply(
+            0, mavproxy_ftp.OP_ListDirectory,
+            opcode=mavproxy_ftp.OP_Nack,
+            payload=bytes([mavproxy_ftp.ERR_EndOfFile]), seq=2))
+        self.ftp.cmd_list(['/other'])
+        self.assertEqual(request_opcode(self.mpstate._master.mav.sent[-1]),
+                         mavproxy_ftp.OP_ListDirectory)
+
+    def test_ignored_list_time_opcode_retries_then_falls_back(self):
+        self.ftp.ftp_settings.list_retries = 1
+        self.ftp.ftp_settings.list_time_timeout = 0
+        self.ftp.cmd_list(['/'])
+        worker = self.ftp.workers[0]
+        first_seq = struct.unpack('<H', self.mpstate._master.mav.sent[-1][:2])[0]
+
+        worker.last_op_time -= max(
+            worker.retry_timeout(), self.ftp.ftp_settings.list_time_timeout) + 0.01
+        self.ftp.idle_task()
+        retry = self.mpstate._master.mav.sent[-1]
+        self.assertEqual(request_opcode(retry),
+                         mavproxy_ftp.OP_ListDirectoryWithTime)
+        self.assertEqual(struct.unpack('<H', retry[:2])[0], first_seq)
+
+        worker.last_op_time -= worker.retry_timeout() + 0.01
+        self.ftp.idle_task()
+        self.assertEqual(request_opcode(self.mpstate._master.mav.sent[-1]),
+                         mavproxy_ftp.OP_ListDirectory)
+
+        # A late reply to the abandoned capability probe must not advance the
+        # fallback listing or be interpreted using the wrong entry format.
+        sent = len(self.mpstate._master.mav.sent)
+        self.ftp.mavlink_packet(reply(
+            0, mavproxy_ftp.OP_ListDirectoryWithTime,
+            payload=b'Fold\t1\t0\x00', seq=1))
+        self.assertEqual(len(self.mpstate._master.mav.sent), sent)
+        self.assertEqual(worker.dir_offset, 0)
 
     def test_cumulative_write_ack_completes_contiguous_batch(self):
         self.ftp.ftp_settings.write_size = 2
@@ -263,12 +341,13 @@ class TestConcurrentFTP(unittest.TestCase):
         self.assertEqual(self.mpstate._master.mav.sent, [])
         self.assertEqual(worker.seq, 1)
         self.ftp.ftp_settings.pkt_loss_tx = 0
-        worker.last_op_time -= worker.retry_timeout() + 0.01
+        worker.last_op_time -= max(
+            worker.retry_timeout(), self.ftp.ftp_settings.list_time_timeout) + 0.01
         self.ftp.idle_task()
         self.assertEqual(len(self.mpstate._master.mav.sent), 1)
 
         # RX loss must likewise be invisible to the worker.
-        eof = reply(0, mavproxy_ftp.OP_ListDirectory,
+        eof = reply(0, mavproxy_ftp.OP_ListDirectoryWithTime,
                     opcode=mavproxy_ftp.OP_Nack,
                     payload=bytes([mavproxy_ftp.ERR_EndOfFile]))
         self.ftp.ftp_settings.pkt_loss_rx = 100
@@ -291,7 +370,7 @@ class TestConcurrentFTP(unittest.TestCase):
         self.assertEqual(len(self.mpstate._master.mav.sent), 1)
 
         self.ftp.ftp_settings.pkt_lag_rx = 100
-        eof = reply(0, mavproxy_ftp.OP_ListDirectory,
+        eof = reply(0, mavproxy_ftp.OP_ListDirectoryWithTime,
                     opcode=mavproxy_ftp.OP_Nack,
                     payload=bytes([mavproxy_ftp.ERR_EndOfFile]))
         self.ftp.mavlink_packet(eof)

--- a/tests/test_mavproxy_ftp.py
+++ b/tests/test_mavproxy_ftp.py
@@ -92,6 +92,12 @@ class TestConcurrentFTP(unittest.TestCase):
         self.ftp = mavproxy_ftp.FTPModule(self.mpstate)
         self.ftp.next_session = 0
 
+    def test_idle_status_keeps_script_compatible_wording(self):
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            self.ftp.cmd_status()
+        self.assertEqual(output.getvalue(), "No transfer in progress\n")
+
     def test_gets_and_list_have_independent_sessions_and_state(self):
         results = {}
 


### PR DESCRIPTION
## Summary

- support multiple concurrent MAVFTP operations with queued overflow and per-operation target pinning
- improve download and upload throughput while retaining the standard CreateFile/WriteFile protocol
- add adaptive retries, gap recovery, delayed-packet handling, and source-aware session routing for unreliable links
- support `OP_ListDirectoryWithTime`, based on Peter Barker's work, with per-target capability fallback
- add focused regression coverage for concurrency, retries, packet loss/lag, directory timestamps, and transfer edge cases

Includes the key parts of #1724 

## Testing

- `pytest -q` (28 passed)
- `flake8 MAVProxy/modules/mavproxy_ftp.py tests/test_mavproxy_ftp.py`
- `python3 -m py_compile MAVProxy/modules/mavproxy_ftp.py tests/test_mavproxy_ftp.py`
- `git diff --check`