### PR TITLE
console title command and GUI serial port selection at startup

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -1320,6 +1320,27 @@ def run_startup_scripts():
             print("no script %s" % start_script)
 
 
+def choose_serial_port(serial_list, should_cancel=None):
+    '''ask the user to choose between multiple serial port candidates with a
+    GUI dialog. Returns the chosen SerialPort or None'''
+    choices = []
+    for p in serial_list:
+        if platform.system() == 'Windows' and p.description:
+            choices.append("%s: %s" % (p.device, p.description))
+        else:
+            choices.append(p.device)
+    try:
+        from MAVProxy.modules.lib.mp_menu import MPChoiceDialog
+        idx = MPChoiceDialog(title='MAVProxy: choose serial port',
+                             message='Choose the serial port to connect to',
+                             choices=choices).show(should_cancel=should_cancel)
+    except Exception:
+        return None
+    if idx is None:
+        return None
+    return serial_list[idx]
+
+
 if __name__ == '__main__':
     from optparse import OptionParser
     parser = OptionParser("mavproxy.py [options]")
@@ -1500,10 +1521,18 @@ if __name__ == '__main__':
         print("Connecting to %s" % serial_list[0])
         mpstate.module('link').link_add(serial_list[0].device)
     elif not opts.master and len(serial_list) > 1:
-        print("Warning: multiple possible serial ports. Use console GUI or 'link add' to add port, or restart using --master to select a single port")  # noqa:E501
         # if no display, assume running CLI mode and exit
         if platform.system() != 'Windows' and "DISPLAY" not in os.environ:
+            print("Warning: multiple possible serial ports. Use 'link add' to add a port, or restart using --master to select a single port")  # noqa:E501
             sys.exit(1)
+        port = None
+        if not opts.daemon and not opts.non_interactive:
+            port = choose_serial_port(serial_list, should_cancel=mpstate.status.stop_event.is_set)
+        if port is not None:
+            print("Connecting to %s" % port)
+            mpstate.module('link').link_add(port.device)
+        else:
+            print("Warning: multiple possible serial ports. Use console GUI or 'link add' to add port, or restart using --master to select a single port")  # noqa:E501
     elif not opts.master:
         wifi_device = '0.0.0.0:14550'
         mpstate.module('link').link_add(wifi_device)

--- a/MAVProxy/modules/lib/mp_menu.py
+++ b/MAVProxy/modules/lib/mp_menu.py
@@ -491,6 +491,50 @@ class MPMenuConfirmDialog(object):
         if ret == wx.ID_YES and self.callback is not None:
             self.callback(self.args)
 
+class MPChoiceDialog(object):
+    '''modal single-choice dialog run in a child process.
+    show() blocks and returns the selected index, or None if cancelled'''
+    def __init__(self, title='Choose', message='', choices=None):
+        self.title = title
+        self.message = message
+        self.choices = choices if choices is not None else []
+        self.pipe_recv, self.pipe_send = multiproc.Pipe(duplex=False)
+
+    def show(self, should_cancel=None):
+        '''block until a choice is made; should_cancel is an optional callable
+        polled to allow shutdown while waiting'''
+        child = multiproc.Process(target=self.child_task)
+        child.start()
+        self.pipe_send.close()
+        ret = None
+        while True:
+            if should_cancel is not None and should_cancel():
+                child.terminate()
+                break
+            try:
+                if self.pipe_recv.poll(0.2):
+                    ret = self.pipe_recv.recv()
+                    break
+            except (EOFError, OSError):
+                break
+        child.join()
+        if ret is not None and 0 <= ret < len(self.choices):
+            return ret
+        return None
+
+    def child_task(self):
+        mp_util.child_close_fds()
+        self.pipe_recv.close()
+        from MAVProxy.modules.lib import wx_processguard  # noqa
+        from MAVProxy.modules.lib.wx_loader import wx
+        app = wx.App(False)
+        dlg = wx.SingleChoiceDialog(None, self.message, self.title, self.choices)
+        if dlg.ShowModal() == wx.ID_OK:
+            self.pipe_send.send(dlg.GetSelection())
+        else:
+            self.pipe_send.send(None)
+        dlg.Destroy()
+
 class MPMenuChildMessageDialog(object):
     '''used to create a message dialog in a child process'''
     def __init__(self, title='Information', message='', font_size=18):

--- a/MAVProxy/modules/lib/textconsole.py
+++ b/MAVProxy/modules/lib/textconsole.py
@@ -43,6 +43,10 @@ class SimpleConsole():
     def set_menu(self, menu, callback):
         pass
 
+    def set_title(self, title):
+        '''set console title'''
+        pass
+
 if __name__ == "__main__":
     # test the console
     import time

--- a/MAVProxy/modules/lib/wxconsole.py
+++ b/MAVProxy/modules/lib/wxconsole.py
@@ -6,7 +6,7 @@
 import threading
 import sys, time
 
-from MAVProxy.modules.lib.wxconsole_util import Value, Text
+from MAVProxy.modules.lib.wxconsole_util import Value, Text, Title
 from MAVProxy.modules.lib import textconsole
 from MAVProxy.modules.lib import win_layout
 from MAVProxy.modules.lib import multiproc
@@ -75,6 +75,11 @@ class MessageConsole(textconsole.SimpleConsole):
         '''set a status value'''
         if self.is_alive():
             self.parent_pipe_send.send(Value(name, text, row, fg, bg))
+
+    def set_title(self, title):
+        '''set the console window title'''
+        if self.is_alive():
+            self.parent_pipe_send.send(Title(title))
 
     def set_menu(self, menu, callback):
         if self.is_alive():

--- a/MAVProxy/modules/lib/wxconsole_ui.py
+++ b/MAVProxy/modules/lib/wxconsole_ui.py
@@ -3,7 +3,7 @@ import time
 import platform
 import socket
 from MAVProxy.modules.lib import mp_menu
-from MAVProxy.modules.lib.wxconsole_util import Value, Text
+from MAVProxy.modules.lib.wxconsole_util import Value, Text, Title
 from MAVProxy.modules.lib.wx_loader import wx
 from MAVProxy.modules.lib import win_layout
 from MAVProxy.modules.lib import icon
@@ -150,6 +150,8 @@ class ConsoleFrame(wx.Frame):
                     self.control.AppendText(p.text)
                     self.control.SetDefaultStyle(oldstyle)
                 self.pending = []
+            elif isinstance(obj, Title):
+                self.SetTitle(obj.title)
             elif isinstance(obj, mp_menu.MPMenuTop):
                 if obj is not None:
                     self.SetMenuBar(None)

--- a/MAVProxy/modules/lib/wxconsole_util.py
+++ b/MAVProxy/modules/lib/wxconsole_util.py
@@ -5,6 +5,11 @@ class Text():
         self.fg = fg
         self.bg = bg
 
+class Title():
+    '''window title for the console'''
+    def __init__(self, title):
+        self.title = title
+
 class Value():
     '''a value for the status bar'''
     def __init__(self, name, text, row=0, fg='black', bg='white'):

--- a/MAVProxy/modules/mavproxy_console.py
+++ b/MAVProxy/modules/mavproxy_console.py
@@ -61,7 +61,7 @@ class ConsoleModule(mp_module.MPModule):
         self.safety_on = False
         self.unload_check_interval = 5 # seconds
         self.last_unload_check_time = time.time()
-        self.add_command('console', self.cmd_console, "console module", ['add','list','remove'])
+        self.add_command('console', self.cmd_console, "console module", ['add','list','remove','title'])
         mpstate.console = wxconsole.MessageConsole(title='Console')
 
         # setup some default status information
@@ -125,7 +125,7 @@ class ConsoleModule(mp_module.MPModule):
         self.shown_agl = False
 
     def cmd_console(self, args):
-        usage = 'usage: console <add|list|remove|menu|set>'
+        usage = 'usage: console <add|list|remove|menu|set|title>'
         if len(args) < 1:
             print(usage)
             return
@@ -155,6 +155,11 @@ class ConsoleModule(mp_module.MPModule):
             self.cmd_menu(args[1:])
         elif cmd == 'set':
             self.cmd_set(args[1:])
+        elif cmd == 'title':
+            if len(args) < 2:
+                print("usage: console title TITLE")
+                return
+            self.console.set_title(' '.join(args[1:]))
         else:
             print(usage)
 


### PR DESCRIPTION
Two small usability changes:

- **mavproxy_console**: new `console title MyTitle` command to set the title of the console window. Useful when running multiple MAVProxy instances.

- **startup port selection**: when MAVProxy starts without `--master` and auto-detects more than one candidate serial port, it now shows a selection dialog instead of just printing a warning. Labels are the `/dev/serial/by-id` names on Linux, and COM port plus the friendly device name on Windows (e.g. `COM3: CubePilot CubeOrange+ Mavlink (COM3)`). Cancelling the dialog, `--daemon` and `--non-interactive` keep the old behaviour, and running without a display still exits as before.

The dialog runs wx in a child process (works with both fork and spawn start methods) and polls a cancel hook so SIGTERM during startup is still honoured while the dialog is open.

Tested on Linux (wx GTK) and Windows 11 (wx 4.3.1 msw).