### PR TITLE
Add Add 'log download sync' command' - sync bin logs to aircraft dir

### DIFF
--- a/MAVProxy/modules/mavproxy_log.py
+++ b/MAVProxy/modules/mavproxy_log.py
@@ -254,7 +254,7 @@ class LogModule(mp_module.MPModule):
 
         elif args[0] == "download":
             if len(args) < 2:
-                print("usage: log download all | log download <lognumber> <filename> | log download from <lognumber>|log download range FIRST LAST") # noqa:E501
+                print("usage: log download sync | log download all | log download <lognumber> <filename> | log download from <lognumber>|log download range FIRST LAST") # noqa:E501
                 return
             if args[1] == 'all':
                 self.log_download_all()
@@ -269,6 +269,18 @@ class LogModule(mp_module.MPModule):
                     print("Usage: log download range FIRST LAST")
                     return
                 self.log_download_range(int(args[2]), int(args[3]))
+                return
+            if args[1] == "sync":
+                if len(self.entries.keys()) == 0:
+                    print("Please use log list first")
+                    return
+                log_num = sorted(self.entries, key=lambda id: self.entries[id].time_utc)[-1]
+                filename = self.default_log_filename(log_num)
+                if self.mpstate.aircraft_dir is None or self.logdir is None:
+                    print("log download sync requires --aircraft to be set")
+                    return
+                filename = os.path.join(self.logdir, filename)
+                self.log_download(log_num, filename)
                 return
             if args[1] == 'latest':
                 if len(self.entries.keys()) == 0:


### PR DESCRIPTION
Adding command `log download sync` this will sync the latest bin log to the right flight if you are using the --aircraft flag.

Testing ran it in sitl see below.

$ sim_vehicle.py -v ArduCopter --aircraft my_plane
Log Directory: my_plane/logs/2026-09-07/flight2
Telemetry log: my_plane/logs/2026-09-07/flight2/flight.tlog
AP: ArduCopter V4.8.0-dev (0c8333a9)
STABILIZE> Mode STABILIZE

STABILIZE> arm throttle
Got COMMAND_ACK: COMPONENT_ARM_DISARM: ACCEPTED
AP: Arming motors
ARMED

STABILIZE> disarm
Got COMMAND_ACK: COMPONENT_ARM_DISARM: ACCEPTED
AP: Disarming motors
AP: Field Elevation Set: 584m
DISARMED

STABILIZE> log list
Requesting log list
Log 1  numLogs 1 lastLog 1 size 630784 Mon Sep  7 15:04:01 2026

STABILIZE> log download sync
Downloading log 1 as my_plane/logs/2026-09-07/flight2/log1.bin
Finished downloading my_plane/logs/2026-09-07/flight2/log1.bin (1290240 bytes 2.5 seconds, 522.6 kbyte/sec 1 retries)

$ tree my_plane
my_plane
└── logs
    └── 2026-09-07
        ├── flight1
        │   ├── flight.tlog
        │   └── flight.tlog.raw
        └── flight2
            ├── defaults.parm
            ├── flight.tlog
            ├── flight.tlog.raw
            ├── log1.bin
            └── mav.parm

5 directories, 7 files