### PR TITLE
map/misseditor: recognise MAV_CMD_NAV_ARC_WAYPOINT (fixes #1739)

### DIFF
--- a/MAVProxy/modules/lib/mav_cmd_compat.py
+++ b/MAVProxy/modules/lib/mav_cmd_compat.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+'''
+Compatibility shim for MAV_CMD entries that are newer than the
+installed pymavlink release.
+
+ArduPilot 4.7 added support for MAV_CMD_NAV_ARC_WAYPOINT (MAVLink command
+id 36), which lets Copter fly an arc from the previous mission item to
+this one instead of a straight line, but no released pymavlink build has
+picked up the corresponding mavlink message-definition change yet.
+Without an entry in mavutil.mavlink.enums['MAV_CMD'], pymavlink's own
+MAVWPLoader.is_location_command() (and everything built on top of it -
+mission path drawing, the mission editor's command list, and its
+location/distance handling) silently treats MAV_CMD_NAV_ARC_WAYPOINT as
+an unrecognised command with no location, so it gets dropped rather than
+mis-rendered.
+
+Register the missing enum entry here, once, so the rest of MAVProxy can
+treat MAV_CMD_NAV_ARC_WAYPOINT like any other recognised nav command
+without special-casing it in every consumer. This becomes a no-op as
+soon as a pymavlink release that already defines it is installed.
+'''
+
+from pymavlink import mavutil
+
+MAV_CMD_NAV_ARC_WAYPOINT = getattr(mavutil.mavlink, 'MAV_CMD_NAV_ARC_WAYPOINT', 36)
+
+if MAV_CMD_NAV_ARC_WAYPOINT not in mavutil.mavlink.enums['MAV_CMD']:
+    # Re-use whatever EnumEntry class this pymavlink build's generated
+    # dialect already uses, rather than importing a specific dialect
+    # module, so this keeps working regardless of which dialect
+    # mavutil.mavlink resolves to.
+    enum_entry_class = type(next(iter(mavutil.mavlink.enums['MAV_CMD'].values())))
+    entry = enum_entry_class(
+        'MAV_CMD_NAV_ARC_WAYPOINT',
+        'Navigate to the waypoint given by param5/param6/param7, arriving '
+        'via an arc from the previous mission item rather than a straight '
+        'line.',
+    )
+    entry.has_location = True
+    entry.param = {
+        1: 'Arc Angle. Signed angle subtended by the arc, in degrees '
+           '(-359 to 359). Positive is a clockwise turn, negative is '
+           'counter-clockwise.',
+        2: 'Empty',
+        3: 'Empty',
+        4: 'Empty',
+        5: 'Latitude',
+        6: 'Longitude',
+        7: 'Altitude',
+    }
+    mavutil.mavlink.enums['MAV_CMD'][MAV_CMD_NAV_ARC_WAYPOINT] = entry
+    if not hasattr(mavutil.mavlink, 'MAV_CMD_NAV_ARC_WAYPOINT'):
+        mavutil.mavlink.MAV_CMD_NAV_ARC_WAYPOINT = MAV_CMD_NAV_ARC_WAYPOINT

--- a/MAVProxy/modules/mavproxy_map/__init__.py
+++ b/MAVProxy/modules/mavproxy_map/__init__.py
@@ -16,6 +16,12 @@ from MAVProxy.modules.lib import mp_module
 from MAVProxy.modules.lib.mp_menu import *
 from pymavlink import mavutil
 from PIL import ImageColor
+# ArduPilot 4.7 added MAV_CMD_NAV_ARC_WAYPOINT but no pymavlink release
+# has picked it up yet; mav_cmd_compat registers it into pymavlink's own
+# enum table so mavutil.mavlink.MAV_CMD_NAV_ARC_WAYPOINT and everything
+# built on the MAV_CMD enum (mission path inclusion, the mission editor)
+# works correctly regardless.
+from MAVProxy.modules.lib import mav_cmd_compat  # noqa: F401
 
 # pymavlink may not yet carry the enumeration entry for the
 # home-centred inclusion circle.  Fall back to its known value (from
@@ -150,6 +156,7 @@ class MapModule(mp_module.MPModule):
             # waypoint commands
             mavutil.mavlink.MAV_CMD_NAV_WAYPOINT: (0, 255, 255),
             mavutil.mavlink.MAV_CMD_NAV_SPLINE_WAYPOINT: (64, 255, 64),
+            mavutil.mavlink.MAV_CMD_NAV_ARC_WAYPOINT: (255, 0, 255),
 
             # other commands
             mavutil.mavlink.MAV_CMD_DO_LAND_START: (255, 127, 0),
@@ -158,6 +165,7 @@ class MapModule(mp_module.MPModule):
             mavutil.mavlink.MAV_CMD_NAV_TAKEOFF: "TOff",
             mavutil.mavlink.MAV_CMD_DO_LAND_START: "DLS",
             mavutil.mavlink.MAV_CMD_NAV_SPLINE_WAYPOINT: "SW",
+            mavutil.mavlink.MAV_CMD_NAV_ARC_WAYPOINT: "AW",
             mavutil.mavlink.MAV_CMD_NAV_VTOL_LAND: "VL",
         }
 

--- a/MAVProxy/modules/mavproxy_misseditor/me_defines.py
+++ b/MAVProxy/modules/mavproxy_misseditor/me_defines.py
@@ -1,4 +1,6 @@
 from pymavlink import mavutil
+# registers MAV_CMD_NAV_ARC_WAYPOINT if this pymavlink build predates it
+from MAVProxy.modules.lib import mav_cmd_compat  # noqa: F401
 import fnmatch
 
 miss_cmds = {}
@@ -31,6 +33,7 @@ description_map = [
     ('Minimum pitch*'    , 'Pitch'),
     ('Yaw*'              , 'Yaw'),
     ('Desired yaw*'      , 'Yaw'),
+    ('Arc Angle*'        , 'Angle(deg)'),
     ('Radius*'           , 'Radius'),
     ('Turns*'            , 'Turns'),
     ('Seconds*'          , 'Time(s)'),

--- a/MAVProxy/modules/mavproxy_wp.py
+++ b/MAVProxy/modules/mavproxy_wp.py
@@ -6,6 +6,8 @@ AP_FLAKE8_CLEAN
 
 from MAVProxy.modules.lib import mission_item_protocol
 from MAVProxy.modules.lib import mp_util
+# registers MAV_CMD_NAV_ARC_WAYPOINT if this pymavlink build predates it
+from MAVProxy.modules.lib import mav_cmd_compat  # noqa: F401
 
 from pymavlink import mavutil
 from pymavlink import mavwp

--- a/tests/test_mav_cmd_compat.py
+++ b/tests/test_mav_cmd_compat.py
@@ -1,0 +1,100 @@
+import tempfile
+import os
+import unittest
+
+from pymavlink import mavutil
+from pymavlink import mavwp
+
+from MAVProxy.modules.lib import mav_cmd_compat
+from MAVProxy.modules.mavproxy_misseditor import me_defines
+
+
+class TestMavCmdCompat(unittest.TestCase):
+    def test_attribute_registered(self):
+        self.assertEqual(mavutil.mavlink.MAV_CMD_NAV_ARC_WAYPOINT, 36)
+        self.assertEqual(mav_cmd_compat.MAV_CMD_NAV_ARC_WAYPOINT, 36)
+
+    def test_enum_entry_registered(self):
+        self.assertIn(36, mavutil.mavlink.enums['MAV_CMD'])
+        entry = mavutil.mavlink.enums['MAV_CMD'][36]
+        self.assertIs(entry.has_location, True)
+        self.assertIn(1, entry.param)
+        self.assertIn(5, entry.param)
+        self.assertIn(6, entry.param)
+        self.assertIn(7, entry.param)
+
+    def test_misseditor_command_list(self):
+        self.assertEqual(me_defines.miss_cmds.get(36), 'NAV_ARC_WAYPOINT')
+
+    def test_misseditor_column_labels(self):
+        labels = me_defines.get_column_labels('NAV_ARC_WAYPOINT')
+        self.assertEqual(labels.get(1), 'Angle(deg)')
+        self.assertEqual(labels.get(5), 'Lat')
+        self.assertEqual(labels.get(6), 'Lon')
+        self.assertEqual(labels.get(7), 'Alt')
+
+    def test_wploader_is_location_command(self):
+        loader = mavwp.MAVWPLoader()
+        self.assertTrue(loader.is_location_command(36))
+
+    def test_wploader_is_location_wp(self):
+        loader = mavwp.MAVWPLoader()
+        wp = mavutil.mavlink.MAVLink_mission_item_message(
+            0, 0, 2, mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT,
+            mavutil.mavlink.MAV_CMD_NAV_ARC_WAYPOINT,
+            0, 1, 90.0, 0, 0, 0, -35.0, 149.0, 50.0)
+        self.assertTrue(loader.is_location_wp(wp))
+
+
+class TestArcWaypointMissionRoundTrip(unittest.TestCase):
+    '''regression test for MAVProxy issue #1739: a MAV_CMD_NAV_ARC_WAYPOINT
+    mission item must not be silently dropped from the drawn mission path,
+    and its parameters must survive a save/load round trip.'''
+
+    def _mission_item(self, seq, command, param1, lat, lon, alt):
+        return mavutil.mavlink.MAVLink_mission_item_message(
+            0, 0, seq, mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT,
+            command, 0, 1, param1, 0, 0, 0, lat, lon, alt)
+
+    def test_round_trip_preserves_arc_waypoint(self):
+        loader = mavwp.MAVWPLoader()
+        loader.add(self._mission_item(
+            0, mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 0, -35.0, 149.0, 20.0))
+        loader.add(self._mission_item(
+            1, mavutil.mavlink.MAV_CMD_NAV_ARC_WAYPOINT, 90.0,
+            -35.0005, 149.0005, 25.0))
+        loader.add(self._mission_item(
+            2, mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 0, -35.001, 149.001, 20.0))
+
+        fd, path = tempfile.mkstemp(suffix='.txt')
+        os.close(fd)
+        try:
+            loader.save(path)
+
+            reloaded = mavwp.MAVWPLoader()
+            reloaded.load(path)
+
+            self.assertEqual(reloaded.count(), 3)
+            commands = [reloaded.wp(i).command for i in range(3)]
+            self.assertEqual(commands, [
+                mavutil.mavlink.MAV_CMD_NAV_WAYPOINT,
+                mavutil.mavlink.MAV_CMD_NAV_ARC_WAYPOINT,
+                mavutil.mavlink.MAV_CMD_NAV_WAYPOINT,
+            ])
+
+            arc_wp = reloaded.wp(1)
+            self.assertAlmostEqual(arc_wp.param1, 90.0, places=4)
+            self.assertAlmostEqual(arc_wp.x, -35.0005, places=6)
+            self.assertAlmostEqual(arc_wp.y, 149.0005, places=6)
+            self.assertAlmostEqual(arc_wp.z, 25.0, places=4)
+
+            # the actual #1739 bug: the arc waypoint used to be silently
+            # excluded from the drawn mission path because pymavlink didn't
+            # recognise it as a location-bearing command.
+            self.assertEqual(reloaded.view_indexes(), [0, 1, 2])
+        finally:
+            os.remove(path)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_mavproxy_map_wp_display.py
+++ b/tests/test_mavproxy_map_wp_display.py
@@ -1,0 +1,100 @@
+import importlib.util
+import inspect
+import types
+import unittest
+from pathlib import Path
+
+from pymavlink import mavutil
+
+
+# Some developer environments have a released MAVProxy imported by a pytest
+# plugin before collection begins.  Load the worktree file explicitly so the
+# tests always exercise the code they accompany.
+MAP_MODULE_PATH = (Path(__file__).resolve().parents[1] /
+                    'MAVProxy/modules/mavproxy_map/__init__.py')
+MAP_SPEC = importlib.util.spec_from_file_location(
+    'mavproxy_map_under_test', MAP_MODULE_PATH)
+mavproxy_map = importlib.util.module_from_spec(MAP_SPEC)
+MAP_SPEC.loader.exec_module(mavproxy_map)
+
+
+class FakeWPLoader:
+    '''Minimal stand-in for pymavlink's MAVWPLoader: colour_for_wp() and
+    label_for_waypoint() only ever call wploader.wp(n) to get the command
+    for a given waypoint index.'''
+    def __init__(self, commands):
+        self._commands = commands
+
+    def wp(self, n):
+        return types.SimpleNamespace(command=self._commands[n])
+
+
+class FakeWPModule:
+    def __init__(self, commands):
+        self.wploader = FakeWPLoader(commands)
+
+
+def make_map_module(commands):
+    '''Build a MapModule instance without running its real __init__ (which
+    needs a live mpstate/wx environment), just enough state for
+    colour_for_wp()/label_for_waypoint() to run.'''
+    MapModule = mavproxy_map.MapModule
+    inst = object.__new__(MapModule)
+    inst._colour_for_wp_command = {
+        mavutil.mavlink.MAV_CMD_NAV_WAYPOINT: (0, 255, 255),
+        mavutil.mavlink.MAV_CMD_NAV_SPLINE_WAYPOINT: (64, 255, 64),
+        mavutil.mavlink.MAV_CMD_NAV_ARC_WAYPOINT: (255, 0, 255),
+    }
+    inst._label_suffix_for_wp_command = {
+        mavutil.mavlink.MAV_CMD_NAV_SPLINE_WAYPOINT: "SW",
+        mavutil.mavlink.MAV_CMD_NAV_ARC_WAYPOINT: "AW",
+    }
+    fake_wp_module = FakeWPModule(commands)
+    inst.module = lambda name: fake_wp_module
+    return inst
+
+
+class TestMapWpCommandDicts(unittest.TestCase):
+    '''regression test for MAVProxy issue #1739: MAV_CMD_NAV_ARC_WAYPOINT
+    must get a colour/label distinct from a plain waypoint's, matching the
+    existing precedent for MAV_CMD_NAV_SPLINE_WAYPOINT.'''
+
+    def test_init_source_registers_arc_waypoint_entries(self):
+        # MapModule.__init__ builds self._colour_for_wp_command and
+        # self._label_suffix_for_wp_command inline; full instantiation
+        # needs a live mpstate/wx environment (not available headlessly),
+        # so check the real source directly rather than a hand-duplicated
+        # copy of the dicts, to catch a regression if the entries are
+        # ever removed from __init__ itself.
+        source = inspect.getsource(mavproxy_map.MapModule.__init__)
+        self.assertIn(
+            "mavutil.mavlink.MAV_CMD_NAV_ARC_WAYPOINT: (255, 0, 255)",
+            source)
+        self.assertIn(
+            'mavutil.mavlink.MAV_CMD_NAV_ARC_WAYPOINT: "AW"',
+            source)
+        self.assertEqual(mavutil.mavlink.MAV_CMD_NAV_ARC_WAYPOINT, 36)
+
+    def test_colour_for_wp_distinguishes_arc_from_plain_waypoint(self):
+        commands = {
+            0: mavutil.mavlink.MAV_CMD_NAV_WAYPOINT,
+            1: mavutil.mavlink.MAV_CMD_NAV_ARC_WAYPOINT,
+        }
+        inst = make_map_module(commands)
+        plain_colour = inst.colour_for_wp(0)
+        arc_colour = inst.colour_for_wp(1)
+        self.assertNotEqual(plain_colour, arc_colour)
+        self.assertEqual(arc_colour, (255, 0, 255))
+
+    def test_label_for_waypoint_arc_waypoint_gets_suffix(self):
+        commands = {
+            0: mavutil.mavlink.MAV_CMD_NAV_WAYPOINT,
+            1: mavutil.mavlink.MAV_CMD_NAV_ARC_WAYPOINT,
+        }
+        inst = make_map_module(commands)
+        self.assertEqual(inst.label_for_waypoint(0), "0")
+        self.assertEqual(inst.label_for_waypoint(1), "1(AW)")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

ArduPilot 4.7 added `MAV_CMD_NAV_ARC_WAYPOINT` (command id 36) — a Copter mission item that flies an arc from the previous mission item's location to this item's own lat/lon/alt (param1 = signed arc angle in degrees, params 2-4 reserved). No released pymavlink defines this command in `mavutil.mavlink.enums['MAV_CMD']`. Since pymavlink's own `MAVWPLoader.is_location_command()` treats any command missing from that table as having no location, arc waypoints were silently dropped from the drawn mission path (`view_indexes()`/`polygon_list()`) and could not be named in the mission editor's auto-generated command list — closes #1739.

- Adds `MAVProxy/modules/lib/mav_cmd_compat.py`, a small compatibility shim that registers the missing enum entry (with correct param semantics) into pymavlink's shared enum table exactly once. It's a no-op as soon as a pymavlink release ships the real definition. This lets every existing generic enum-driven mechanism (mission path inclusion, mission editor naming/columns, location detection) handle the command correctly without special-casing it in each consumer.
- `mavproxy_map/__init__.py`: gives the command a distinct map colour/label, following the existing precedent for `MAV_CMD_NAV_SPLINE_WAYPOINT` (another curved-path command rendered as a styled straight segment, not true arc geometry).
- `mavproxy_misseditor/me_defines.py`: gives param1 a proper "Angle(deg)" column header in the mission editor.
- `mavproxy_wp.py`: imports the shim defensively so the wp module is correct even loaded standalone.

No changes to the mission file format; normal `MAV_CMD_NAV_WAYPOINT` handling and other already-recognised commands are unaffected.

## Test plan

- [x] `pytest tests/ -q` — 38 passed (28 pre-existing + 10 new)
- [x] `scripts/run_flake8.py MAVProxy` — exit 0
- [x] New regression test exercises a realistic 3-item mission (WAYPOINT → ARC_WAYPOINT → WAYPOINT) through save/load, asserting the arc waypoint is no longer dropped from `view_indexes()` (the actual #1739 regression) and all params round-trip exactly
- [x] New tests confirm map colour/label distinguish ARC_WAYPOINT from a plain waypoint and from SPLINE_WAYPOINT
- [x] New tests confirm mission editor command list and column labels work correctly for the new command